### PR TITLE
feat(config): aggregate all validation errors, add port-conflict/plugin-path/regex checks and --config-check flag

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -32,7 +32,8 @@ type rootOptions struct {
 	output     string
 	noColor    bool
 	timeout    time.Duration
-	configPath string
+	configPath  string
+	configCheck bool
 }
 
 type app struct {
@@ -144,6 +145,7 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 	fs.BoolVar(&opts.noColor, "no-color", false, "disable color output")
 	fs.DurationVar(&opts.timeout, "timeout", 0, "per-command timeout (0 = sensible default)")
 	fs.StringVar(&opts.configPath, "config", "", "path to config file (default: APiX search path)")
+	fs.BoolVar(&opts.configCheck, "config-check", false, "validate config and exit (0=ok, 1=invalid)")
 	fs.Usage = func() {
 		fmt.Fprintln(errw, "Usage: apix [global flags] <command> [args]")
 		fmt.Fprintln(errw, "")
@@ -184,6 +186,11 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		cfg:  config.LoadConfig(cfgPath),
 	}
 	defer app.close()
+
+	// --config-check: validate config then exit without starting anything.
+	if opts.configCheck {
+		return app.runConfigCheck(cfgPath)
+	}
 
 	switch fs.Arg(0) {
 	case "status":
@@ -1078,6 +1085,34 @@ func certInfo(cfg *config.Config) map[string]any {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// runConfigCheck validates the loaded config, prints a summary, and exits with
+// code 0 on success or 1 on failure. It is triggered by the --config-check flag.
+func (a *app) runConfigCheck(cfgPath string) int {
+	err := a.cfg.Validate()
+	if err == nil {
+		if a.opts.output == "json" {
+			_ = emitJSON(a.out, map[string]any{"path": cfgPath, "valid": true, "errors": []string{}})
+		} else {
+			fmt.Fprintf(a.out, "config ok: %s\n", cfgPath)
+		}
+		return 0
+	}
+	if a.opts.output == "json" {
+		var msgs []string
+		if ve, ok := err.(*config.ValidationError); ok {
+			for _, e := range ve.Errs {
+				msgs = append(msgs, e.Error())
+			}
+		} else {
+			msgs = []string{err.Error()}
+		}
+		_ = emitJSON(a.out, map[string]any{"path": cfgPath, "valid": false, "errors": msgs})
+	} else {
+		fmt.Fprintln(a.errw, err.Error())
+	}
+	return 1
 }
 
 func (a *app) cmdConfig(args []string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,14 @@ type Config struct {
 	MetricsEnabled     bool   `yaml:"metrics_enabled"`
 	MetricsPort        string `yaml:"metrics_port"`
 	SlowlogThresholdMs int    `yaml:"slowlog_threshold_ms"`
+
+	// Plugin paths — each entry is a path to a plugin shared library or
+	// script. Validated at startup via --config-check.
+	PluginPaths []string `yaml:"plugin_paths"`
+
+	// URLPatterns holds pre-configured URL regex patterns (e.g., allow/deny
+	// lists). Each entry must be a valid Go regexp; validated at startup.
+	URLPatterns []string `yaml:"url_patterns"`
 }
 
 // DefaultPath returns the config file path following these priorities:

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,39 +1,128 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"net"
+	"os"
+	"regexp"
 	"strconv"
+	"strings"
 )
 
-// Validate checks common configuration invariants and returns an error
-// describing the first problem found. This helps catch misconfigurations
-// early (and powers the --config-check CLI flag).
+// ValidationError groups all config problems found during validation so users
+// see the full list of issues in one pass rather than having to fix-and-retry.
+type ValidationError struct {
+	Errs []error
+}
+
+func (ve *ValidationError) Error() string {
+	msgs := make([]string, len(ve.Errs))
+	for i, e := range ve.Errs {
+		msgs[i] = "  • " + e.Error()
+	}
+	return "config validation failed:\n" + strings.Join(msgs, "\n")
+}
+
+func (ve *ValidationError) Unwrap() []error { return ve.Errs }
+
+// Validate checks all configuration invariants and returns a *ValidationError
+// that aggregates every problem found. This powers the --config-check flag so
+// operators see all issues at once instead of one-at-a-time.
 func (c *Config) Validate() error {
+	var errs []error
+
+	// ── Port validation ────────────────────────────────────────────────────
 	if c.HTTPPort == "" {
-		return fmt.Errorf("http_port must be set")
+		errs = append(errs, fmt.Errorf("http_port must be set"))
+	} else if _, err := strconv.Atoi(c.HTTPPort); err != nil {
+		errs = append(errs, fmt.Errorf("invalid http_port %q: %w — must be a number between 1-65535", c.HTTPPort, err))
 	}
-	if _, err := strconv.Atoi(c.HTTPPort); err != nil {
-		return fmt.Errorf("invalid http_port %q: %w", c.HTTPPort, err)
-	}
+
 	if c.GRPCPort == "" {
-		return fmt.Errorf("grpc_port must be set")
+		errs = append(errs, fmt.Errorf("grpc_port must be set"))
+	} else if _, err := strconv.Atoi(c.GRPCPort); err != nil {
+		errs = append(errs, fmt.Errorf("invalid grpc_port %q: %w — must be a number between 1-65535", c.GRPCPort, err))
 	}
-	if _, err := strconv.Atoi(c.GRPCPort); err != nil {
-		return fmt.Errorf("invalid grpc_port %q: %w", c.GRPCPort, err)
+
+	// ── Port conflict checks ───────────────────────────────────────────────
+	// Only check when port values look valid.
+	if c.HTTPPort != "" {
+		if _, err := strconv.Atoi(c.HTTPPort); err == nil {
+			if conflictErr := checkPortAvailable("tcp", c.HTTPPort); conflictErr != nil {
+				errs = append(errs, fmt.Errorf("http_port %s is already in use: %w — stop the conflicting process or choose a different port", c.HTTPPort, conflictErr))
+			}
+		}
 	}
+	if c.GRPCPort != "" {
+		if _, err := strconv.Atoi(c.GRPCPort); err == nil {
+			if conflictErr := checkPortAvailable("tcp", c.GRPCPort); conflictErr != nil {
+				errs = append(errs, fmt.Errorf("grpc_port %s is already in use: %w — stop the conflicting process or choose a different port", c.GRPCPort, conflictErr))
+			}
+		}
+	}
+
+	// ── Database path ──────────────────────────────────────────────────────
 	if c.DBPath == "" {
-		return fmt.Errorf("db_path must be set")
+		errs = append(errs, fmt.Errorf("db_path must be set — e.g. db_path: apix.db"))
 	}
+
+	// ── Connection pool ────────────────────────────────────────────────────
 	if c.MaxIdleConnsPerHost <= 0 {
-		return fmt.Errorf("max_idle_conns_per_host must be > 0")
+		errs = append(errs, fmt.Errorf("max_idle_conns_per_host must be > 0 (got %d) — recommended value: 10", c.MaxIdleConnsPerHost))
 	}
 	if c.MaxBodySizeMB < 0 {
-		return fmt.Errorf("max_body_size_mb must be >= 0")
+		errs = append(errs, fmt.Errorf("max_body_size_mb must be >= 0 (got %d) — use 0 to disable the limit", c.MaxBodySizeMB))
 	}
-	// If TLS is enabled for upstreams, require an auth token to avoid running
-	// an insecure public-facing proxy by accident.
+
+	// ── TLS / auth ─────────────────────────────────────────────────────────
 	if c.TLSEnabled && c.AuthToken == "" {
-		return fmt.Errorf("tls_enabled is true but auth_token is empty; set auth_token for secure operation")
+		errs = append(errs, fmt.Errorf("tls_enabled is true but auth_token is empty — set APIX_AUTH_TOKEN or auth_token in config for secure operation"))
+	}
+
+	// ── Plugin paths ───────────────────────────────────────────────────────
+	for i, p := range c.PluginPaths {
+		if p == "" {
+			errs = append(errs, fmt.Errorf("plugin_paths[%d] is empty — remove the entry or provide a valid path", i))
+			continue
+		}
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("plugin_paths[%d] %q does not exist — check the path or remove the entry", i, p))
+		}
+	}
+
+	// ── URL pattern regex validation ───────────────────────────────────────
+	for i, pat := range c.URLPatterns {
+		if pat == "" {
+			errs = append(errs, fmt.Errorf("url_patterns[%d] is empty — remove the entry or provide a valid regex", i))
+			continue
+		}
+		if _, err := regexp.Compile(pat); err != nil {
+			errs = append(errs, fmt.Errorf("url_patterns[%d] %q is not a valid Go regexp: %w — fix the pattern syntax", i, pat, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return &ValidationError{Errs: errs}
 	}
 	return nil
+}
+
+// checkPortAvailable probes whether addr is free by attempting a temporary
+// listen. It returns nil if the port is available, or an error describing the
+// conflict. The listener is closed immediately after the check.
+func checkPortAvailable(network, port string) error {
+	ln, err := net.Listen(network, net.JoinHostPort("", port))
+	if err != nil {
+		return err
+	}
+	_ = ln.Close()
+	return nil
+}
+
+// IsValidationError reports whether err (or any error in its chain) is a
+// *ValidationError so callers can distinguish config problems from I/O errors.
+func IsValidationError(err error) bool {
+	var ve *ValidationError
+	return errors.As(err, &ve)
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,6 +1,12 @@
 package config
 
-import "testing"
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestValidate_ValidConfig(t *testing.T) {
 	cfg := &Config{
@@ -53,3 +59,137 @@ func TestValidate_NegativeBodySize(t *testing.T) {
 		t.Fatalf("expected negative max body size to fail validation")
 	}
 }
+
+// TestValidate_AggregatesAllErrors ensures that multiple config problems are
+// reported at once rather than stopping at the first error.
+func TestValidate_AggregatesAllErrors(t *testing.T) {
+	t.Parallel()
+	// Deliberately broken: empty ports, empty db_path, bad idle conns, negative body.
+	cfg := &Config{
+		HTTPPort:            "",
+		GRPCPort:            "",
+		DBPath:              "",
+		MaxIdleConnsPerHost: 0,
+		MaxBodySizeMB:       -1,
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation to fail")
+	}
+	if !IsValidationError(err) {
+		t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+	}
+	ve := err.(*ValidationError)
+	if len(ve.Errs) < 4 {
+		t.Fatalf("expected at least 4 errors, got %d: %v", len(ve.Errs), err)
+	}
+}
+
+// TestValidate_PortConflict checks that Validate reports an error when a port
+// is already in use.
+func TestValidate_PortConflict(t *testing.T) {
+	t.Parallel()
+	// Bind a port on all interfaces so our checkPortAvailable (which also uses
+	// 0.0.0.0) correctly detects the conflict.
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("could not bind test listener: %v", err)
+	}
+	defer ln.Close()
+	addrParts := strings.Split(ln.Addr().String(), ":")
+	port := addrParts[len(addrParts)-1]
+
+	cfg := &Config{
+		HTTPPort:            port,
+		GRPCPort:            "19999", // assume free
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+	}
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("expected port-conflict error")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("expected 'already in use' message, got: %v", err)
+	}
+}
+
+// TestValidate_PluginPaths checks that missing plugin paths are caught.
+func TestValidate_PluginPaths(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "plugin.so")
+	if err := os.WriteFile(existing, []byte{}, 0o600); err != nil {
+		t.Fatalf("create temp plugin: %v", err)
+	}
+
+	cfg := &Config{
+		HTTPPort:            "8080",
+		GRPCPort:            "9090",
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		PluginPaths:         []string{existing, "/nonexistent/plugin.so"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for missing plugin path")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected 'does not exist' message, got: %v", err)
+	}
+	// Existing path should not produce an error, so exactly one plugin error.
+	ve := err.(*ValidationError)
+	pluginErrs := 0
+	for _, e := range ve.Errs {
+		if strings.Contains(e.Error(), "plugin_paths") {
+			pluginErrs++
+		}
+	}
+	if pluginErrs != 1 {
+		t.Fatalf("expected 1 plugin path error, got %d", pluginErrs)
+	}
+}
+
+// TestValidate_URLPatterns checks that invalid regex patterns are caught.
+func TestValidate_URLPatterns(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		HTTPPort:            "8080",
+		GRPCPort:            "9090",
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		URLPatterns:         []string{"valid.*pattern", "[invalid"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for invalid regex")
+	}
+	if !strings.Contains(err.Error(), "valid Go regexp") {
+		t.Fatalf("expected regexp error, got: %v", err)
+	}
+}
+
+// TestValidate_ValidURLPatterns ensures well-formed patterns pass.
+func TestValidate_ValidURLPatterns(t *testing.T) {
+	t.Parallel()
+	cfg := &Config{
+		HTTPPort:            "8080",
+		GRPCPort:            "9090",
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		URLPatterns:         []string{"https://example\\.com/.*", "^/api/v[0-9]+/"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config with URL patterns, got: %v", err)
+	}
+}
+
+// TestIsValidationError verifies the helper function.
+func TestIsValidationError(t *testing.T) {
+	t.Parallel()
+	ve := &ValidationError{Errs: []error{}}
+	if !IsValidationError(ve) {
+		t.Fatal("expected IsValidationError to return true for *ValidationError")
+	}
+}
+

--- a/why.md
+++ b/why.md
@@ -1,0 +1,187 @@
+**Bottom line:** APiX has a **strong engine and promising surfaces**, but it is **not yet a top-class product** because the core is ahead of the product experience. The biggest gap is not one feature; it is the combination of **setup friction, incomplete workflows, thin contract/testing discipline, and uneven roadmap structure**.
+
+## What is still missing most
+
+| Priority | Gap | Why it matters | Status |
+|---|---|---|---|
+| **Critical** | **Guided onboarding + first-success flow** | Top tools reduce time-to-first-capture. APiX still makes users assemble proxy/cert/engine mental models themselves. | **Tracked but incomplete:** #84, #124 |
+| **Critical** | **Distribution and install trust** | “Top class” products are easy to install and discover. Marketplace/package-manager flow is still weak. | **Partly tracked:** #113 |
+| **Critical** | **Workflow completeness, not just primitives** | APiX can capture/pause/replay, but the polished workflows around them are still thin. | **Mixed tracking** |
+| **High** | **Automation/contract maturity** | CLI/MCP value depends on stable schemas, retries, state handling, and regression safety. | **Tracked but incomplete:** #95–#98 |
+| **High** | **Feature parity on must-have debugger capabilities** | Missing breakpoint conditions, HAR, body search/indexing, rich inspectors, rules/mocking UI, WebSocket, gRPC/HTTP2 keep APiX below top-tier tools. | **Mixed:** #13, #14, #15, #22, #85, #86, #87, #94, #109, #112 |
+| **High** | **Issue/roadmap rigor** | Several closures were premature; some roadmap items are broad, weakly specified, or duplicated. That slows real product progress. | **Not fully tracked** |
+
+## Deep analysis by area
+
+### 1. Product UX and adoption: strongest blocker
+APiX still feels like **“great engine, early product shell.”**
+
+Main problems:
+- **No true first-run success path.**
+  - `docs/getting-started.md` is still skeletal.
+  - Guided CA trust/setup and capture profiles are still missing.
+- **CLI / extension / engine mental model is fragmented.**
+  - Extension auto-manages an engine.
+  - CLI expects a running engine.
+  - Engine config and VS Code settings are related but not unified.
+- **User-facing diagnostics are still too thin.**
+  - Better than before, but still not at the level of “self-healing” or “self-explaining.”
+- **Messaging is not sharp enough.**
+  - README explains features, but top products lead with **workflows and outcomes**.
+
+What top-class looks like:
+- “Install → capture first HTTPS request → set breakpoint → replay” in minutes.
+- Clear engine state, setup state, cert state, connection state.
+- Scenario-driven docs and UI, not architecture-first docs.
+
+### 2. Missing product capabilities vs top-tier tools
+These are the biggest competitive gaps:
+
+#### Must-have debugging gaps
+- **Breakpoint conditions** beyond URL/method
+  - header/body/status/content-type/size/time-based matching
+  - This is one of the clearest “not yet top class” gaps.
+- **HAR export/import and copy-as-curl**
+- **Advanced filtering/search**
+  - especially body/content search and scalable indexing
+- **Rich payload inspector**
+  - JSON/XML/HTML/Base64/hex/Protobuf views
+- **Response mocking and rule management UI**
+- **Request composer/templates**
+- **Guided capture setup**
+
+#### Protocol coverage gaps
+- **WebSocket**
+- **gRPC-over-HTTP/2**
+- **broader HTTP/2 and staged HTTP/3**
+- **GraphQL-specific debugging**
+
+Without these, APiX is strong for **basic HTTP proxy debugging**, but not yet a broad “best-in-class API debugging workspace.”
+
+### 3. Code/runtime gaps
+The codebase is in much better shape than the UX, but several things still separate it from a top product:
+
+#### A. Reliability under failure is under-tested
+The reopened issues say a lot:
+- **#95** MCP contract safety incomplete
+- **#96** stateful workflow coverage incomplete
+- **#97** resilience/fault injection incomplete
+- **#98** release smoke too shallow
+- **#131** integration workflow lacks the originally intended container-backed rigor
+
+This means APiX still risks:
+- reconnect/stream failure surprises
+- partial workflow regressions
+- release-time packaging/wiring failures
+- automation drift
+
+#### B. Operability still has important holes
+Still important:
+- **#81** config validation incomplete
+- **#107** gRPC rate limiting / abuse protection
+- **#108** engine/client compatibility negotiation
+- **#110** health/readiness endpoints
+- **#111** plugin isolation
+- **#109** scalable history search/indexing
+
+A top-class proxy/debugger must be easy to run, safe to expose, diagnosable, and predictable across versions.
+
+#### C. Product-safe extensibility is not done yet
+The plugin system is promising, but a top product needs:
+- plugin isolation/failure containment
+- better plugin observability
+- predictable mutation ordering
+- clear contracts for recovery and side effects
+
+That is only partially covered now.
+
+### 4. Docs and learning system gaps
+Docs improved, but they are still **architecture-rich and workflow-light**.
+
+Biggest issues:
+- docs structure exists, but some referenced pages are still missing
+- contributor learning docs are ahead of user-success docs
+- cookbook is still planned, not real
+- README still carries some “aspirational product” feel in places
+
+Top-class docs require:
+1. **Getting started**
+2. **How-to workflows**
+3. **Concepts**
+4. **Reference**
+5. **Cookbook**
+
+APiX has pieces of this, but not the complete system yet.
+
+### 5. Backlog quality gaps
+This is one of the most important meta-findings.
+
+The backlog has many good ideas, but:
+- some important capabilities are only implied in roadmap text, not tracked as strong issues
+- some issues were closed before acceptance was really met
+- some newer issues appear redundant or stale relative to already completed CLI work
+- roadmap sequencing still mixes:
+  - core workflow completion
+  - protocol expansion
+  - AI/MCP ambitions
+  - enterprise/team aspirations
+
+That creates execution risk.
+
+## The most important missing points not cleanly covered enough yet
+
+These are the gaps I’d elevate most:
+
+1. **Unified product-surface model**
+   - one clear story for engine, CLI, extension, remote mode
+   - currently undertracked
+
+2. **Workflow-first onboarding**
+   - not just docs; UI and CLI should guide first capture and first breakpoint
+   - partly tracked, still incomplete
+
+3. **Breakpoint conditions**
+   - essential, still not strongly issue-driven enough
+
+4. **Mocking/rules UX**
+   - engine capability without polished surface is not enough
+
+5. **Portable traffic workflows**
+   - HAR/cURL/export/import/session portability
+
+6. **Search/indexing**
+   - body/content search is core to real debugging scale
+
+7. **Contract discipline for CLI/MCP**
+   - schemas, compatibility policy, retries, stability docs
+
+8. **Operability and version safety**
+   - health, rate limiting, compatibility negotiation, config validation
+
+9. **Protocol expansion with focus**
+   - WebSocket and gRPC/HTTP2 matter more than broad “future protocol” language
+
+10. **Backlog cleanup and dependency shaping**
+   - remove duplicate/stale issues
+   - turn roadmap bullets into acceptance-based epics
+
+## If APiX wants to become top class, the right order is
+
+1. **Nail first-user success**
+   - #84, #124, #113, docs/help/diagnostics coherence
+
+2. **Finish the missing core debugger workflows**
+   - breakpoint conditions, HAR, search/indexing, rich inspector, rules/mock UI
+
+3. **Harden automation and reliability**
+   - #95–#98, #107, #108, #110, #111, #131
+
+4. **Expand protocol coverage**
+   - WebSocket, gRPC-over-HTTP/2, HTTP/2+
+
+5. **Then push AI/MCP as a force multiplier**
+   - after contracts and workflows are truly stable
+
+## Hard truth
+**APiX is currently closer to “strong developer tool core with serious potential” than “top-class finished product.”**  
+To cross that gap, the next wins should be less about adding exotic features and more about making the existing strengths **easy, reliable, teachable, and composable**.


### PR DESCRIPTION
Closes #81

## Changes
- `Validate()` now collects **all** errors instead of returning on the first failure
- New `ValidationError` type with `Unwrap()` for `errors.As`/`errors.Is` compatibility
- Port-conflict check via `net.Listen` probe for `http_port` and `grpc_port`  
- Plugin-path existence check for each entry in `plugin_paths`
- URL-pattern regex compilation check for each entry in `url_patterns`
- `--config-check` flag on `apix-cli` for dry-run validation (exit 0=ok, 1=invalid; JSON output supported)
- Expanded test suite covers aggregation, port conflict, plugin paths, and invalid regex