### PR TITLE
docs: workflow-first getting-started guides for first capture, breakpoint, and replay

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,23 +1,100 @@
 # Getting Started — Workflow-first Guides
 
-This guide provides short, task-oriented workflows to get APiX users started quickly.
+> **New to APiX?** Pick a workflow below and follow the steps. Each guide is self-contained and takes less than five minutes to complete.
 
-## First capture (quick)
-1. Build and run the engine: ./apix-engine
-2. Configure your tool to use the proxy: curl -x http://localhost:8080 https://example.com
-3. Watch the CLI or VS Code extension for captured requests
-4. Inspect the captured request and response in the UI
+## Prerequisites
 
-## First breakpoint (quick)
-1. Open the VS Code extension or apix-cli and add a breakpoint that matches example.com
-2. Send a request that matches the breakpoint
-3. The request will pause; edit the request/response and Resume (Forward/Respond/Drop)
+1. **Build the engine** (one-time):
 
-## Replay a captured request
-1. From the traffic view, select a captured request
-2. Choose "Replay" and optionally modify the request
-3. Verify the replayed response and compare timings
+   ```sh
+   go build -o apix-engine ./cmd/apix-engine/
+   go build -o apix-cli   ./cmd/apix-cli/
+   ```
 
-Each of the above sections links to more detailed how-to pages (how-to/breakpoints.md, how-to/replay.md) when users need deeper examples.
+2. **Start the engine** (HTTP proxy on `:8080`, gRPC on `:9090`):
 
-(Planned via issue #124)
+   ```sh
+   ./apix-engine
+   ```
+
+   Verify it is running:
+
+   ```sh
+   ./apix-cli status
+   ```
+
+---
+
+## 1 — First capture
+
+→ **[Full how-to guide](how-to/first-capture.md)**
+
+Quick-start:
+
+```sh
+# Send a request through the proxy
+curl -x http://localhost:8080 https://httpbin.org/get
+
+# List captured traffic
+./apix-cli history list
+```
+
+You should see the captured request and its response in the output.
+
+---
+
+## 2 — First breakpoint
+
+→ **[Full how-to guide](how-to/first-breakpoint.md)**
+
+Quick-start:
+
+```sh
+# Add a breakpoint matching any URL containing "httpbin"
+./apix-cli breakpoints add --pattern "httpbin"
+
+# In another terminal, send a matching request
+curl -x http://localhost:8080 https://httpbin.org/get
+
+# Watch the paused request, then forward it
+./apix-cli paused watch         # shows the paused request ID
+./apix-cli paused forward <id>  # forward with original request
+```
+
+---
+
+## 3 — Replay a captured request
+
+→ **[Full how-to guide](how-to/replay.md)**
+
+Quick-start:
+
+```sh
+# List captured requests to find an ID
+./apix-cli history list
+
+# Replay a specific request
+./apix-cli replay --id <request-id>
+```
+
+---
+
+## 4 — Validate your configuration
+
+```sh
+./apix-cli --config-check
+```
+
+This runs all config checks (port availability, plugin paths, regex patterns) and exits 0 on success or 1 with a full error list on failure.
+
+---
+
+## Next steps
+
+| Topic | Link |
+|---|---|
+| HTTPS interception (CA cert setup) | [proxy_mitm.md](proxy_mitm.md) |
+| Plugin development | [extension_arch.md](extension_arch.md) |
+| gRPC API reference | [grpc_protobuf.md](grpc_protobuf.md) |
+| Configuration reference | [CONFIG_VALIDATION.md](CONFIG_VALIDATION.md) |
+| Storage and replay internals | [storage_replay.md](storage_replay.md) |

--- a/docs/how-to/first-breakpoint.md
+++ b/docs/how-to/first-breakpoint.md
@@ -1,0 +1,131 @@
+# How-to: First breakpoint
+
+A breakpoint pauses a matching HTTP request before it reaches the upstream server. You can inspect it, modify headers or the body, and then choose to **Forward** the request, **Drop** it (return an error), or **Respond** with a synthetic response — all without changing the client or server code.
+
+## Prerequisites
+
+- Engine running (`./apix-engine`)
+- At least one request captured previously (see [first-capture.md](first-capture.md))
+
+## Step 1 — Add a breakpoint
+
+```sh
+# Pause any request whose URL contains "httpbin"
+./apix-cli breakpoints add --pattern "httpbin"
+```
+
+List breakpoints to confirm:
+
+```sh
+./apix-cli breakpoints list
+```
+
+Output:
+
+```
+ID                                    PATTERN   ENABLED
+a1b2c3d4-...                          httpbin   true
+```
+
+> **Pattern syntax:** The pattern is a Go regular expression (`regexp.Compile`). Examples:
+> - `httpbin` — matches any URL containing "httpbin"
+> - `^https://api\.example\.com/v2/` — matches a specific API prefix
+> - `\.(png|jpg|gif)$` — matches image requests
+
+## Step 2 — Watch for paused requests (in a second terminal)
+
+```sh
+./apix-cli paused watch
+```
+
+This command blocks and streams paused requests as they arrive.
+
+## Step 3 — Trigger the breakpoint
+
+In a third terminal, send a matching request through the proxy:
+
+```sh
+curl -x http://localhost:8080 https://httpbin.org/get --insecure
+```
+
+The `paused watch` terminal prints something like:
+
+```
+REQUEST_ID: 7f3a9b12-...
+METHOD: GET
+URL: https://httpbin.org/get
+HEADERS:
+  User-Agent: curl/7.88.1
+  Accept: */*
+```
+
+The curl command is still **hanging** — the request is paused until you decide what to do.
+
+## Step 4 — Decide: Forward, Drop, or Respond
+
+### Option A — Forward (pass the original request through)
+
+```sh
+./apix-cli paused forward <REQUEST_ID>
+```
+
+The request is forwarded to the upstream unchanged. curl receives the real response.
+
+### Option B — Drop (return an error to the client)
+
+```sh
+./apix-cli paused drop <REQUEST_ID>
+```
+
+The request is dropped and curl sees a connection reset.
+
+### Option C — Respond with a synthetic response
+
+```sh
+./apix-cli paused respond <REQUEST_ID> \
+  --status 200 \
+  --header "Content-Type: application/json" \
+  --body '{"intercepted": true}'
+```
+
+curl receives your crafted response instead of hitting the real server.
+
+## Step 5 — Disable or remove the breakpoint
+
+```sh
+# Temporarily disable without deleting
+./apix-cli breakpoints disable <BREAKPOINT_ID>
+
+# Re-enable
+./apix-cli breakpoints enable <BREAKPOINT_ID>
+
+# Delete permanently
+./apix-cli breakpoints delete <BREAKPOINT_ID>
+```
+
+## Using breakpoints from the VS Code extension
+
+1. Open the APiX sidebar in VS Code.
+2. Click **Breakpoints → Add Breakpoint**.
+3. Enter the URL pattern and click **Save**.
+4. Send a matching request — a notification appears and the **Paused Requests** view shows the entry.
+5. Click **Forward**, **Drop**, or **Respond** directly in the extension.
+
+## Tips
+
+- Multiple breakpoints are evaluated in insertion order; the **first** match wins.
+- Disable all breakpoints at once with `./apix-cli breakpoints disable --all`.
+- Breakpoints survive engine restart as long as they are re-registered via the API or extension.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `paused watch` shows nothing | Make sure the breakpoint is enabled and the request URL matches the pattern. |
+| curl hangs forever | The breakpoint is still paused — run `forward`, `drop`, or `respond`. |
+| Pattern doesn't match | Test your regex with `go run` or an online Go regex tester. |
+
+## Next steps
+
+- **[Replay](replay.md)** — re-send a captured request with optional modifications.
+- **[First capture](first-capture.md)** — back to basics if needed.

--- a/docs/how-to/first-capture.md
+++ b/docs/how-to/first-capture.md
@@ -1,0 +1,99 @@
+# How-to: First capture
+
+This guide walks you through capturing your first HTTP/HTTPS request with APiX. You will go from a fresh build to seeing full request and response details in under five minutes.
+
+## What you will need
+
+- Go 1.21+ installed
+- `curl` (or any HTTP client)
+- APiX source code (or pre-built binaries)
+
+## Step 1 — Build and start the engine
+
+```sh
+# Build (skip if you already have binaries)
+go build -o apix-engine ./cmd/apix-engine/
+go build -o apix-cli   ./cmd/apix-cli/
+
+# Start the engine (HTTP proxy :8080 · gRPC :9090)
+./apix-engine
+```
+
+You should see:
+
+```
+APiX engine listening on :8080 (proxy) and :9090 (gRPC)
+```
+
+> **Tip:** The engine stores captures in `apix.db` in the current directory by default. Use `--config` to point it at a different config file.
+
+## Step 2 — Send traffic through the proxy
+
+Open a second terminal and send any HTTP or HTTPS request through the proxy:
+
+```sh
+# Plain HTTP
+curl -x http://localhost:8080 http://httpbin.org/get
+
+# HTTPS (you will see a TLS warning until you install the APiX CA — see proxy_mitm.md)
+curl -x http://localhost:8080 https://httpbin.org/get --insecure
+```
+
+The proxy logs the request immediately.
+
+## Step 3 — List captured traffic
+
+```sh
+./apix-cli history list
+```
+
+Sample output:
+
+```
+ID                                    METHOD  URL                        STATUS  DURATION
+3e7c1a2b-...                          GET     https://httpbin.org/get    200     142ms
+```
+
+## Step 4 — Inspect a specific request
+
+```sh
+./apix-cli history get <ID>
+```
+
+This prints the full request headers, body, response status, response headers, and body.
+
+## Step 5 — Watch traffic live
+
+Instead of listing after the fact, open a live stream:
+
+```sh
+./apix-cli watch
+```
+
+Every new request appears in the terminal as it is captured.
+
+## What just happened?
+
+```
+curl  ──► APiX proxy (:8080) ──► real upstream
+                │
+                ▼
+          APiX engine stores request + response in SQLite
+                │
+                ▼
+          apix-cli reads from engine over gRPC (:9090)
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `curl: (7) Failed to connect to localhost port 8080` | Engine is not running. Start `./apix-engine` first. |
+| HTTPS request fails with `SSL: no alternative certificate subject name matches target host name` | Install the APiX CA certificate. See [proxy_mitm.md](../proxy_mitm.md). |
+| `history list` shows nothing | Make sure curl is proxied (`-x http://localhost:8080`) and try again. |
+
+## Next steps
+
+- **[First breakpoint](first-breakpoint.md)** — pause a request before it reaches the server and edit it in place.
+- **[Replay](replay.md)** — re-send a captured request, optionally with modifications.
+- **[HTTPS interception](../proxy_mitm.md)** — install the CA cert to capture HTTPS traffic without warnings.

--- a/docs/how-to/replay.md
+++ b/docs/how-to/replay.md
@@ -1,0 +1,126 @@
+# How-to: Replay a captured request
+
+Replay lets you re-send any previously captured HTTP request, optionally with modifications, and see the new response side-by-side. It is useful for debugging, regression testing, and exploring how an API behaves under different conditions.
+
+## Prerequisites
+
+- Engine running (`./apix-engine`)
+- At least one request in the capture history (see [first-capture.md](first-capture.md))
+
+## Step 1 — Find the request ID
+
+```sh
+./apix-cli history list
+```
+
+Output:
+
+```
+ID                                    METHOD  URL                             STATUS  DURATION
+3e7c1a2b-f10a-4c8e-b3a7-9d0e52c14f88  GET     https://httpbin.org/get         200     142ms
+8a1c3d5e-...                          POST    https://httpbin.org/post        201      89ms
+```
+
+Copy the ID of the request you want to replay.
+
+## Step 2 — Replay without modifications
+
+```sh
+./apix-cli replay --id 3e7c1a2b-f10a-4c8e-b3a7-9d0e52c14f88
+```
+
+APiX re-sends the exact original request and prints the new response:
+
+```
+STATUS: 200 OK
+DURATION: 128ms
+HEADERS:
+  Content-Type: application/json
+BODY:
+{
+  "url": "https://httpbin.org/get",
+  ...
+}
+```
+
+## Step 3 — Replay with header modifications
+
+Add, replace, or remove headers with `--header` (repeatable):
+
+```sh
+./apix-cli replay --id <ID> \
+  --header "Authorization: Bearer my-test-token" \
+  --header "X-Debug: true"
+```
+
+## Step 4 — Replay with a different body
+
+Replace the request body entirely:
+
+```sh
+./apix-cli replay --id <ID> \
+  --body '{"key": "new-value"}'
+```
+
+Combined with a header change:
+
+```sh
+./apix-cli replay --id <ID> \
+  --header "Content-Type: application/json" \
+  --body '{"user": "alice"}'
+```
+
+## Step 5 — Replay against a different host
+
+Use `--target` to send the request to a different base URL while keeping the original path:
+
+```sh
+./apix-cli replay --id <ID> --target https://staging.example.com
+```
+
+This is useful for comparing production and staging responses.
+
+## Step 6 — Compare original vs replayed
+
+Use `--compare` to print a diff of the original and new response bodies:
+
+```sh
+./apix-cli replay --id <ID> --compare
+```
+
+Output:
+
+```diff
+  {
+-   "origin": "10.0.0.1",
++   "origin": "10.0.0.2",
+    "url": "https://httpbin.org/get"
+  }
+```
+
+## Using replay from the VS Code extension
+
+1. In the **Traffic** tree view, right-click any captured request.
+2. Select **Replay Request**.
+3. The **Replay** panel opens pre-filled with the original request.
+4. Edit headers or body if needed, then click **Send**.
+5. The response appears in the right-hand pane alongside the original.
+
+## Tips
+
+- Replay honours the `replay_skip_tls_verify` config option for HTTPS targets.
+- The replayed request and its response are stored as a new capture in history.
+- Use `--count N` to replay the same request N times in sequence (load-testing).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `request not found` | The ID does not exist — run `history list` to get a valid one. |
+| Replay returns a different status than original | Normal — the server state may have changed. Use `--compare` to see what changed. |
+| TLS error during replay | Add `replay_skip_tls_verify: true` in `config.yaml` or use `--skip-tls`. |
+
+## Next steps
+
+- **[First breakpoint](first-breakpoint.md)** — pause and edit requests before they hit the server.
+- **[gRPC API reference](../grpc_protobuf.md)** — drive replay programmatically.


### PR DESCRIPTION
Closes #124

Expands the skeleton `getting-started.md` and adds three complete how-to guides:
- `docs/how-to/first-capture.md` — build → start → send → list → inspect
- `docs/how-to/first-breakpoint.md` — add breakpoint, watch, forward/drop/respond
- `docs/how-to/replay.md` — replay with header/body/target overrides, diff output, VS Code panel