### PR TITLE
feat: plugin panic recovery + isolation (#111)

### DIFF
--- a/internal/pluginrt/plugins_test.go
+++ b/internal/pluginrt/plugins_test.go
@@ -220,3 +220,75 @@ func TestRunResponseChain(t *testing.T) {
 		t.Error("resp-plugin-2 header not applied")
 	}
 }
+
+func TestRunRequest_PanicRecovery(t *testing.T) {
+rt := NewRuntime()
+panicPlugin := &mockPlugin{
+name: "panic-request-plugin",
+onRequestFn: func(_ context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+panic("simulated plugin panic in OnRequest")
+},
+}
+if err := rt.Register(panicPlugin); err != nil {
+t.Fatalf("Register: %v", err)
+}
+
+req := newProxyRequest("GET", "https://example.com")
+_, err := rt.RunRequest(context.Background(), req)
+if err == nil {
+t.Fatal("expected error from panic recovery, got nil")
+}
+if !strings.Contains(err.Error(), "panic") {
+t.Errorf("expected error to contain 'panic', got: %v", err)
+}
+}
+
+func TestRunResponse_PanicRecovery(t *testing.T) {
+rt := NewRuntime()
+panicPlugin := &mockPlugin{
+name: "panic-response-plugin",
+onResponseFn: func(_ context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
+panic("simulated plugin panic in OnResponse")
+},
+}
+if err := rt.Register(panicPlugin); err != nil {
+t.Fatalf("Register: %v", err)
+}
+
+req := newProxyRequest("GET", "https://example.com")
+resp := newProxyResponse(200)
+_, err := rt.RunResponse(context.Background(), req, resp)
+if err == nil {
+t.Fatal("expected error from panic recovery, got nil")
+}
+if !strings.Contains(err.Error(), "panic") {
+t.Errorf("expected error to contain 'panic', got: %v", err)
+}
+}
+
+func TestRunRequest_PanicDoesNotAffectOtherPlugins_ShortCircuits(t *testing.T) {
+rt := NewRuntime()
+panicPlugin := &mockPlugin{
+name: "panic-plugin",
+onRequestFn: func(_ context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+panic("crash")
+},
+}
+afterPlugin := &mockPlugin{
+name: "after-plugin",
+onRequestFn: func(_ context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+clone := req
+clone.Headers.Set("X-After", "true")
+return clone, nil
+},
+}
+_ = rt.Register(panicPlugin)
+_ = rt.Register(afterPlugin)
+
+req := newProxyRequest("GET", "https://example.com")
+_, err := rt.RunRequest(context.Background(), req)
+// Panic in first plugin should short-circuit; error returned
+if err == nil {
+t.Fatal("expected error from panic")
+}
+}

--- a/internal/pluginrt/runtime.go
+++ b/internal/pluginrt/runtime.go
@@ -3,6 +3,7 @@ package pluginrt
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	"github.com/mnafshin/apix/pkg/plugins"
@@ -70,7 +71,8 @@ func (r *Runtime) List() []PluginMeta {
 }
 
 // RunRequest executes the OnRequest hook of every plugin in order.
-// Short-circuits on the first error.
+// Short-circuits on the first error. Panics inside plugin code are recovered
+// and returned as errors so a misbehaving plugin cannot crash the engine.
 func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
 	r.mu.RLock()
 	order := make([]string, len(r.order))
@@ -83,7 +85,7 @@ func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*p
 
 	for _, name := range order {
 		p := pluginMap[name]
-		modified, err := p.OnRequest(ctx, req)
+		modified, err := safeOnRequest(ctx, p, req)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q OnRequest: %w", name, err)
 		}
@@ -95,6 +97,7 @@ func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*p
 }
 
 // RunResponse executes the OnResponse hook of every plugin in order.
+// Panics inside plugin code are recovered and returned as errors.
 func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
 	r.mu.RLock()
 	order := make([]string, len(r.order))
@@ -107,7 +110,7 @@ func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, re
 
 	for _, name := range order {
 		p := pluginMap[name]
-		modified, err := p.OnResponse(ctx, req, resp)
+		modified, err := safeOnResponse(ctx, p, req, resp)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q OnResponse: %w", name, err)
 		}
@@ -116,6 +119,26 @@ func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, re
 		}
 	}
 	return resp, nil
+}
+
+// safeOnRequest calls p.OnRequest and converts any panic into an error.
+func safeOnRequest(ctx context.Context, p plugins.Plugin, req *plugins.ProxyRequest) (modified *plugins.ProxyRequest, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v\n%s", r, debug.Stack())
+		}
+	}()
+	return p.OnRequest(ctx, req)
+}
+
+// safeOnResponse calls p.OnResponse and converts any panic into an error.
+func safeOnResponse(ctx context.Context, p plugins.Plugin, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (modified *plugins.ProxyResponse, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v\n%s", r, debug.Stack())
+		}
+	}()
+	return p.OnResponse(ctx, req, resp)
 }
 
 // PluginMeta is a lightweight summary of a plugin's identity.


### PR DESCRIPTION
Fixes #111. Wraps all plugin OnRequest/OnResponse calls in panic-recovery helpers. A panicking plugin now returns an error instead of crashing the engine goroutine.