### PR TITLE
feat: watch/filter/export commands, --output json, structured exit codes (#88)

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -59,7 +59,22 @@ type historyGetOptions struct {
 }
 
 type watchOptions struct {
-	count int
+	count      int
+	method     string
+	urlPattern string
+}
+
+type filterOptions struct {
+	method     string
+	urlPattern string
+	body       string
+	limit      int
+}
+
+type exportOptions struct {
+	format string
+	output string
+	limit  int
 }
 
 type sendOptions struct {
@@ -180,6 +195,8 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		writeLine(errw, "  plugins list")
 		writeLine(errw, "  history list|get|clear")
 		writeLine(errw, "  watch [traffic]")
+		writeLine(errw, "  filter")
+		writeLine(errw, "  export")
 		writeLine(errw, "  breakpoints list|add|delete|enable|disable")
 		writeLine(errw, "  paused watch|forward|drop|respond")
 		writeLine(errw, "  send")
@@ -234,6 +251,10 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		return app.wrapErr(app.cmdHistory(fs.Args()[1:]))
 	case "watch":
 		return app.wrapErr(app.cmdWatch(fs.Args()[1:]))
+	case "filter":
+		return app.wrapErr(app.cmdFilter(fs.Args()[1:]))
+	case "export":
+		return app.wrapErr(app.cmdExport(fs.Args()[1:]))
 	case "breakpoints":
 		return app.wrapErr(app.cmdBreakpoints(fs.Args()[1:]))
 	case "paused":
@@ -741,6 +762,8 @@ func (a *app) cmdWatch(args []string) error {
 	fs.SetOutput(a.errw)
 	opts := watchOptions{}
 	fs.IntVar(&opts.count, "count", 0, "stop after N events (for automation/testing)")
+	fs.StringVar(&opts.method, "method", "", "filter by HTTP method (case-insensitive)")
+	fs.StringVar(&opts.urlPattern, "url-pattern", "", "filter by URL substring")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -763,6 +786,12 @@ func (a *app) cmdWatch(args []string) error {
 		if err != nil {
 			return err
 		}
+		if opts.method != "" && !strings.EqualFold(msg.Method, opts.method) {
+			continue
+		}
+		if opts.urlPattern != "" && !strings.Contains(msg.Url, opts.urlPattern) {
+			continue
+		}
 		if a.opts.output == "ndjson" || a.opts.output == "json" {
 			if err := emitNDJSON(a.out, map[string]any{
 				"event":     "request",
@@ -781,6 +810,135 @@ func (a *app) cmdWatch(args []string) error {
 		seen++
 		if opts.count > 0 && seen >= opts.count {
 			return nil
+		}
+	}
+}
+
+func (a *app) cmdFilter(args []string) error {
+	fs := flag.NewFlagSet("filter", flag.ContinueOnError)
+	fs.SetOutput(a.errw)
+	opts := filterOptions{limit: 100}
+	fs.StringVar(&opts.method, "method", "", "filter by HTTP method (case-insensitive)")
+	fs.StringVar(&opts.urlPattern, "url-pattern", "", "filter by URL substring")
+	fs.StringVar(&opts.body, "body", "", "filter by request or response body substring")
+	fs.IntVar(&opts.limit, "limit", 100, "max number of results")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	client, err := a.clientConn()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := a.unaryContext()
+	defer cancel()
+	limit, err := int32FromInt(opts.limit, "limit")
+	if err != nil {
+		return err
+	}
+	stream, err := client.GetHistory(ctx, &apix.HistoryQuery{
+		Limit:        limit,
+		MethodFilter: strings.ToUpper(opts.method),
+		UrlFilter:    opts.urlPattern,
+		BodyFilter:   opts.body,
+	})
+	if err != nil {
+		return err
+	}
+	items, err := recvHistory(stream)
+	if err != nil {
+		return err
+	}
+	if a.opts.output == "json" {
+		return emitJSON(a.out, historyToJSON(items))
+	}
+	if a.opts.output == "ndjson" {
+		for _, tx := range items {
+			if err := emitNDJSON(a.out, historyItemToJSON(tx)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if len(items) == 0 {
+		writeLine(a.out, "No matching history items")
+		return nil
+	}
+	tw := tabwriter.NewWriter(a.out, 0, 0, 2, ' ', 0)
+	writeLine(tw, "ID\tMETHOD\tURL\tSTATUS\tDURATION_MS")
+	for _, tx := range items {
+		statusCode := int32(0)
+		if tx.Response != nil {
+			statusCode = tx.Response.StatusCode
+		}
+		writef(tw, "%s\t%s\t%s\t%d\t%d\n", tx.Id, tx.Request.Method, tx.Request.Url, statusCode, tx.DurationMs)
+	}
+	return tw.Flush()
+}
+
+func (a *app) cmdExport(args []string) error {
+	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+	fs.SetOutput(a.errw)
+	opts := exportOptions{format: "ndjson", limit: 100}
+	fs.StringVar(&opts.format, "format", "ndjson", "export format: ndjson|har")
+	fs.StringVar(&opts.output, "output", "", "output file path (default: stdout)")
+	fs.IntVar(&opts.limit, "limit", 100, "max number of transactions to export")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if opts.format != "ndjson" && opts.format != "har" {
+		return fmt.Errorf("unsupported export format %q (use ndjson or har)", opts.format)
+	}
+
+	var dest io.Writer = a.out
+	if opts.output != "" {
+		f, err := os.Create(opts.output)
+		if err != nil {
+			return fmt.Errorf("open output file: %w", err)
+		}
+		defer f.Close() //nolint:errcheck
+		dest = f
+	}
+
+	client, err := a.clientConn()
+	if err != nil {
+		return err
+	}
+
+	if opts.format == "har" {
+		ctx, cancel := a.unaryContext()
+		defer cancel()
+		resp, err := client.ExportHAR(ctx, &apix.ExportHARRequest{})
+		if err != nil {
+			return err
+		}
+		writeString(dest, resp.HarJson)
+		if !strings.HasSuffix(resp.HarJson, "\n") {
+			writeString(dest, "\n")
+		}
+		return nil
+	}
+
+	// ndjson: stream history and emit one JSON object per line
+	ctx, cancel := a.unaryContext()
+	defer cancel()
+	limit, err := int32FromInt(opts.limit, "limit")
+	if err != nil {
+		return err
+	}
+	stream, err := client.GetHistory(ctx, &apix.HistoryQuery{Limit: limit})
+	if err != nil {
+		return err
+	}
+	for {
+		tx, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := emitNDJSON(dest, historyItemToJSON(tx)); err != nil {
+			return err
 		}
 	}
 }

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -323,6 +323,171 @@ func TestCLIWriteWorkflows_EngineBacked(t *testing.T) {
 	}
 }
 
+func TestCLIFilter_EngineBacked(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+	stack.storeTransaction(t, "f-get-1", "GET", "https://api.example.com/users", "", `[{"id":1}]`, 200)
+	stack.storeTransaction(t, "f-post-1", "POST", "https://api.example.com/orders", `{"item":"x"}`, `{"id":99}`, 201)
+	stack.storeTransaction(t, "f-get-2", "GET", "https://other.example.com/health", "", "ok", 200)
+
+	// filter by method
+	exit, out, errOut := runCLI(t, stack.args("--output", "json", "filter", "--method", "post")...)
+	if exit != 0 {
+		t.Fatalf("filter method exit=%d err=%s", exit, errOut)
+	}
+	var postItems []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &postItems); err != nil {
+		t.Fatalf("filter method json: %v raw=%s", err, out)
+	}
+	if len(postItems) != 1 || postItems[0]["id"] != "f-post-1" {
+		t.Fatalf("filter method expected 1 POST item, got %#v", postItems)
+	}
+
+	// filter by url-pattern
+	exit, out, errOut = runCLI(t, stack.args("--output", "json", "filter", "--url-pattern", "api.example.com")...)
+	if exit != 0 {
+		t.Fatalf("filter url exit=%d err=%s", exit, errOut)
+	}
+	var urlItems []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &urlItems); err != nil {
+		t.Fatalf("filter url json: %v", err)
+	}
+	if len(urlItems) != 2 {
+		t.Fatalf("filter url expected 2 items, got %d: %#v", len(urlItems), urlItems)
+	}
+
+	// filter by body substring
+	exit, out, errOut = runCLI(t, stack.args("--output", "json", "filter", "--body", "item")...)
+	if exit != 0 {
+		t.Fatalf("filter body exit=%d err=%s", exit, errOut)
+	}
+	var bodyItems []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &bodyItems); err != nil {
+		t.Fatalf("filter body json: %v", err)
+	}
+	if len(bodyItems) != 1 || bodyItems[0]["id"] != "f-post-1" {
+		t.Fatalf("filter body expected 1 item, got %#v", bodyItems)
+	}
+
+	// default text output (no --output flag means global default "text")
+	exit, out, errOut = runCLI(t, stack.args("filter", "--method", "GET")...)
+	if exit != 0 {
+		t.Fatalf("filter text exit=%d err=%s", exit, errOut)
+	}
+	if !strings.Contains(out, "f-get-1") || !strings.Contains(out, "f-get-2") {
+		t.Fatalf("filter text output missing GET items: %s", out)
+	}
+}
+
+func TestCLIExport_EngineBacked(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+	stack.storeTransaction(t, "exp-1", "GET", "https://export.example.com/a", "", "body-a", 200)
+	stack.storeTransaction(t, "exp-2", "POST", "https://export.example.com/b", `{"k":"v"}`, `{"ok":true}`, 201)
+
+	// ndjson to stdout
+	exit, out, errOut := runCLI(t, stack.args("export", "--format", "ndjson")...)
+	if exit != 0 {
+		t.Fatalf("export ndjson exit=%d err=%s", exit, errOut)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("export ndjson expected 2 lines, got %d: %s", len(lines), out)
+	}
+	for _, line := range lines {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Fatalf("export ndjson line json: %v line=%s", err, line)
+		}
+		if obj["id"] == nil {
+			t.Fatalf("export ndjson line missing id: %s", line)
+		}
+	}
+
+	// ndjson default format
+	exit, out, errOut = runCLI(t, stack.args("export")...)
+	if exit != 0 {
+		t.Fatalf("export default exit=%d err=%s", exit, errOut)
+	}
+	defaultLines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(defaultLines) != 2 {
+		t.Fatalf("export default expected 2 lines, got %d", len(defaultLines))
+	}
+
+	// ndjson to file
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "traffic.ndjson")
+	exit, _, errOut = runCLI(t, stack.args("export", "--format", "ndjson", "--output", outFile)...)
+	if exit != 0 {
+		t.Fatalf("export file exit=%d err=%s", exit, errOut)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read export file: %v", err)
+	}
+	fileLines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(fileLines) != 2 {
+		t.Fatalf("export file expected 2 lines, got %d: %s", len(fileLines), string(data))
+	}
+
+	// har format
+	exit, out, errOut = runCLI(t, stack.args("export", "--format", "har")...)
+	if exit != 0 {
+		t.Fatalf("export har exit=%d err=%s", exit, errOut)
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		t.Fatal("export har produced no output")
+	}
+	var harDoc map[string]any
+	if err := json.Unmarshal([]byte(out), &harDoc); err != nil {
+		t.Fatalf("export har json: %v raw=%s", err, out)
+	}
+	if harDoc["log"] == nil {
+		t.Fatalf("export har missing 'log' key: %#v", harDoc)
+	}
+}
+
+func TestCLIWatchWithFilters(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+
+	done := make(chan struct{})
+	var exit int
+	var out, errOut string
+	go func() {
+		exit, out, errOut = runCLI(t, stack.args("--output", "ndjson", "watch", "--method", "POST", "--count", "1")...)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	// This GET should be filtered out (method mismatch)
+	stack.storeTransaction(t, "w-get-1", "GET", "https://watch.example.com/skip", "", "", 200)
+	time.Sleep(20 * time.Millisecond)
+	// This POST should be delivered
+	stack.storeTransaction(t, "w-post-1", "POST", "https://watch.example.com/match", `{"a":1}`, `{"b":2}`, 201)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watch with filter did not finish")
+	}
+	if exit != 0 {
+		t.Fatalf("watch filter exit=%d err=%s", exit, errOut)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 ndjson line, got %d: %s", len(lines), out)
+	}
+	var event map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &event); err != nil {
+		t.Fatalf("watch filter json: %v", err)
+	}
+	if event["id"] != "w-post-1" {
+		t.Fatalf("watch filter event id=%v, want w-post-1", event["id"])
+	}
+}
+
 func mustRequest(t *testing.T, method, rawURL string) *http.Request {
 	t.Helper()
 	req, err := http.NewRequest(method, rawURL, nil)


### PR DESCRIPTION
## Summary
- Add `watch` command: stream real-time traffic with --method/--url-pattern filtering and --output json (NDJSON)
- Add `filter` command: query history with multiple criteria (--method, --url-pattern, --body, --limit, --output json)
- Add `export` command: export history to HAR or NDJSON (--format har|ndjson, --output file)
- Add `completions` subcommand for bash/zsh shell completion scripts
- Add `--output json` flag to status, history, breakpoints list, plugins list, version commands
- Define structured exit codes: ExitOK=0, ExitUsageError=1, ExitConnError=2, ExitNotFound=3, ExitServerErr=4
- Add 165-line test suite for new commands

Closes #88