### PR TITLE
feat: declarative rewrite rules + HTTP/2 protocol tracking (#86, #94)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -89,6 +89,7 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 			Body:       tx.RequestBody,
 			Timestamp:  time.Now(),
 			DurationMs: tx.DurationMs,
+			Protocol:   req.Protocol,
 		}
 		if err := e.db.SaveRequest(rec); err != nil {
 			logging.Errorf(context.Background(), "engine: save request: %v", err)
@@ -102,6 +103,7 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 			Headers:   hdrs,
 			Body:      tx.RequestBody,
 			Timestamp: time.Now().UnixMilli(),
+			Protocol:  req.Protocol,
 		}
 		e.mu.Lock()
 		subscribers := make([]chan *apix.HttpRequest, 0, len(e.subscribers))
@@ -248,3 +250,8 @@ func (e *Engine) BreakpointManager() *breakpoints.Manager { return e.bpManager }
 
 // PluginRuntime returns the plugin runtime.
 func (e *Engine) PluginRuntime() *pluginrt.Runtime { return e.pluginRT }
+
+// RewriteRules loads the current list of rewrite rules from storage.
+func (e *Engine) RewriteRules() ([]*proxy.RewriteRuleProto, error) {
+	return e.db.ListRewriteRules()
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	logging "github.com/mnafshin/apix/internal/logging"
 	metrics "github.com/mnafshin/apix/internal/metrics"
+	"github.com/mnafshin/apix/internal/rewrite"
 	"io"
 	"net"
 	"net/http"
@@ -167,13 +168,22 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	origHeaders := r.Header.Clone()
 
+	// Detect negotiated protocol. For HTTP/1.x requests r.Proto is "HTTP/1.1".
+	// For h2c (cleartext HTTP/2) the Go standard library upgrades the connection
+	// before reaching the handler, so r.Proto will be "HTTP/2.0".
+	protocol := r.Proto
+	if protocol == "" {
+		protocol = "HTTP/1.1"
+	}
+
 	proxyReq := &plugins.ProxyRequest{
-		ID:      reqID,
-		Method:  r.Method,
-		URL:     r.URL,
-		Headers: r.Header.Clone(),
-		Body:    io.NopCloser(bytes.NewReader(bodyBytes)),
-		Raw:     r,
+		ID:       reqID,
+		Method:   r.Method,
+		URL:      r.URL,
+		Headers:  r.Header.Clone(),
+		Body:     io.NopCloser(bytes.NewReader(bodyBytes)),
+		Protocol: protocol,
+		Raw:      r,
 	}
 
 	// Run plugin OnRequest chain (with panic recovery).
@@ -258,6 +268,30 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Apply rewrite rules to the request (before forwarding upstream).
+	if p.engine != nil {
+		rules, err := p.engine.RewriteRules()
+		if err != nil {
+			logging.Errorf(ctx, "load rewrite rules: %v", err)
+		} else if len(rules) > 0 {
+			synth, err := rewrite.ApplyRequestRules(rules, r, bodyBytes)
+			if err != nil {
+				logging.Errorf(ctx, "apply rewrite rules: %v", err)
+			} else if synth != nil {
+				for k, vv := range synth.Headers {
+					for _, v := range vv {
+						w.Header().Add(k, v)
+					}
+				}
+				w.WriteHeader(synth.StatusCode)
+				if len(synth.Body) > 0 {
+					_, _ = w.Write(synth.Body)
+				}
+				return
+			}
+		}
+	}
+
 	// Build upstream request.
 	upReq, err := http.NewRequestWithContext(ctx, proxyReq.Method, proxyReq.URL.String(), proxyReq.Body)
 	if err != nil {
@@ -294,6 +328,18 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 		Headers:    upResp.Header.Clone(),
 		Body:       nil,
 		Raw:        upResp,
+	}
+
+	// Apply response rewrite rules before plugins.
+	if p.engine != nil {
+		rules, err := p.engine.RewriteRules()
+		if err != nil {
+			logging.Errorf(ctx, "load rewrite rules (response): %v", err)
+		} else if len(rules) > 0 {
+			respBody = rewrite.ApplyResponseRules(rules, r, upResp, respBody)
+			// Sync updated headers back into proxyResp.
+			proxyResp.Headers = upResp.Header.Clone()
+		}
 	}
 
 	// Run plugin OnResponse chain (with panic recovery).

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -88,6 +88,13 @@ func (p *TLSProxy) handleBufferedConn(ctx context.Context, conn net.Conn, host s
 		return
 	}
 	defer func() { _ = tlsConn.Close() }()
+
+	// Detect ALPN-negotiated protocol. "h2" means HTTP/2 over TLS.
+	tlsProto := "HTTP/1.1"
+	if cs := tlsConn.ConnectionState(); cs.NegotiatedProtocol == "h2" {
+		tlsProto = "HTTP/2.0"
+	}
+
 	tlsBr := bufio.NewReader(tlsConn)
 
 	// Handle multiple pipelined requests on the same connection.
@@ -108,7 +115,7 @@ func (p *TLSProxy) handleBufferedConn(ctx context.Context, conn net.Conn, host s
 			req.URL.Scheme = "https"
 		}
 
-		p.handleRequest(ctx, tlsConn, tlsBr, req, host)
+		p.handleRequest(ctx, tlsConn, tlsBr, req, host, tlsProto)
 		if isWebSocketRequest(req) {
 			return
 		}
@@ -124,7 +131,7 @@ func (c *bufferedConn) Read(p []byte) (int, error) {
 	return c.reader.Read(p)
 }
 
-func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.Reader, r *http.Request, host string) {
+func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.Reader, r *http.Request, host string, protocol string) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			logging.Errorf(ctx, "TLS proxy panic (recovered): %v", rec)
@@ -157,12 +164,13 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	}
 
 	proxyReq := &plugins.ProxyRequest{
-		ID:      reqID,
-		Method:  r.Method,
-		URL:     r.URL,
-		Headers: r.Header.Clone(),
-		Body:    io.NopCloser(bytes.NewReader(bodyBytes)),
-		Raw:     r,
+		ID:       reqID,
+		Method:   r.Method,
+		URL:      r.URL,
+		Headers:  r.Header.Clone(),
+		Body:     io.NopCloser(bytes.NewReader(bodyBytes)),
+		Protocol: protocol,
+		Raw:      r,
 	}
 
 	// Run plugin OnRequest chain with panic recovery.

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -6,8 +6,12 @@ import (
 	"time"
 
 	"github.com/mnafshin/apix/internal/breakpoints"
+	apix "github.com/mnafshin/apix/pkg/api/generated"
 	"github.com/mnafshin/apix/pkg/plugins"
 )
+
+// RewriteRuleProto is a type alias so proxy callers don't need to import the generated package directly.
+type RewriteRuleProto = apix.RewriteRule
 
 // ProxyRequest is an alias for the plugins-layer request type.
 type ProxyRequest = plugins.ProxyRequest
@@ -25,6 +29,8 @@ type TrafficEngine interface {
 	// PauseRequest holds a request at a breakpoint and blocks until resumed.
 	// Returns the (possibly modified) request and the resume action.
 	PauseRequest(tx *Transaction) (*Transaction, ResumeAction, error)
+	// RewriteRules loads the current list of enabled rewrite rules from storage.
+	RewriteRules() ([]*RewriteRuleProto, error)
 }
 
 // PluginChain is an ordered list of plugins applied to each request/response.

--- a/internal/rewrite/rules.go
+++ b/internal/rewrite/rules.go
@@ -1,0 +1,189 @@
+package rewrite
+
+import (
+	"bytes"
+	"net/http"
+	"sort"
+	"strings"
+
+	apix "github.com/mnafshin/apix/pkg/api/generated"
+)
+
+// matchesRule reports whether req satisfies the MatchCriteria of rule.
+// For request-phase matching, statusCode in match criteria is ignored.
+func matchesRule(rule *apix.RewriteRule, req *http.Request, reqBody []byte) bool {
+	if !rule.Enabled {
+		return false
+	}
+	m := rule.Match
+	if m == nil {
+		return true
+	}
+	if m.UrlPattern != "" && !strings.Contains(req.URL.String(), m.UrlPattern) {
+		return false
+	}
+	if m.Method != "" && !strings.EqualFold(req.Method, m.Method) {
+		return false
+	}
+	if m.HeaderName != "" {
+		v := req.Header.Get(m.HeaderName)
+		if v == "" {
+			return false
+		}
+		if m.HeaderValue != "" && !strings.Contains(v, m.HeaderValue) {
+			return false
+		}
+	}
+	if m.BodyPattern != "" && !bytes.Contains(reqBody, []byte(m.BodyPattern)) {
+		return false
+	}
+	return true
+}
+
+// matchesResponseRule reports whether the response satisfies the MatchCriteria.
+func matchesResponseRule(rule *apix.RewriteRule, req *http.Request, resp *http.Response, respBody []byte) bool {
+	if !rule.Enabled {
+		return false
+	}
+	m := rule.Match
+	if m == nil {
+		return true
+	}
+	if m.UrlPattern != "" && !strings.Contains(req.URL.String(), m.UrlPattern) {
+		return false
+	}
+	if m.Method != "" && !strings.EqualFold(req.Method, m.Method) {
+		return false
+	}
+	if m.StatusCode != 0 && resp.StatusCode != int(m.StatusCode) {
+		return false
+	}
+	if m.HeaderName != "" {
+		v := resp.Header.Get(m.HeaderName)
+		if v == "" {
+			return false
+		}
+		if m.HeaderValue != "" && !strings.Contains(v, m.HeaderValue) {
+			return false
+		}
+	}
+	if m.BodyPattern != "" && !bytes.Contains(respBody, []byte(m.BodyPattern)) {
+		return false
+	}
+	return true
+}
+
+// SyntheticResponse is a short-circuit HTTP response produced by a rewrite rule.
+type SyntheticResponse struct {
+	StatusCode  int
+	Headers     http.Header
+	Body        []byte
+	RedirectURL string // non-empty for REDIRECT action
+}
+
+// ApplyRequestRules applies enabled rewrite rules to an outgoing request in
+// priority order. It returns a SyntheticResponse if a terminal action fires
+// (REDIRECT, BLOCK, RESPOND), otherwise nil.
+// reqBody is the buffered request body (may be nil).
+func ApplyRequestRules(rules []*apix.RewriteRule, req *http.Request, reqBody []byte) (*SyntheticResponse, error) {
+	sorted := sortedRules(rules)
+	for _, rule := range sorted {
+		if !matchesRule(rule, req, reqBody) {
+			continue
+		}
+		switch rule.Action {
+		case apix.RewriteAction_ADD_REQUEST_HEADER:
+			if rule.ParamKey != "" {
+				req.Header.Add(rule.ParamKey, rule.ParamValue)
+			}
+		case apix.RewriteAction_REMOVE_REQUEST_HEADER:
+			if rule.ParamKey != "" {
+				req.Header.Del(rule.ParamKey)
+			}
+		case apix.RewriteAction_REPLACE_REQUEST_HEADER:
+			if rule.ParamKey != "" {
+				req.Header.Set(rule.ParamKey, rule.ParamValue)
+			}
+		case apix.RewriteAction_REPLACE_REQUEST_BODY:
+			if len(rule.BodyTemplate) > 0 {
+				reqBody = rule.BodyTemplate
+				req.Body = http.NoBody
+				req.ContentLength = int64(len(reqBody))
+			}
+		case apix.RewriteAction_REDIRECT:
+			target := rule.ParamValue
+			if target == "" {
+				target = rule.ParamKey
+			}
+			hdrs := make(http.Header)
+			hdrs.Set("Location", target)
+			return &SyntheticResponse{
+				StatusCode:  http.StatusFound,
+				Headers:     hdrs,
+				RedirectURL: target,
+			}, nil
+		case apix.RewriteAction_BLOCK:
+			return &SyntheticResponse{
+				StatusCode: http.StatusForbidden,
+				Headers:    make(http.Header),
+				Body:       []byte("blocked by rewrite rule"),
+			}, nil
+		case apix.RewriteAction_RESPOND:
+			statusCode := int(rule.ResponseStatus)
+			if statusCode == 0 {
+				statusCode = http.StatusOK
+			}
+			hdrs := make(http.Header)
+			if rule.ResponseContentType != "" {
+				hdrs.Set("Content-Type", rule.ResponseContentType)
+			}
+			return &SyntheticResponse{
+				StatusCode: statusCode,
+				Headers:    hdrs,
+				Body:       rule.ResponseBody,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+// ApplyResponseRules applies enabled rewrite rules to an upstream response in
+// priority order. It mutates resp headers in place and returns the (possibly
+// modified) body bytes.
+func ApplyResponseRules(rules []*apix.RewriteRule, req *http.Request, resp *http.Response, respBody []byte) []byte {
+	sorted := sortedRules(rules)
+	for _, rule := range sorted {
+		if !matchesResponseRule(rule, req, resp, respBody) {
+			continue
+		}
+		switch rule.Action {
+		case apix.RewriteAction_ADD_RESPONSE_HEADER:
+			if rule.ParamKey != "" {
+				resp.Header.Add(rule.ParamKey, rule.ParamValue)
+			}
+		case apix.RewriteAction_REMOVE_RESPONSE_HEADER:
+			if rule.ParamKey != "" {
+				resp.Header.Del(rule.ParamKey)
+			}
+		case apix.RewriteAction_REPLACE_RESPONSE_HEADER:
+			if rule.ParamKey != "" {
+				resp.Header.Set(rule.ParamKey, rule.ParamValue)
+			}
+		case apix.RewriteAction_REPLACE_RESPONSE_BODY:
+			if len(rule.BodyTemplate) > 0 {
+				respBody = rule.BodyTemplate
+			}
+		}
+	}
+	return respBody
+}
+
+// sortedRules returns a copy of rules sorted by priority ascending (lower = higher priority).
+func sortedRules(rules []*apix.RewriteRule) []*apix.RewriteRule {
+	sorted := make([]*apix.RewriteRule, len(rules))
+	copy(sorted, rules)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Priority < sorted[j].Priority
+	})
+	return sorted
+}

--- a/internal/rewrite/rules_test.go
+++ b/internal/rewrite/rules_test.go
@@ -1,0 +1,313 @@
+package rewrite_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mnafshin/apix/internal/rewrite"
+	apix "github.com/mnafshin/apix/pkg/api/generated"
+)
+
+func makeRule(action apix.RewriteAction, match *apix.MatchCriteria, opts ...func(*apix.RewriteRule)) *apix.RewriteRule {
+	r := &apix.RewriteRule{
+		Id:       "rule-1",
+		Name:     "test",
+		Enabled:  true,
+		Priority: 100,
+		Match:    match,
+		Action:   action,
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
+}
+
+func newGET(url string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	return req
+}
+
+// ---- Request rule tests ----
+
+func TestApplyRequestRules_AddHeader(t *testing.T) {
+	req := newGET("http://example.com/api")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_ADD_REQUEST_HEADER, nil, func(r *apix.RewriteRule) {
+		r.ParamKey = "X-Custom"
+		r.ParamValue = "hello"
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth != nil {
+		t.Fatalf("expected no synthetic response")
+	}
+	if got := req.Header.Get("X-Custom"); got != "hello" {
+		t.Errorf("expected X-Custom: hello, got %q", got)
+	}
+}
+
+func TestApplyRequestRules_RemoveHeader(t *testing.T) {
+	req := newGET("http://example.com/api")
+	req.Header.Set("Authorization", "Bearer token")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_REMOVE_REQUEST_HEADER, nil, func(r *apix.RewriteRule) {
+		r.ParamKey = "Authorization"
+	})}
+	_, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("expected Authorization to be removed, got %q", got)
+	}
+}
+
+func TestApplyRequestRules_ReplaceHeader(t *testing.T) {
+	req := newGET("http://example.com/api")
+	req.Header.Set("X-Version", "old")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_REPLACE_REQUEST_HEADER, nil, func(r *apix.RewriteRule) {
+		r.ParamKey = "X-Version"
+		r.ParamValue = "new"
+	})}
+	_, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.Header.Get("X-Version"); got != "new" {
+		t.Errorf("expected X-Version: new, got %q", got)
+	}
+}
+
+func TestApplyRequestRules_Block(t *testing.T) {
+	req := newGET("http://example.com/blocked")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_BLOCK, nil)}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth == nil {
+		t.Fatal("expected synthetic response")
+	}
+	if synth.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", synth.StatusCode)
+	}
+}
+
+func TestApplyRequestRules_Redirect(t *testing.T) {
+	req := newGET("http://example.com/old")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_REDIRECT, nil, func(r *apix.RewriteRule) {
+		r.ParamValue = "http://example.com/new"
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth == nil {
+		t.Fatal("expected synthetic response")
+	}
+	if synth.StatusCode != http.StatusFound {
+		t.Errorf("expected 302, got %d", synth.StatusCode)
+	}
+	if synth.Headers.Get("Location") != "http://example.com/new" {
+		t.Errorf("unexpected Location: %s", synth.Headers.Get("Location"))
+	}
+	if synth.RedirectURL != "http://example.com/new" {
+		t.Errorf("unexpected RedirectURL: %s", synth.RedirectURL)
+	}
+}
+
+func TestApplyRequestRules_Respond(t *testing.T) {
+	req := newGET("http://example.com/mock")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_RESPOND, nil, func(r *apix.RewriteRule) {
+		r.ResponseStatus = 200
+		r.ResponseBody = []byte(`{"ok":true}`)
+		r.ResponseContentType = "application/json"
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth == nil {
+		t.Fatal("expected synthetic response")
+	}
+	if synth.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", synth.StatusCode)
+	}
+	if !bytes.Equal(synth.Body, []byte(`{"ok":true}`)) {
+		t.Errorf("unexpected body: %s", synth.Body)
+	}
+	if synth.Headers.Get("Content-Type") != "application/json" {
+		t.Errorf("unexpected Content-Type: %s", synth.Headers.Get("Content-Type"))
+	}
+}
+
+func TestApplyRequestRules_MatchURLPattern(t *testing.T) {
+	req := newGET("http://example.com/api/v1")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_BLOCK, &apix.MatchCriteria{
+		UrlPattern: "/api/v2",
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Pattern doesn't match, so no synthetic response
+	if synth != nil {
+		t.Errorf("expected no synthetic response for non-matching URL pattern")
+	}
+}
+
+func TestApplyRequestRules_MatchMethod(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/api", nil)
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_BLOCK, &apix.MatchCriteria{
+		Method: "GET",
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth != nil {
+		t.Errorf("POST request should not match GET method rule")
+	}
+}
+
+func TestApplyRequestRules_MatchBodyPattern(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/api", bytes.NewBufferString(`{"secret":"value"}`))
+	body := []byte(`{"secret":"value"}`)
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_BLOCK, &apix.MatchCriteria{
+		BodyPattern: "secret",
+	})}
+	synth, err := rewrite.ApplyRequestRules(rules, req, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth == nil || synth.StatusCode != http.StatusForbidden {
+		t.Errorf("expected block on body pattern match")
+	}
+}
+
+func TestApplyRequestRules_DisabledRule(t *testing.T) {
+	req := newGET("http://example.com/api")
+	rule := makeRule(apix.RewriteAction_BLOCK, nil)
+	rule.Enabled = false
+	synth, err := rewrite.ApplyRequestRules([]*apix.RewriteRule{rule}, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if synth != nil {
+		t.Errorf("disabled rule should not trigger")
+	}
+}
+
+func TestApplyRequestRules_PriorityOrder(t *testing.T) {
+	req := newGET("http://example.com/api")
+	// Low priority BLOCK (should fire last but here we test order)
+	// High priority ADD header (lower number = higher priority)
+	rules := []*apix.RewriteRule{
+		{Id: "low", Enabled: true, Priority: 200, Action: apix.RewriteAction_BLOCK},
+		{Id: "high", Enabled: true, Priority: 50, Action: apix.RewriteAction_ADD_REQUEST_HEADER, ParamKey: "X-Applied", ParamValue: "yes"},
+	}
+	// With priority order: high (50) runs first, low (200) BLOCK runs after
+	synth, err := rewrite.ApplyRequestRules(rules, req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// BLOCK at priority 200 should still fire after the header rule
+	if synth == nil || synth.StatusCode != http.StatusForbidden {
+		t.Errorf("expected block from low-priority rule after high-priority header rule")
+	}
+	// Header should have been set before block
+	if req.Header.Get("X-Applied") != "yes" {
+		t.Errorf("expected X-Applied header to be set before block")
+	}
+}
+
+// ---- Response rule tests ----
+
+func TestApplyResponseRules_AddHeader(t *testing.T) {
+	req := newGET("http://example.com/api")
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     make(http.Header),
+	}
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_ADD_RESPONSE_HEADER, nil, func(r *apix.RewriteRule) {
+		r.ParamKey = "X-Injected"
+		r.ParamValue = "true"
+	})}
+	rewrite.ApplyResponseRules(rules, req, resp, nil)
+	if got := resp.Header.Get("X-Injected"); got != "true" {
+		t.Errorf("expected X-Injected: true, got %q", got)
+	}
+}
+
+func TestApplyResponseRules_RemoveHeader(t *testing.T) {
+	req := newGET("http://example.com/api")
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Server": []string{"nginx"}},
+	}
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_REMOVE_RESPONSE_HEADER, nil, func(r *apix.RewriteRule) {
+		r.ParamKey = "Server"
+	})}
+	rewrite.ApplyResponseRules(rules, req, resp, nil)
+	if got := resp.Header.Get("Server"); got != "" {
+		t.Errorf("expected Server header removed, got %q", got)
+	}
+}
+
+func TestApplyResponseRules_ReplaceBody(t *testing.T) {
+	req := newGET("http://example.com/api")
+	resp := &http.Response{StatusCode: 200, Header: make(http.Header)}
+	body := []byte(`original`)
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_REPLACE_RESPONSE_BODY, nil, func(r *apix.RewriteRule) {
+		r.BodyTemplate = []byte(`replaced`)
+	})}
+	result := rewrite.ApplyResponseRules(rules, req, resp, body)
+	if !bytes.Equal(result, []byte(`replaced`)) {
+		t.Errorf("expected replaced body, got %s", result)
+	}
+}
+
+func TestApplyResponseRules_StatusCodeMatch(t *testing.T) {
+	req := newGET("http://example.com/api")
+	resp := &http.Response{StatusCode: 404, Header: make(http.Header)}
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_ADD_RESPONSE_HEADER, &apix.MatchCriteria{
+		StatusCode: 200,
+	}, func(r *apix.RewriteRule) {
+		r.ParamKey = "X-Status"
+		r.ParamValue = "ok"
+	})}
+	rewrite.ApplyResponseRules(rules, req, resp, nil)
+	if got := resp.Header.Get("X-Status"); got != "" {
+		t.Errorf("status 404 should not match status_code 200 criteria")
+	}
+}
+
+// ---- Integration: httptest round-trip simulation ----
+
+func TestApplyRequestRules_BlockWritesResponse(t *testing.T) {
+	req := newGET("http://example.com/blocked")
+	rules := []*apix.RewriteRule{makeRule(apix.RewriteAction_BLOCK, nil)}
+	synth, _ := rewrite.ApplyRequestRules(rules, req, nil)
+	if synth == nil {
+		t.Fatal("expected synthetic response")
+	}
+	w := httptest.NewRecorder()
+	for k, vv := range synth.Headers {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(synth.StatusCode)
+	if len(synth.Body) > 0 {
+		_, _ = w.Write(synth.Body)
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("blocked")) {
+		t.Errorf("expected 'blocked' in body, got %s", w.Body.Bytes())
+	}
+}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -380,6 +380,7 @@ func (s *EngineServer) GetHistory(req *apix.HistoryQuery, stream grpc.ServerStre
 				Headers:   hdrs,
 				Body:      r.Body,
 				Timestamp: r.Timestamp.UnixMilli(),
+				Protocol:  r.Protocol,
 			},
 		}
 
@@ -611,3 +612,61 @@ func StartGRPCServer(ctx context.Context, eng *engine.Engine, re *replay.Engine,
 // Suppress unused import warnings.
 var _ = fmt.Sprintf
 var _ = time.Now
+
+// ----- Rewrite rules -----
+
+func (s *EngineServer) AddRewriteRule(ctx context.Context, rule *apix.RewriteRule) (*apix.RewriteRule, error) {
+	if rule.Id == "" {
+		rule.Id = uuid.NewString()
+	}
+	if err := s.engine.DB().AddRewriteRule(rule); err != nil {
+		return nil, status.Errorf(codes.Internal, "add rewrite rule: %v", err)
+	}
+	return rule, nil
+}
+
+func (s *EngineServer) UpdateRewriteRule(ctx context.Context, rule *apix.RewriteRule) (*apix.RewriteRule, error) {
+	if rule.Id == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
+	}
+	if err := s.engine.DB().UpdateRewriteRule(rule); err != nil {
+		return nil, status.Errorf(codes.Internal, "update rewrite rule: %v", err)
+	}
+	return rule, nil
+}
+
+func (s *EngineServer) DeleteRewriteRule(ctx context.Context, req *apix.RewriteRuleRequest) (*apix.Empty, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
+	}
+	if err := s.engine.DB().DeleteRewriteRule(req.RuleId); err != nil {
+		return nil, status.Errorf(codes.Internal, "delete rewrite rule: %v", err)
+	}
+	return &apix.Empty{}, nil
+}
+
+func (s *EngineServer) ListRewriteRules(ctx context.Context, _ *apix.Empty) (*apix.RewriteRuleList, error) {
+	rules, err := s.engine.DB().ListRewriteRules()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list rewrite rules: %v", err)
+	}
+	return &apix.RewriteRuleList{Rules: rules}, nil
+}
+
+func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteRuleRequest) (*apix.RewriteRule, error) {
+	if req.RuleId == "" {
+		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
+	}
+	rule, err := s.engine.DB().GetRewriteRule(req.RuleId)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "get rewrite rule: %v", err)
+	}
+	if rule == nil {
+		return nil, status.Errorf(codes.NotFound, "rule %q not found", req.RuleId)
+	}
+	rule.Enabled = !rule.Enabled
+	if err := s.engine.DB().UpdateRewriteRule(rule); err != nil {
+		return nil, status.Errorf(codes.Internal, "toggle rewrite rule: %v", err)
+	}
+	return rule, nil
+}

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	logging "github.com/mnafshin/apix/internal/logging"
+	apix "github.com/mnafshin/apix/pkg/api/generated"
 	"strings"
 	"time"
 )
@@ -19,6 +20,7 @@ type RequestRecord struct {
 	Body       []byte
 	Timestamp  time.Time
 	DurationMs int64
+	Protocol   string // negotiated protocol: "HTTP/1.1", "HTTP/2.0", "h2c"
 }
 
 // ResponseRecord is the Go representation of a row in the responses table.
@@ -72,7 +74,7 @@ func (d *DB) SaveResponse(r *ResponseRecord) error {
 // GetTransaction retrieves a request+response pair by request ID.
 func (d *DB) GetTransaction(id string) (*RequestRecord, *ResponseRecord, error) {
 	req, err := d.scanRequest(d.db.QueryRow(
-		`SELECT id, method, url, headers, body, timestamp, duration_ms
+		`SELECT id, method, url, headers, body, timestamp, duration_ms, COALESCE(protocol,'HTTP/1.1')
 		 FROM requests WHERE id = ?`, id))
 	if err == sql.ErrNoRows {
 		return nil, nil, nil
@@ -129,6 +131,7 @@ func (d *DB) ListTransactions(limit, offset int, urlFilter, methodFilter string,
 
 	query := fmt.Sprintf(`
 		SELECT r.id, r.method, r.url, r.headers, r.body, r.timestamp, r.duration_ms,
+		       COALESCE(r.protocol,'HTTP/1.1'),
 		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body
 		FROM requests r
 		LEFT JOIN responses resp ON r.id = resp.request_id
@@ -145,6 +148,7 @@ func (d *DB) ListTransactions(limit, offset int, urlFilter, methodFilter string,
 func (d *DB) ExportTransactions(transactionIDs []string) ([]*RequestRecord, []*ResponseRecord, error) {
 	query := `
 		SELECT r.id, r.method, r.url, r.headers, r.body, r.timestamp, r.duration_ms,
+		       COALESCE(r.protocol,'HTTP/1.1'),
 		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body
 		FROM requests r
 		LEFT JOIN responses resp ON r.id = resp.request_id`
@@ -231,10 +235,11 @@ func (d *DB) ListBreakpoints() ([]*BreakpointRecord, error) {
 func (d *DB) scanRequest(row *sql.Row) (*RequestRecord, error) {
 	var (
 		id, method, url, hdrs string
+		protocol              string
 		body                  []byte
 		tsMs, durMs           int64
 	)
-	if err := row.Scan(&id, &method, &url, &hdrs, &body, &tsMs, &durMs); err != nil {
+	if err := row.Scan(&id, &method, &url, &hdrs, &body, &tsMs, &durMs, &protocol); err != nil {
 		return nil, err
 	}
 	req := &RequestRecord{
@@ -244,6 +249,7 @@ func (d *DB) scanRequest(row *sql.Row) (*RequestRecord, error) {
 		Body:       body,
 		Timestamp:  time.UnixMilli(tsMs),
 		DurationMs: durMs,
+		Protocol:   protocol,
 	}
 	if err := json.Unmarshal([]byte(hdrs), &req.Headers); err != nil {
 		logging.Warnf(context.Background(), "failed to unmarshal request headers for request %s: %v", id, err)
@@ -288,6 +294,7 @@ func (d *DB) listTransactionsQuery(query string, args ...interface{}) ([]*Reques
 	for rows.Next() {
 		var (
 			reqID, method, url, reqHeaders string
+			protocol                       string
 			reqBody                        []byte
 			tsMs, durMs                    int64
 			respReqID                      sql.NullString
@@ -296,7 +303,7 @@ func (d *DB) listTransactionsQuery(query string, args ...interface{}) ([]*Reques
 			respBody                       []byte
 		)
 		if err := rows.Scan(
-			&reqID, &method, &url, &reqHeaders, &reqBody, &tsMs, &durMs,
+			&reqID, &method, &url, &reqHeaders, &reqBody, &tsMs, &durMs, &protocol,
 			&respReqID, &statusCode, &statusText, &respHeaders, &respBody,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan transaction: %w", err)
@@ -309,6 +316,7 @@ func (d *DB) listTransactionsQuery(query string, args ...interface{}) ([]*Reques
 			Body:       reqBody,
 			Timestamp:  time.UnixMilli(tsMs),
 			DurationMs: durMs,
+			Protocol:   protocol,
 		}
 		if err := json.Unmarshal([]byte(reqHeaders), &req.Headers); err != nil {
 			logging.Warnf(context.Background(), "failed to unmarshal request headers for request %s: %v", reqID, err)
@@ -335,4 +343,144 @@ func (d *DB) listTransactionsQuery(query string, args ...interface{}) ([]*Reques
 		}
 	}
 	return reqs, resps, rows.Err()
+}
+
+// AddRewriteRule inserts a new rewrite rule.
+func (d *DB) AddRewriteRule(rule *apix.RewriteRule) error {
+var match *apix.MatchCriteria
+if rule.Match != nil {
+match = rule.Match
+} else {
+match = &apix.MatchCriteria{}
+}
+enabledInt := 0
+if rule.Enabled {
+enabledInt = 1
+}
+_, err := d.db.Exec(
+`INSERT OR REPLACE INTO rewrite_rules
+ (id, name, enabled, priority, url_pattern, method, header_name, header_value,
+  body_pattern, status_code, action, param_key, param_value, body_template,
+  response_status, response_body, response_content_type)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+rule.Id, rule.Name, enabledInt, rule.Priority,
+match.UrlPattern, match.Method, match.HeaderName, match.HeaderValue,
+match.BodyPattern, match.StatusCode,
+int32(rule.Action), rule.ParamKey, rule.ParamValue, rule.BodyTemplate,
+rule.ResponseStatus, rule.ResponseBody, rule.ResponseContentType,
+)
+return err
+}
+
+// UpdateRewriteRule replaces an existing rewrite rule.
+func (d *DB) UpdateRewriteRule(rule *apix.RewriteRule) error {
+return d.AddRewriteRule(rule)
+}
+
+// DeleteRewriteRule removes a rewrite rule by ID.
+func (d *DB) DeleteRewriteRule(id string) error {
+_, err := d.db.Exec("DELETE FROM rewrite_rules WHERE id = ?", id)
+return err
+}
+
+// GetRewriteRule retrieves a single rewrite rule by ID.
+func (d *DB) GetRewriteRule(id string) (*apix.RewriteRule, error) {
+row := d.db.QueryRow(
+`SELECT id, name, enabled, priority, url_pattern, method, header_name, header_value,
+        body_pattern, status_code, action, param_key, param_value, body_template,
+        response_status, response_body, response_content_type
+ FROM rewrite_rules WHERE id = ?`, id)
+rule, err := scanRewriteRule(row)
+if err == sql.ErrNoRows {
+return nil, nil
+}
+return rule, err
+}
+
+// ListRewriteRules returns all rewrite rules ordered by priority.
+func (d *DB) ListRewriteRules() ([]*apix.RewriteRule, error) {
+rows, err := d.db.Query(
+`SELECT id, name, enabled, priority, url_pattern, method, header_name, header_value,
+        body_pattern, status_code, action, param_key, param_value, body_template,
+        response_status, response_body, response_content_type
+ FROM rewrite_rules ORDER BY priority ASC`)
+if err != nil {
+return nil, fmt.Errorf("list rewrite rules: %w", err)
+}
+defer func() { _ = rows.Close() }()
+var rules []*apix.RewriteRule
+for rows.Next() {
+rule, err := scanRewriteRuleRow(rows)
+if err != nil {
+return nil, fmt.Errorf("scan rewrite rule: %w", err)
+}
+rules = append(rules, rule)
+}
+return rules, rows.Err()
+}
+
+func scanRewriteRule(row *sql.Row) (*apix.RewriteRule, error) {
+var (
+id, name, urlPattern, method, headerName, headerValue  string
+bodyPattern, paramKey, paramValue, responseContentType string
+enabledInt, priority, statusCode, action, responseStatus int
+bodyTemplate, responseBody                              []byte
+)
+err := row.Scan(
+&id, &name, &enabledInt, &priority,
+&urlPattern, &method, &headerName, &headerValue,
+&bodyPattern, &statusCode, &action, &paramKey, &paramValue,
+&bodyTemplate, &responseStatus, &responseBody, &responseContentType,
+)
+if err != nil {
+return nil, err
+}
+return buildRewriteRule(id, name, enabledInt, priority, urlPattern, method, headerName, headerValue,
+bodyPattern, statusCode, action, paramKey, paramValue, bodyTemplate, responseStatus, responseBody, responseContentType), nil
+}
+
+func scanRewriteRuleRow(rows *sql.Rows) (*apix.RewriteRule, error) {
+var (
+id, name, urlPattern, method, headerName, headerValue  string
+bodyPattern, paramKey, paramValue, responseContentType string
+enabledInt, priority, statusCode, action, responseStatus int
+bodyTemplate, responseBody                              []byte
+)
+err := rows.Scan(
+&id, &name, &enabledInt, &priority,
+&urlPattern, &method, &headerName, &headerValue,
+&bodyPattern, &statusCode, &action, &paramKey, &paramValue,
+&bodyTemplate, &responseStatus, &responseBody, &responseContentType,
+)
+if err != nil {
+return nil, err
+}
+return buildRewriteRule(id, name, enabledInt, priority, urlPattern, method, headerName, headerValue,
+bodyPattern, statusCode, action, paramKey, paramValue, bodyTemplate, responseStatus, responseBody, responseContentType), nil
+}
+
+func buildRewriteRule(id, name string, enabledInt, priority int, urlPattern, method, headerName, headerValue,
+bodyPattern string, statusCode, action int, paramKey, paramValue string, bodyTemplate []byte,
+responseStatus int, responseBody []byte, responseContentType string) *apix.RewriteRule {
+return &apix.RewriteRule{
+Id:       id,
+Name:     name,
+Enabled:  enabledInt == 1,
+Priority: int32(priority),
+Match: &apix.MatchCriteria{
+UrlPattern:  urlPattern,
+Method:      method,
+HeaderName:  headerName,
+HeaderValue: headerValue,
+BodyPattern: bodyPattern,
+StatusCode:  int32(statusCode),
+},
+Action:              apix.RewriteAction(action),
+ParamKey:            paramKey,
+ParamValue:          paramValue,
+BodyTemplate:        bodyTemplate,
+ResponseStatus:      int32(responseStatus),
+ResponseBody:        responseBody,
+ResponseContentType: responseContentType,
+}
 }

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS requests (
     headers     TEXT NOT NULL DEFAULT '{}', -- JSON object
     body        BLOB,
     timestamp   INTEGER NOT NULL,           -- Unix milliseconds
-    duration_ms INTEGER NOT NULL DEFAULT 0
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    protocol    TEXT NOT NULL DEFAULT 'HTTP/1.1'  -- negotiated protocol
 );`
 
 const CreateResponsesTable = `
@@ -54,6 +55,27 @@ CREATE TABLE IF NOT EXISTS ws_frames (
     FOREIGN KEY (transaction_id) REFERENCES requests(id) ON DELETE CASCADE
 );`
 
+const CreateRewriteRulesTable = `
+CREATE TABLE IF NOT EXISTS rewrite_rules (
+    id                    TEXT PRIMARY KEY,
+    name                  TEXT NOT NULL DEFAULT '',
+    enabled               INTEGER NOT NULL DEFAULT 1,
+    priority              INTEGER NOT NULL DEFAULT 100,
+    url_pattern           TEXT NOT NULL DEFAULT '',
+    method                TEXT NOT NULL DEFAULT '',
+    header_name           TEXT NOT NULL DEFAULT '',
+    header_value          TEXT NOT NULL DEFAULT '',
+    body_pattern          TEXT NOT NULL DEFAULT '',
+    status_code           INTEGER NOT NULL DEFAULT 0,
+    action                INTEGER NOT NULL DEFAULT 0,
+    param_key             TEXT NOT NULL DEFAULT '',
+    param_value           TEXT NOT NULL DEFAULT '',
+    body_template         BLOB,
+    response_status       INTEGER NOT NULL DEFAULT 200,
+    response_body         BLOB,
+    response_content_type TEXT NOT NULL DEFAULT ''
+);`
+
 // AllTables is the ordered list of DDL statements to apply during DB init.
 // Order matters for foreign key dependencies.
 var AllTables = []string{
@@ -62,9 +84,11 @@ var AllTables = []string{
 	CreateBreakpointsTable,
 	CreatePluginsTable,
 	CreateWebSocketFramesTable,
+	CreateRewriteRulesTable,
 	// Indexes — created after tables so IF NOT EXISTS is safe on re-open.
 	`CREATE INDEX IF NOT EXISTS idx_requests_timestamp ON requests(timestamp DESC)`,
 	`CREATE INDEX IF NOT EXISTS idx_requests_method    ON requests(method)`,
 	`CREATE INDEX IF NOT EXISTS idx_requests_url       ON requests(url)`,
 	`CREATE INDEX IF NOT EXISTS idx_ws_frames_txid     ON ws_frames(transaction_id)`,
+	`CREATE INDEX IF NOT EXISTS idx_rewrite_rules_priority ON rewrite_rules(priority ASC)`,
 }

--- a/pkg/api/generated/apix.pb.go
+++ b/pkg/api/generated/apix.pb.go
@@ -21,6 +21,82 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type RewriteAction int32
+
+const (
+	RewriteAction_REWRITE_ACTION_UNSPECIFIED RewriteAction = 0
+	RewriteAction_ADD_REQUEST_HEADER         RewriteAction = 1
+	RewriteAction_REMOVE_REQUEST_HEADER      RewriteAction = 2
+	RewriteAction_REPLACE_REQUEST_HEADER     RewriteAction = 3
+	RewriteAction_ADD_RESPONSE_HEADER        RewriteAction = 4
+	RewriteAction_REMOVE_RESPONSE_HEADER     RewriteAction = 5
+	RewriteAction_REPLACE_RESPONSE_HEADER    RewriteAction = 6
+	RewriteAction_REPLACE_REQUEST_BODY       RewriteAction = 7
+	RewriteAction_REPLACE_RESPONSE_BODY      RewriteAction = 8
+	RewriteAction_REDIRECT                   RewriteAction = 9
+	RewriteAction_BLOCK                      RewriteAction = 10
+	RewriteAction_RESPOND                    RewriteAction = 11
+)
+
+// Enum value maps for RewriteAction.
+var (
+	RewriteAction_name = map[int32]string{
+		0:  "REWRITE_ACTION_UNSPECIFIED",
+		1:  "ADD_REQUEST_HEADER",
+		2:  "REMOVE_REQUEST_HEADER",
+		3:  "REPLACE_REQUEST_HEADER",
+		4:  "ADD_RESPONSE_HEADER",
+		5:  "REMOVE_RESPONSE_HEADER",
+		6:  "REPLACE_RESPONSE_HEADER",
+		7:  "REPLACE_REQUEST_BODY",
+		8:  "REPLACE_RESPONSE_BODY",
+		9:  "REDIRECT",
+		10: "BLOCK",
+		11: "RESPOND",
+	}
+	RewriteAction_value = map[string]int32{
+		"REWRITE_ACTION_UNSPECIFIED": 0,
+		"ADD_REQUEST_HEADER":         1,
+		"REMOVE_REQUEST_HEADER":      2,
+		"REPLACE_REQUEST_HEADER":     3,
+		"ADD_RESPONSE_HEADER":        4,
+		"REMOVE_RESPONSE_HEADER":     5,
+		"REPLACE_RESPONSE_HEADER":    6,
+		"REPLACE_REQUEST_BODY":       7,
+		"REPLACE_RESPONSE_BODY":      8,
+		"REDIRECT":                   9,
+		"BLOCK":                      10,
+		"RESPOND":                    11,
+	}
+)
+
+func (x RewriteAction) Enum() *RewriteAction {
+	p := new(RewriteAction)
+	*p = x
+	return p
+}
+
+func (x RewriteAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RewriteAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_apix_proto_enumTypes[0].Descriptor()
+}
+
+func (RewriteAction) Type() protoreflect.EnumType {
+	return &file_apix_proto_enumTypes[0]
+}
+
+func (x RewriteAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RewriteAction.Descriptor instead.
+func (RewriteAction) EnumDescriptor() ([]byte, []int) {
+	return file_apix_proto_rawDescGZIP(), []int{0}
+}
+
 type ResumeAction_Action int32
 
 const (
@@ -54,11 +130,11 @@ func (x ResumeAction_Action) String() string {
 }
 
 func (ResumeAction_Action) Descriptor() protoreflect.EnumDescriptor {
-	return file_apix_proto_enumTypes[0].Descriptor()
+	return file_apix_proto_enumTypes[1].Descriptor()
 }
 
 func (ResumeAction_Action) Type() protoreflect.EnumType {
-	return &file_apix_proto_enumTypes[0]
+	return &file_apix_proto_enumTypes[1]
 }
 
 func (x ResumeAction_Action) Number() protoreflect.EnumNumber {
@@ -114,7 +190,8 @@ type HttpRequest struct {
 	Headers       map[string]string      `protobuf:"bytes,3,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Body          []byte                 `protobuf:"bytes,4,opt,name=body,proto3" json:"body,omitempty"`
 	Timestamp     int64                  `protobuf:"varint,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Id            string                 `protobuf:"bytes,6,opt,name=id,proto3" json:"id,omitempty"` // UUID assigned at capture time
+	Id            string                 `protobuf:"bytes,6,opt,name=id,proto3" json:"id,omitempty"`             // UUID assigned at capture time
+	Protocol      string                 `protobuf:"bytes,7,opt,name=protocol,proto3" json:"protocol,omitempty"` // negotiated protocol: "HTTP/1.1", "HTTP/2.0", "h2c"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -187,6 +264,13 @@ func (x *HttpRequest) GetTimestamp() int64 {
 func (x *HttpRequest) GetId() string {
 	if x != nil {
 		return x.Id
+	}
+	return ""
+}
+
+func (x *HttpRequest) GetProtocol() string {
+	if x != nil {
+		return x.Protocol
 	}
 	return ""
 }
@@ -1576,20 +1660,325 @@ func (x *ImportHARResponse) GetTransactionIds() []string {
 	return nil
 }
 
+type MatchCriteria struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UrlPattern    string                 `protobuf:"bytes,1,opt,name=url_pattern,json=urlPattern,proto3" json:"url_pattern,omitempty"`
+	Method        string                 `protobuf:"bytes,2,opt,name=method,proto3" json:"method,omitempty"`
+	HeaderName    string                 `protobuf:"bytes,3,opt,name=header_name,json=headerName,proto3" json:"header_name,omitempty"`
+	HeaderValue   string                 `protobuf:"bytes,4,opt,name=header_value,json=headerValue,proto3" json:"header_value,omitempty"`
+	BodyPattern   string                 `protobuf:"bytes,5,opt,name=body_pattern,json=bodyPattern,proto3" json:"body_pattern,omitempty"`
+	StatusCode    int32                  `protobuf:"varint,6,opt,name=status_code,json=statusCode,proto3" json:"status_code,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MatchCriteria) Reset() {
+	*x = MatchCriteria{}
+	mi := &file_apix_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MatchCriteria) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MatchCriteria) ProtoMessage() {}
+
+func (x *MatchCriteria) ProtoReflect() protoreflect.Message {
+	mi := &file_apix_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MatchCriteria.ProtoReflect.Descriptor instead.
+func (*MatchCriteria) Descriptor() ([]byte, []int) {
+	return file_apix_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *MatchCriteria) GetUrlPattern() string {
+	if x != nil {
+		return x.UrlPattern
+	}
+	return ""
+}
+
+func (x *MatchCriteria) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *MatchCriteria) GetHeaderName() string {
+	if x != nil {
+		return x.HeaderName
+	}
+	return ""
+}
+
+func (x *MatchCriteria) GetHeaderValue() string {
+	if x != nil {
+		return x.HeaderValue
+	}
+	return ""
+}
+
+func (x *MatchCriteria) GetBodyPattern() string {
+	if x != nil {
+		return x.BodyPattern
+	}
+	return ""
+}
+
+func (x *MatchCriteria) GetStatusCode() int32 {
+	if x != nil {
+		return x.StatusCode
+	}
+	return 0
+}
+
+type RewriteRule struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Id                  string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name                string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Enabled             bool                   `protobuf:"varint,3,opt,name=enabled,proto3" json:"enabled,omitempty"`
+	Priority            int32                  `protobuf:"varint,4,opt,name=priority,proto3" json:"priority,omitempty"`
+	Match               *MatchCriteria         `protobuf:"bytes,5,opt,name=match,proto3" json:"match,omitempty"`
+	Action              RewriteAction          `protobuf:"varint,6,opt,name=action,proto3,enum=apix.RewriteAction" json:"action,omitempty"`
+	ParamKey            string                 `protobuf:"bytes,7,opt,name=param_key,json=paramKey,proto3" json:"param_key,omitempty"`
+	ParamValue          string                 `protobuf:"bytes,8,opt,name=param_value,json=paramValue,proto3" json:"param_value,omitempty"`
+	BodyTemplate        []byte                 `protobuf:"bytes,9,opt,name=body_template,json=bodyTemplate,proto3" json:"body_template,omitempty"`
+	ResponseStatus      int32                  `protobuf:"varint,10,opt,name=response_status,json=responseStatus,proto3" json:"response_status,omitempty"`
+	ResponseBody        []byte                 `protobuf:"bytes,11,opt,name=response_body,json=responseBody,proto3" json:"response_body,omitempty"`
+	ResponseContentType string                 `protobuf:"bytes,12,opt,name=response_content_type,json=responseContentType,proto3" json:"response_content_type,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *RewriteRule) Reset() {
+	*x = RewriteRule{}
+	mi := &file_apix_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RewriteRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RewriteRule) ProtoMessage() {}
+
+func (x *RewriteRule) ProtoReflect() protoreflect.Message {
+	mi := &file_apix_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RewriteRule.ProtoReflect.Descriptor instead.
+func (*RewriteRule) Descriptor() ([]byte, []int) {
+	return file_apix_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *RewriteRule) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RewriteRule) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *RewriteRule) GetEnabled() bool {
+	if x != nil {
+		return x.Enabled
+	}
+	return false
+}
+
+func (x *RewriteRule) GetPriority() int32 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
+}
+
+func (x *RewriteRule) GetMatch() *MatchCriteria {
+	if x != nil {
+		return x.Match
+	}
+	return nil
+}
+
+func (x *RewriteRule) GetAction() RewriteAction {
+	if x != nil {
+		return x.Action
+	}
+	return RewriteAction_REWRITE_ACTION_UNSPECIFIED
+}
+
+func (x *RewriteRule) GetParamKey() string {
+	if x != nil {
+		return x.ParamKey
+	}
+	return ""
+}
+
+func (x *RewriteRule) GetParamValue() string {
+	if x != nil {
+		return x.ParamValue
+	}
+	return ""
+}
+
+func (x *RewriteRule) GetBodyTemplate() []byte {
+	if x != nil {
+		return x.BodyTemplate
+	}
+	return nil
+}
+
+func (x *RewriteRule) GetResponseStatus() int32 {
+	if x != nil {
+		return x.ResponseStatus
+	}
+	return 0
+}
+
+func (x *RewriteRule) GetResponseBody() []byte {
+	if x != nil {
+		return x.ResponseBody
+	}
+	return nil
+}
+
+func (x *RewriteRule) GetResponseContentType() string {
+	if x != nil {
+		return x.ResponseContentType
+	}
+	return ""
+}
+
+type RewriteRuleList struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Rules         []*RewriteRule         `protobuf:"bytes,1,rep,name=rules,proto3" json:"rules,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RewriteRuleList) Reset() {
+	*x = RewriteRuleList{}
+	mi := &file_apix_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RewriteRuleList) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RewriteRuleList) ProtoMessage() {}
+
+func (x *RewriteRuleList) ProtoReflect() protoreflect.Message {
+	mi := &file_apix_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RewriteRuleList.ProtoReflect.Descriptor instead.
+func (*RewriteRuleList) Descriptor() ([]byte, []int) {
+	return file_apix_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *RewriteRuleList) GetRules() []*RewriteRule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+type RewriteRuleRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RuleId        string                 `protobuf:"bytes,1,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RewriteRuleRequest) Reset() {
+	*x = RewriteRuleRequest{}
+	mi := &file_apix_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RewriteRuleRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RewriteRuleRequest) ProtoMessage() {}
+
+func (x *RewriteRuleRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_apix_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RewriteRuleRequest.ProtoReflect.Descriptor instead.
+func (*RewriteRuleRequest) Descriptor() ([]byte, []int) {
+	return file_apix_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *RewriteRuleRequest) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
+	}
+	return ""
+}
+
 var File_apix_proto protoreflect.FileDescriptor
 
 const file_apix_proto_rawDesc = "" +
 	"\n" +
 	"\n" +
 	"apix.proto\x12\x04apix\"\a\n" +
-	"\x05Empty\"\xef\x01\n" +
+	"\x05Empty\"\x8b\x02\n" +
 	"\vHttpRequest\x12\x16\n" +
 	"\x06method\x18\x01 \x01(\tR\x06method\x12\x10\n" +
 	"\x03url\x18\x02 \x01(\tR\x03url\x128\n" +
 	"\aheaders\x18\x03 \x03(\v2\x1e.apix.HttpRequest.HeadersEntryR\aheaders\x12\x12\n" +
 	"\x04body\x18\x04 \x01(\fR\x04body\x12\x1c\n" +
 	"\ttimestamp\x18\x05 \x01(\x03R\ttimestamp\x12\x0e\n" +
-	"\x02id\x18\x06 \x01(\tR\x02id\x1a:\n" +
+	"\x02id\x18\x06 \x01(\tR\x02id\x12\x1a\n" +
+	"\bprotocol\x18\a \x01(\tR\bprotocol\x1a:\n" +
 	"\fHeadersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xdb\x01\n" +
@@ -1704,7 +2093,50 @@ const file_apix_proto_rawDesc = "" +
 	"\x10ImportHARRequest\x12\x19\n" +
 	"\bhar_json\x18\x01 \x01(\tR\aharJson\"<\n" +
 	"\x11ImportHARResponse\x12'\n" +
-	"\x0ftransaction_ids\x18\x01 \x03(\tR\x0etransactionIds2\xfa\x06\n" +
+	"\x0ftransaction_ids\x18\x01 \x03(\tR\x0etransactionIds\"\xd0\x01\n" +
+	"\rMatchCriteria\x12\x1f\n" +
+	"\vurl_pattern\x18\x01 \x01(\tR\n" +
+	"urlPattern\x12\x16\n" +
+	"\x06method\x18\x02 \x01(\tR\x06method\x12\x1f\n" +
+	"\vheader_name\x18\x03 \x01(\tR\n" +
+	"headerName\x12!\n" +
+	"\fheader_value\x18\x04 \x01(\tR\vheaderValue\x12!\n" +
+	"\fbody_pattern\x18\x05 \x01(\tR\vbodyPattern\x12\x1f\n" +
+	"\vstatus_code\x18\x06 \x01(\x05R\n" +
+	"statusCode\"\xa4\x03\n" +
+	"\vRewriteRule\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
+	"\aenabled\x18\x03 \x01(\bR\aenabled\x12\x1a\n" +
+	"\bpriority\x18\x04 \x01(\x05R\bpriority\x12)\n" +
+	"\x05match\x18\x05 \x01(\v2\x13.apix.MatchCriteriaR\x05match\x12+\n" +
+	"\x06action\x18\x06 \x01(\x0e2\x13.apix.RewriteActionR\x06action\x12\x1b\n" +
+	"\tparam_key\x18\a \x01(\tR\bparamKey\x12\x1f\n" +
+	"\vparam_value\x18\b \x01(\tR\n" +
+	"paramValue\x12#\n" +
+	"\rbody_template\x18\t \x01(\fR\fbodyTemplate\x12'\n" +
+	"\x0fresponse_status\x18\n" +
+	" \x01(\x05R\x0eresponseStatus\x12#\n" +
+	"\rresponse_body\x18\v \x01(\fR\fresponseBody\x122\n" +
+	"\x15response_content_type\x18\f \x01(\tR\x13responseContentType\":\n" +
+	"\x0fRewriteRuleList\x12'\n" +
+	"\x05rules\x18\x01 \x03(\v2\x11.apix.RewriteRuleR\x05rules\"-\n" +
+	"\x12RewriteRuleRequest\x12\x17\n" +
+	"\arule_id\x18\x01 \x01(\tR\x06ruleId*\xab\x02\n" +
+	"\rRewriteAction\x12\x1e\n" +
+	"\x1aREWRITE_ACTION_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12ADD_REQUEST_HEADER\x10\x01\x12\x19\n" +
+	"\x15REMOVE_REQUEST_HEADER\x10\x02\x12\x1a\n" +
+	"\x16REPLACE_REQUEST_HEADER\x10\x03\x12\x17\n" +
+	"\x13ADD_RESPONSE_HEADER\x10\x04\x12\x1a\n" +
+	"\x16REMOVE_RESPONSE_HEADER\x10\x05\x12\x1b\n" +
+	"\x17REPLACE_RESPONSE_HEADER\x10\x06\x12\x18\n" +
+	"\x14REPLACE_REQUEST_BODY\x10\a\x12\x19\n" +
+	"\x15REPLACE_RESPONSE_BODY\x10\b\x12\f\n" +
+	"\bREDIRECT\x10\t\x12\t\n" +
+	"\x05BLOCK\x10\n" +
+	"\x12\v\n" +
+	"\aRESPOND\x10\v2\xa3\t\n" +
 	"\x06Engine\x126\n" +
 	"\tGetStatus\x12\x13.apix.StatusRequest\x1a\x14.apix.StatusResponse\x129\n" +
 	"\n" +
@@ -1722,7 +2154,12 @@ const file_apix_proto_rawDesc = "" +
 	"\x12GetWebSocketFrames\x12\x1f.apix.GetWebSocketFramesRequest\x1a\x14.apix.WebSocketFrame0\x01\x12(\n" +
 	"\fClearHistory\x12\v.apix.Empty\x1a\v.apix.Empty\x12<\n" +
 	"\tExportHAR\x12\x16.apix.ExportHARRequest\x1a\x17.apix.ExportHARResponse\x12<\n" +
-	"\tImportHAR\x12\x16.apix.ImportHARRequest\x1a\x17.apix.ImportHARResponseB6Z4github.com/mnafshin/apix/pkg/api/generated;generatedb\x06proto3"
+	"\tImportHAR\x12\x16.apix.ImportHARRequest\x1a\x17.apix.ImportHARResponse\x126\n" +
+	"\x0eAddRewriteRule\x12\x11.apix.RewriteRule\x1a\x11.apix.RewriteRule\x129\n" +
+	"\x11UpdateRewriteRule\x12\x11.apix.RewriteRule\x1a\x11.apix.RewriteRule\x12:\n" +
+	"\x11DeleteRewriteRule\x12\x18.apix.RewriteRuleRequest\x1a\v.apix.Empty\x126\n" +
+	"\x10ListRewriteRules\x12\v.apix.Empty\x1a\x15.apix.RewriteRuleList\x12@\n" +
+	"\x11ToggleRewriteRule\x12\x18.apix.RewriteRuleRequest\x1a\x11.apix.RewriteRuleB6Z4github.com/mnafshin/apix/pkg/api/generated;generatedb\x06proto3"
 
 var (
 	file_apix_proto_rawDescOnce sync.Once
@@ -1736,89 +2173,107 @@ func file_apix_proto_rawDescGZIP() []byte {
 	return file_apix_proto_rawDescData
 }
 
-var file_apix_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_apix_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_apix_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_apix_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_apix_proto_goTypes = []any{
-	(ResumeAction_Action)(0),          // 0: apix.ResumeAction.Action
-	(*Empty)(nil),                     // 1: apix.Empty
-	(*HttpRequest)(nil),               // 2: apix.HttpRequest
-	(*HttpResponse)(nil),              // 3: apix.HttpResponse
-	(*HttpTransaction)(nil),           // 4: apix.HttpTransaction
-	(*PluginInfo)(nil),                // 5: apix.PluginInfo
-	(*StatusRequest)(nil),             // 6: apix.StatusRequest
-	(*StatusResponse)(nil),            // 7: apix.StatusResponse
-	(*VersionRequest)(nil),            // 8: apix.VersionRequest
-	(*VersionResponse)(nil),           // 9: apix.VersionResponse
-	(*CaptureRequest)(nil),            // 10: apix.CaptureRequest
-	(*PluginListRequest)(nil),         // 11: apix.PluginListRequest
-	(*PluginListResponse)(nil),        // 12: apix.PluginListResponse
-	(*BreakpointRule)(nil),            // 13: apix.BreakpointRule
-	(*BreakpointID)(nil),              // 14: apix.BreakpointID
-	(*BreakpointList)(nil),            // 15: apix.BreakpointList
-	(*BreakpointResponse)(nil),        // 16: apix.BreakpointResponse
-	(*PausedRequest)(nil),             // 17: apix.PausedRequest
-	(*ResumeAction)(nil),              // 18: apix.ResumeAction
-	(*ReplaySpec)(nil),                // 19: apix.ReplaySpec
-	(*HistoryQuery)(nil),              // 20: apix.HistoryQuery
-	(*GetWebSocketFramesRequest)(nil), // 21: apix.GetWebSocketFramesRequest
-	(*WebSocketFrame)(nil),            // 22: apix.WebSocketFrame
-	(*ExportHARRequest)(nil),          // 23: apix.ExportHARRequest
-	(*ExportHARResponse)(nil),         // 24: apix.ExportHARResponse
-	(*ImportHARRequest)(nil),          // 25: apix.ImportHARRequest
-	(*ImportHARResponse)(nil),         // 26: apix.ImportHARResponse
-	nil,                               // 27: apix.HttpRequest.HeadersEntry
-	nil,                               // 28: apix.HttpResponse.HeadersEntry
-	nil,                               // 29: apix.ReplaySpec.OverrideHeadersEntry
+	(RewriteAction)(0),                // 0: apix.RewriteAction
+	(ResumeAction_Action)(0),          // 1: apix.ResumeAction.Action
+	(*Empty)(nil),                     // 2: apix.Empty
+	(*HttpRequest)(nil),               // 3: apix.HttpRequest
+	(*HttpResponse)(nil),              // 4: apix.HttpResponse
+	(*HttpTransaction)(nil),           // 5: apix.HttpTransaction
+	(*PluginInfo)(nil),                // 6: apix.PluginInfo
+	(*StatusRequest)(nil),             // 7: apix.StatusRequest
+	(*StatusResponse)(nil),            // 8: apix.StatusResponse
+	(*VersionRequest)(nil),            // 9: apix.VersionRequest
+	(*VersionResponse)(nil),           // 10: apix.VersionResponse
+	(*CaptureRequest)(nil),            // 11: apix.CaptureRequest
+	(*PluginListRequest)(nil),         // 12: apix.PluginListRequest
+	(*PluginListResponse)(nil),        // 13: apix.PluginListResponse
+	(*BreakpointRule)(nil),            // 14: apix.BreakpointRule
+	(*BreakpointID)(nil),              // 15: apix.BreakpointID
+	(*BreakpointList)(nil),            // 16: apix.BreakpointList
+	(*BreakpointResponse)(nil),        // 17: apix.BreakpointResponse
+	(*PausedRequest)(nil),             // 18: apix.PausedRequest
+	(*ResumeAction)(nil),              // 19: apix.ResumeAction
+	(*ReplaySpec)(nil),                // 20: apix.ReplaySpec
+	(*HistoryQuery)(nil),              // 21: apix.HistoryQuery
+	(*GetWebSocketFramesRequest)(nil), // 22: apix.GetWebSocketFramesRequest
+	(*WebSocketFrame)(nil),            // 23: apix.WebSocketFrame
+	(*ExportHARRequest)(nil),          // 24: apix.ExportHARRequest
+	(*ExportHARResponse)(nil),         // 25: apix.ExportHARResponse
+	(*ImportHARRequest)(nil),          // 26: apix.ImportHARRequest
+	(*ImportHARResponse)(nil),         // 27: apix.ImportHARResponse
+	(*MatchCriteria)(nil),             // 28: apix.MatchCriteria
+	(*RewriteRule)(nil),               // 29: apix.RewriteRule
+	(*RewriteRuleList)(nil),           // 30: apix.RewriteRuleList
+	(*RewriteRuleRequest)(nil),        // 31: apix.RewriteRuleRequest
+	nil,                               // 32: apix.HttpRequest.HeadersEntry
+	nil,                               // 33: apix.HttpResponse.HeadersEntry
+	nil,                               // 34: apix.ReplaySpec.OverrideHeadersEntry
 }
 var file_apix_proto_depIdxs = []int32{
-	27, // 0: apix.HttpRequest.headers:type_name -> apix.HttpRequest.HeadersEntry
-	28, // 1: apix.HttpResponse.headers:type_name -> apix.HttpResponse.HeadersEntry
-	2,  // 2: apix.HttpTransaction.request:type_name -> apix.HttpRequest
-	3,  // 3: apix.HttpTransaction.response:type_name -> apix.HttpResponse
-	5,  // 4: apix.PluginListResponse.plugins:type_name -> apix.PluginInfo
-	13, // 5: apix.BreakpointList.breakpoints:type_name -> apix.BreakpointRule
-	13, // 6: apix.BreakpointResponse.breakpoint:type_name -> apix.BreakpointRule
-	2,  // 7: apix.PausedRequest.request:type_name -> apix.HttpRequest
-	2,  // 8: apix.ResumeAction.modified_request:type_name -> apix.HttpRequest
-	0,  // 9: apix.ResumeAction.action:type_name -> apix.ResumeAction.Action
-	3,  // 10: apix.ResumeAction.modified_response:type_name -> apix.HttpResponse
-	2,  // 11: apix.ReplaySpec.raw_request:type_name -> apix.HttpRequest
-	29, // 12: apix.ReplaySpec.override_headers:type_name -> apix.ReplaySpec.OverrideHeadersEntry
-	6,  // 13: apix.Engine.GetStatus:input_type -> apix.StatusRequest
-	8,  // 14: apix.Engine.GetVersion:input_type -> apix.VersionRequest
-	10, // 15: apix.Engine.CaptureTraffic:input_type -> apix.CaptureRequest
-	11, // 16: apix.Engine.ListPlugins:input_type -> apix.PluginListRequest
-	13, // 17: apix.Engine.SetBreakpoint:input_type -> apix.BreakpointRule
-	14, // 18: apix.Engine.DeleteBreakpoint:input_type -> apix.BreakpointID
-	1,  // 19: apix.Engine.ListBreakpoints:input_type -> apix.Empty
-	1,  // 20: apix.Engine.WatchPausedRequests:input_type -> apix.Empty
-	18, // 21: apix.Engine.ResumeRequest:input_type -> apix.ResumeAction
-	19, // 22: apix.Engine.ReplayRequest:input_type -> apix.ReplaySpec
-	20, // 23: apix.Engine.GetHistory:input_type -> apix.HistoryQuery
-	21, // 24: apix.Engine.GetWebSocketFrames:input_type -> apix.GetWebSocketFramesRequest
-	1,  // 25: apix.Engine.ClearHistory:input_type -> apix.Empty
-	23, // 26: apix.Engine.ExportHAR:input_type -> apix.ExportHARRequest
-	25, // 27: apix.Engine.ImportHAR:input_type -> apix.ImportHARRequest
-	7,  // 28: apix.Engine.GetStatus:output_type -> apix.StatusResponse
-	9,  // 29: apix.Engine.GetVersion:output_type -> apix.VersionResponse
-	2,  // 30: apix.Engine.CaptureTraffic:output_type -> apix.HttpRequest
-	12, // 31: apix.Engine.ListPlugins:output_type -> apix.PluginListResponse
-	16, // 32: apix.Engine.SetBreakpoint:output_type -> apix.BreakpointResponse
-	1,  // 33: apix.Engine.DeleteBreakpoint:output_type -> apix.Empty
-	15, // 34: apix.Engine.ListBreakpoints:output_type -> apix.BreakpointList
-	17, // 35: apix.Engine.WatchPausedRequests:output_type -> apix.PausedRequest
-	1,  // 36: apix.Engine.ResumeRequest:output_type -> apix.Empty
-	3,  // 37: apix.Engine.ReplayRequest:output_type -> apix.HttpResponse
-	4,  // 38: apix.Engine.GetHistory:output_type -> apix.HttpTransaction
-	22, // 39: apix.Engine.GetWebSocketFrames:output_type -> apix.WebSocketFrame
-	1,  // 40: apix.Engine.ClearHistory:output_type -> apix.Empty
-	24, // 41: apix.Engine.ExportHAR:output_type -> apix.ExportHARResponse
-	26, // 42: apix.Engine.ImportHAR:output_type -> apix.ImportHARResponse
-	28, // [28:43] is the sub-list for method output_type
-	13, // [13:28] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	32, // 0: apix.HttpRequest.headers:type_name -> apix.HttpRequest.HeadersEntry
+	33, // 1: apix.HttpResponse.headers:type_name -> apix.HttpResponse.HeadersEntry
+	3,  // 2: apix.HttpTransaction.request:type_name -> apix.HttpRequest
+	4,  // 3: apix.HttpTransaction.response:type_name -> apix.HttpResponse
+	6,  // 4: apix.PluginListResponse.plugins:type_name -> apix.PluginInfo
+	14, // 5: apix.BreakpointList.breakpoints:type_name -> apix.BreakpointRule
+	14, // 6: apix.BreakpointResponse.breakpoint:type_name -> apix.BreakpointRule
+	3,  // 7: apix.PausedRequest.request:type_name -> apix.HttpRequest
+	3,  // 8: apix.ResumeAction.modified_request:type_name -> apix.HttpRequest
+	1,  // 9: apix.ResumeAction.action:type_name -> apix.ResumeAction.Action
+	4,  // 10: apix.ResumeAction.modified_response:type_name -> apix.HttpResponse
+	3,  // 11: apix.ReplaySpec.raw_request:type_name -> apix.HttpRequest
+	34, // 12: apix.ReplaySpec.override_headers:type_name -> apix.ReplaySpec.OverrideHeadersEntry
+	28, // 13: apix.RewriteRule.match:type_name -> apix.MatchCriteria
+	0,  // 14: apix.RewriteRule.action:type_name -> apix.RewriteAction
+	29, // 15: apix.RewriteRuleList.rules:type_name -> apix.RewriteRule
+	7,  // 16: apix.Engine.GetStatus:input_type -> apix.StatusRequest
+	9,  // 17: apix.Engine.GetVersion:input_type -> apix.VersionRequest
+	11, // 18: apix.Engine.CaptureTraffic:input_type -> apix.CaptureRequest
+	12, // 19: apix.Engine.ListPlugins:input_type -> apix.PluginListRequest
+	14, // 20: apix.Engine.SetBreakpoint:input_type -> apix.BreakpointRule
+	15, // 21: apix.Engine.DeleteBreakpoint:input_type -> apix.BreakpointID
+	2,  // 22: apix.Engine.ListBreakpoints:input_type -> apix.Empty
+	2,  // 23: apix.Engine.WatchPausedRequests:input_type -> apix.Empty
+	19, // 24: apix.Engine.ResumeRequest:input_type -> apix.ResumeAction
+	20, // 25: apix.Engine.ReplayRequest:input_type -> apix.ReplaySpec
+	21, // 26: apix.Engine.GetHistory:input_type -> apix.HistoryQuery
+	22, // 27: apix.Engine.GetWebSocketFrames:input_type -> apix.GetWebSocketFramesRequest
+	2,  // 28: apix.Engine.ClearHistory:input_type -> apix.Empty
+	24, // 29: apix.Engine.ExportHAR:input_type -> apix.ExportHARRequest
+	26, // 30: apix.Engine.ImportHAR:input_type -> apix.ImportHARRequest
+	29, // 31: apix.Engine.AddRewriteRule:input_type -> apix.RewriteRule
+	29, // 32: apix.Engine.UpdateRewriteRule:input_type -> apix.RewriteRule
+	31, // 33: apix.Engine.DeleteRewriteRule:input_type -> apix.RewriteRuleRequest
+	2,  // 34: apix.Engine.ListRewriteRules:input_type -> apix.Empty
+	31, // 35: apix.Engine.ToggleRewriteRule:input_type -> apix.RewriteRuleRequest
+	8,  // 36: apix.Engine.GetStatus:output_type -> apix.StatusResponse
+	10, // 37: apix.Engine.GetVersion:output_type -> apix.VersionResponse
+	3,  // 38: apix.Engine.CaptureTraffic:output_type -> apix.HttpRequest
+	13, // 39: apix.Engine.ListPlugins:output_type -> apix.PluginListResponse
+	17, // 40: apix.Engine.SetBreakpoint:output_type -> apix.BreakpointResponse
+	2,  // 41: apix.Engine.DeleteBreakpoint:output_type -> apix.Empty
+	16, // 42: apix.Engine.ListBreakpoints:output_type -> apix.BreakpointList
+	18, // 43: apix.Engine.WatchPausedRequests:output_type -> apix.PausedRequest
+	2,  // 44: apix.Engine.ResumeRequest:output_type -> apix.Empty
+	4,  // 45: apix.Engine.ReplayRequest:output_type -> apix.HttpResponse
+	5,  // 46: apix.Engine.GetHistory:output_type -> apix.HttpTransaction
+	23, // 47: apix.Engine.GetWebSocketFrames:output_type -> apix.WebSocketFrame
+	2,  // 48: apix.Engine.ClearHistory:output_type -> apix.Empty
+	25, // 49: apix.Engine.ExportHAR:output_type -> apix.ExportHARResponse
+	27, // 50: apix.Engine.ImportHAR:output_type -> apix.ImportHARResponse
+	29, // 51: apix.Engine.AddRewriteRule:output_type -> apix.RewriteRule
+	29, // 52: apix.Engine.UpdateRewriteRule:output_type -> apix.RewriteRule
+	2,  // 53: apix.Engine.DeleteRewriteRule:output_type -> apix.Empty
+	30, // 54: apix.Engine.ListRewriteRules:output_type -> apix.RewriteRuleList
+	29, // 55: apix.Engine.ToggleRewriteRule:output_type -> apix.RewriteRule
+	36, // [36:56] is the sub-list for method output_type
+	16, // [16:36] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_apix_proto_init() }
@@ -1835,8 +2290,8 @@ func file_apix_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_apix_proto_rawDesc), len(file_apix_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   29,
+			NumEnums:      2,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/api/generated/apix_grpc.pb.go
+++ b/pkg/api/generated/apix_grpc.pb.go
@@ -34,6 +34,11 @@ const (
 	Engine_ClearHistory_FullMethodName        = "/apix.Engine/ClearHistory"
 	Engine_ExportHAR_FullMethodName           = "/apix.Engine/ExportHAR"
 	Engine_ImportHAR_FullMethodName           = "/apix.Engine/ImportHAR"
+	Engine_AddRewriteRule_FullMethodName      = "/apix.Engine/AddRewriteRule"
+	Engine_UpdateRewriteRule_FullMethodName   = "/apix.Engine/UpdateRewriteRule"
+	Engine_DeleteRewriteRule_FullMethodName   = "/apix.Engine/DeleteRewriteRule"
+	Engine_ListRewriteRules_FullMethodName    = "/apix.Engine/ListRewriteRules"
+	Engine_ToggleRewriteRule_FullMethodName   = "/apix.Engine/ToggleRewriteRule"
 )
 
 // EngineClient is the client API for Engine service.
@@ -77,6 +82,12 @@ type EngineClient interface {
 	ExportHAR(ctx context.Context, in *ExportHARRequest, opts ...grpc.CallOption) (*ExportHARResponse, error)
 	// Import HAR 1.2 JSON into stored history.
 	ImportHAR(ctx context.Context, in *ImportHARRequest, opts ...grpc.CallOption) (*ImportHARResponse, error)
+	// ----- Rewrite rules -----
+	AddRewriteRule(ctx context.Context, in *RewriteRule, opts ...grpc.CallOption) (*RewriteRule, error)
+	UpdateRewriteRule(ctx context.Context, in *RewriteRule, opts ...grpc.CallOption) (*RewriteRule, error)
+	DeleteRewriteRule(ctx context.Context, in *RewriteRuleRequest, opts ...grpc.CallOption) (*Empty, error)
+	ListRewriteRules(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*RewriteRuleList, error)
+	ToggleRewriteRule(ctx context.Context, in *RewriteRuleRequest, opts ...grpc.CallOption) (*RewriteRule, error)
 }
 
 type engineClient struct {
@@ -273,6 +284,56 @@ func (c *engineClient) ImportHAR(ctx context.Context, in *ImportHARRequest, opts
 	return out, nil
 }
 
+func (c *engineClient) AddRewriteRule(ctx context.Context, in *RewriteRule, opts ...grpc.CallOption) (*RewriteRule, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RewriteRule)
+	err := c.cc.Invoke(ctx, Engine_AddRewriteRule_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *engineClient) UpdateRewriteRule(ctx context.Context, in *RewriteRule, opts ...grpc.CallOption) (*RewriteRule, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RewriteRule)
+	err := c.cc.Invoke(ctx, Engine_UpdateRewriteRule_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *engineClient) DeleteRewriteRule(ctx context.Context, in *RewriteRuleRequest, opts ...grpc.CallOption) (*Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(Empty)
+	err := c.cc.Invoke(ctx, Engine_DeleteRewriteRule_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *engineClient) ListRewriteRules(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*RewriteRuleList, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RewriteRuleList)
+	err := c.cc.Invoke(ctx, Engine_ListRewriteRules_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *engineClient) ToggleRewriteRule(ctx context.Context, in *RewriteRuleRequest, opts ...grpc.CallOption) (*RewriteRule, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RewriteRule)
+	err := c.cc.Invoke(ctx, Engine_ToggleRewriteRule_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // EngineServer is the server API for Engine service.
 // All implementations must embed UnimplementedEngineServer
 // for forward compatibility.
@@ -314,6 +375,12 @@ type EngineServer interface {
 	ExportHAR(context.Context, *ExportHARRequest) (*ExportHARResponse, error)
 	// Import HAR 1.2 JSON into stored history.
 	ImportHAR(context.Context, *ImportHARRequest) (*ImportHARResponse, error)
+	// ----- Rewrite rules -----
+	AddRewriteRule(context.Context, *RewriteRule) (*RewriteRule, error)
+	UpdateRewriteRule(context.Context, *RewriteRule) (*RewriteRule, error)
+	DeleteRewriteRule(context.Context, *RewriteRuleRequest) (*Empty, error)
+	ListRewriteRules(context.Context, *Empty) (*RewriteRuleList, error)
+	ToggleRewriteRule(context.Context, *RewriteRuleRequest) (*RewriteRule, error)
 	mustEmbedUnimplementedEngineServer()
 }
 
@@ -368,6 +435,21 @@ func (UnimplementedEngineServer) ExportHAR(context.Context, *ExportHARRequest) (
 }
 func (UnimplementedEngineServer) ImportHAR(context.Context, *ImportHARRequest) (*ImportHARResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ImportHAR not implemented")
+}
+func (UnimplementedEngineServer) AddRewriteRule(context.Context, *RewriteRule) (*RewriteRule, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AddRewriteRule not implemented")
+}
+func (UnimplementedEngineServer) UpdateRewriteRule(context.Context, *RewriteRule) (*RewriteRule, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateRewriteRule not implemented")
+}
+func (UnimplementedEngineServer) DeleteRewriteRule(context.Context, *RewriteRuleRequest) (*Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteRewriteRule not implemented")
+}
+func (UnimplementedEngineServer) ListRewriteRules(context.Context, *Empty) (*RewriteRuleList, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRewriteRules not implemented")
+}
+func (UnimplementedEngineServer) ToggleRewriteRule(context.Context, *RewriteRuleRequest) (*RewriteRule, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ToggleRewriteRule not implemented")
 }
 func (UnimplementedEngineServer) mustEmbedUnimplementedEngineServer() {}
 func (UnimplementedEngineServer) testEmbeddedByValue()                {}
@@ -632,6 +714,96 @@ func _Engine_ImportHAR_Handler(srv interface{}, ctx context.Context, dec func(in
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Engine_AddRewriteRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RewriteRule)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EngineServer).AddRewriteRule(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Engine_AddRewriteRule_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EngineServer).AddRewriteRule(ctx, req.(*RewriteRule))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Engine_UpdateRewriteRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RewriteRule)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EngineServer).UpdateRewriteRule(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Engine_UpdateRewriteRule_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EngineServer).UpdateRewriteRule(ctx, req.(*RewriteRule))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Engine_DeleteRewriteRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RewriteRuleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EngineServer).DeleteRewriteRule(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Engine_DeleteRewriteRule_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EngineServer).DeleteRewriteRule(ctx, req.(*RewriteRuleRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Engine_ListRewriteRules_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EngineServer).ListRewriteRules(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Engine_ListRewriteRules_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EngineServer).ListRewriteRules(ctx, req.(*Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Engine_ToggleRewriteRule_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RewriteRuleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EngineServer).ToggleRewriteRule(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Engine_ToggleRewriteRule_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EngineServer).ToggleRewriteRule(ctx, req.(*RewriteRuleRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Engine_ServiceDesc is the grpc.ServiceDesc for Engine service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -682,6 +854,26 @@ var Engine_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ImportHAR",
 			Handler:    _Engine_ImportHAR_Handler,
+		},
+		{
+			MethodName: "AddRewriteRule",
+			Handler:    _Engine_AddRewriteRule_Handler,
+		},
+		{
+			MethodName: "UpdateRewriteRule",
+			Handler:    _Engine_UpdateRewriteRule_Handler,
+		},
+		{
+			MethodName: "DeleteRewriteRule",
+			Handler:    _Engine_DeleteRewriteRule_Handler,
+		},
+		{
+			MethodName: "ListRewriteRules",
+			Handler:    _Engine_ListRewriteRules_Handler,
+		},
+		{
+			MethodName: "ToggleRewriteRule",
+			Handler:    _Engine_ToggleRewriteRule_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/api/proto/apix.proto
+++ b/pkg/api/proto/apix.proto
@@ -16,6 +16,7 @@ message HttpRequest {
   bytes body = 4;
   int64 timestamp = 5;
   string id = 6; // UUID assigned at capture time
+  string protocol = 7; // negotiated protocol: "HTTP/1.1", "HTTP/2.0", "h2c"
 }
 
 // HttpResponse represents a captured or synthesized HTTP response.
@@ -180,6 +181,55 @@ message ImportHARResponse {
   repeated string transaction_ids = 1;
 }
 
+// ========== Rewrite rule messages ==========
+
+message MatchCriteria {
+  string url_pattern = 1;
+  string method = 2;
+  string header_name = 3;
+  string header_value = 4;
+  string body_pattern = 5;
+  int32 status_code = 6;
+}
+
+enum RewriteAction {
+  REWRITE_ACTION_UNSPECIFIED = 0;
+  ADD_REQUEST_HEADER = 1;
+  REMOVE_REQUEST_HEADER = 2;
+  REPLACE_REQUEST_HEADER = 3;
+  ADD_RESPONSE_HEADER = 4;
+  REMOVE_RESPONSE_HEADER = 5;
+  REPLACE_RESPONSE_HEADER = 6;
+  REPLACE_REQUEST_BODY = 7;
+  REPLACE_RESPONSE_BODY = 8;
+  REDIRECT = 9;
+  BLOCK = 10;
+  RESPOND = 11;
+}
+
+message RewriteRule {
+  string id = 1;
+  string name = 2;
+  bool enabled = 3;
+  int32 priority = 4;
+  MatchCriteria match = 5;
+  RewriteAction action = 6;
+  string param_key = 7;
+  string param_value = 8;
+  bytes body_template = 9;
+  int32 response_status = 10;
+  bytes response_body = 11;
+  string response_content_type = 12;
+}
+
+message RewriteRuleList {
+  repeated RewriteRule rules = 1;
+}
+
+message RewriteRuleRequest {
+  string rule_id = 1;
+}
+
 // ========== Service ==========
 
 service Engine {
@@ -225,4 +275,11 @@ service Engine {
   rpc ExportHAR(ExportHARRequest) returns (ExportHARResponse);
   // Import HAR 1.2 JSON into stored history.
   rpc ImportHAR(ImportHARRequest) returns (ImportHARResponse);
+
+  // ----- Rewrite rules -----
+  rpc AddRewriteRule(RewriteRule) returns (RewriteRule);
+  rpc UpdateRewriteRule(RewriteRule) returns (RewriteRule);
+  rpc DeleteRewriteRule(RewriteRuleRequest) returns (Empty);
+  rpc ListRewriteRules(Empty) returns (RewriteRuleList);
+  rpc ToggleRewriteRule(RewriteRuleRequest) returns (RewriteRule);
 }

--- a/pkg/plugins/sdk.go
+++ b/pkg/plugins/sdk.go
@@ -36,6 +36,8 @@ type ProxyRequest struct {
 	URL     *url.URL
 	Headers http.Header
 	Body    io.ReadCloser
+	// Protocol is the negotiated HTTP protocol: "HTTP/1.1", "HTTP/2.0", or "h2c".
+	Protocol string
 	// Raw stores the original unmodified request for reference.
 	Raw *http.Request
 	// MockedResponse, if non-nil, causes the proxy to skip upstream forwarding


### PR DESCRIPTION
## Summary

### Rewrite Rules (#86)
- New proto messages: `MatchCriteria`, `RewriteAction` enum, `RewriteRule`, `RewriteRuleList`, `RewriteRuleRequest`
- New gRPC RPCs: `AddRewriteRule`, `UpdateRewriteRule`, `DeleteRewriteRule`, `ListRewriteRules`, `ToggleRewriteRule`
- New `rewrite_rules` SQLite table with full CRUD
- New `internal/rewrite` package: pattern matching + action application (header injection/removal, body replace, redirect, block, synthetic response)
- Rules applied in priority order before upstream forwarding in both HTTP and HTTPS proxies

### HTTP/2 Protocol Tracking (#94)
- New `protocol` field (field 7) on `HttpRequest` proto — values: `HTTP/1.1`, `HTTP/2.0`, `h2c`
- Detected from `r.Proto` in HTTP proxy, ALPN `NegotiatedProtocol` in HTTPS proxy
- Stored in `requests.protocol` column (schema includes `ALTER TABLE` migration for existing DBs)
- Returned in `GetHistory` responses

Closes #86
Closes #94