### PR TITLE
feat: MocksProvider tree view for rewrite/mock rules

### DIFF
--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -29,7 +29,8 @@
     "onCommand:apix.importHAR",
     "onCommand:apix.copyAsCurl",
     "onView:apix.trafficView",
-    "onView:apix.breakpointsView"
+    "onView:apix.breakpointsView",
+    "onView:apix.mocksView"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -93,6 +94,21 @@
         "command": "apix.refreshTraffic",
         "title": "APiX: Refresh Traffic",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "apix.mocks.refresh",
+        "title": "APiX: Refresh Mocks",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "apix.mocks.toggle",
+        "title": "APiX: Enable/Disable Mock Rule",
+        "icon": "$(circle-outline)"
+      },
+      {
+        "command": "apix.mocks.delete",
+        "title": "APiX: Delete Mock Rule",
+        "icon": "$(trash)"
       }
     ],
     "viewsContainers": {
@@ -119,6 +135,13 @@
           "type": "tree",
           "icon": "$(debug-breakpoint)",
           "contextualTitle": "APiX Breakpoints"
+        },
+        {
+          "id": "apix.mocksView",
+          "name": "Mocks",
+          "type": "tree",
+          "icon": "$(server)",
+          "contextualTitle": "APiX Mocks"
         }
       ]
     },
@@ -158,6 +181,11 @@
           "command": "apix.importHAR",
           "when": "view == apix.trafficView",
           "group": "navigation"
+        },
+        {
+          "command": "apix.mocks.refresh",
+          "when": "view == apix.mocksView",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -184,6 +212,16 @@
         {
           "command": "apix.toggleBreakpoint",
           "when": "view == apix.breakpointsView && viewItem == breakpoint",
+          "group": "inline"
+        },
+        {
+          "command": "apix.mocks.toggle",
+          "when": "view == apix.mocksView && viewItem == mockRule",
+          "group": "inline"
+        },
+        {
+          "command": "apix.mocks.delete",
+          "when": "view == apix.mocksView && viewItem == mockRule",
           "group": "inline"
         }
       ]

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -110,6 +110,29 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand('apix.refreshTraffic', () => {
             trafficProvider?.refresh();
         }),
+        vscode.commands.registerCommand('apix.mocks.refresh', () => {
+            mocksProvider?.refresh();
+        }),
+        vscode.commands.registerCommand('apix.mocks.toggle', async (itemOrId: MockItem | string) => {
+            const id = typeof itemOrId === 'string' ? itemOrId : itemOrId?.rule?.id;
+            if (!id || !engineClient) { return; }
+            try {
+                await engineClient.toggleRewriteRule(id);
+                mocksProvider?.refresh();
+            } catch (err: any) {
+                vscode.window.showErrorMessage(`APiX: Toggle mock failed — ${err?.message || err}`);
+            }
+        }),
+        vscode.commands.registerCommand('apix.mocks.delete', async (itemOrId: MockItem | string) => {
+            const id = typeof itemOrId === 'string' ? itemOrId : itemOrId?.rule?.id;
+            if (!id || !engineClient) { return; }
+            try {
+                await engineClient.deleteRewriteRule(id);
+                mocksProvider?.refresh();
+            } catch (err: any) {
+                vscode.window.showErrorMessage(`APiX: Delete mock failed — ${err?.message || err}`);
+            }
+        }),
     );
 
     if (autoStart) {
@@ -131,6 +154,7 @@ export function deactivate(): void {
     // Dispose all providers and their EventEmitters
     trafficProvider?.dispose();
     breakpointsProvider?.dispose();
+    mocksProvider?.dispose();
     
     // Dispose webview panels
     TrafficPanel.currentPanel?.dispose();
@@ -150,7 +174,8 @@ async function startEngine(
     pm: EngineProcessManager,
     client: EngineClient,
     breakpointsProvider: BreakpointsProvider,
-    trafficProvider: TrafficProvider
+    trafficProvider: TrafficProvider,
+    mocksProvider?: MocksProvider
 ): Promise<void> {
     if (pm.isRunning()) {
         vscode.window.showInformationMessage('APiX Engine is already running.');
@@ -176,6 +201,7 @@ async function startEngine(
 
         breakpointsProvider.refresh();
         trafficProvider.refresh();
+        mocksProvider?.refresh();
 
         // Start watching for paused (breakpointed) requests
         _startWatchPausedRequests(context, client);

--- a/apix-vscode/src/mocksProvider.ts
+++ b/apix-vscode/src/mocksProvider.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+import { EngineClient } from './engineClient';
+import { RewriteRule } from './types';
+
+/**
+ * MocksProvider implements TreeDataProvider for the APiX Mocks view.
+ * Each item represents one RewriteRule registered in the engine.
+ */
+export class MocksProvider implements vscode.TreeDataProvider<MockItem | ErrorItem> {
+    private _onDidChangeTreeData = new vscode.EventEmitter<MockItem | ErrorItem | undefined | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    constructor(private readonly client: EngineClient, private readonly output?: vscode.OutputChannel) {}
+
+    /** Force a refresh of the tree view. */
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    dispose(): void {
+        this._onDidChangeTreeData.dispose();
+    }
+
+    getTreeItem(element: MockItem | ErrorItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(element?: MockItem | ErrorItem): Promise<(MockItem | ErrorItem)[]> {
+        if (element) {
+            return [];
+        }
+        try {
+            const list = await this.client.listRewriteRules();
+            return (list.rules || []).map(rule => new MockItem(rule));
+        } catch (err: any) {
+            const msg = err?.message || String(err);
+            this.output?.appendLine(`[APiX] Mocks view error: ${msg}`);
+            return [new ErrorItem(`Engine unreachable: ${msg}`)];
+        }
+    }
+}
+
+/** A single item in the Mocks tree view. */
+export class MockItem extends vscode.TreeItem {
+    constructor(public readonly rule: RewriteRule) {
+        super(rule.name || rule.id, vscode.TreeItemCollapsibleState.None);
+
+        this.description = rule.action || '';
+        this.tooltip = `Action: ${rule.action}\nEnabled: ${rule.enabled}\nPriority: ${rule.priority}`;
+        this.contextValue = 'mockRule';
+
+        this.iconPath = rule.enabled
+            ? new vscode.ThemeIcon('circle-filled')
+            : new vscode.ThemeIcon('circle-outline');
+    }
+}
+
+/** Error item displayed when the engine is unreachable. */
+export class ErrorItem extends vscode.TreeItem {
+    constructor(message: string) {
+        super(message, vscode.TreeItemCollapsibleState.None);
+        this.iconPath = new vscode.ThemeIcon('error');
+        this.description = '';
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **Mocks** panel to the APiX VS Code sidebar so users can view and manage rewrite rules (mock responses) without leaving the editor.

### Changes

**`apix-vscode/src/types.ts`**
- Added `RewriteRule` and `RewriteRuleList` interfaces mirroring proto `RewriteRule` message

**`apix-vscode/src/engineClient.ts`**
- `listRewriteRules()` — calls `ListRewriteRules` gRPC RPC
- `toggleRewriteRule(id)` — calls `ToggleRewriteRule` gRPC RPC
- `deleteRewriteRule(id)` — calls `DeleteRewriteRule` gRPC RPC

**`apix-vscode/src/mocksProvider.ts`** (new)
- `MocksProvider`: TreeDataProvider showing all rewrite rules
- Each `MockItem` displays: icon (enabled/disabled), name, action type
- Context menu: toggle, delete

**`apix-vscode/package.json`**
- `apix.mocksView` tree view in the APiX sidebar
- Commands: `apix.mocks.refresh`, `apix.mocks.toggle`, `apix.mocks.delete`
- Menu entries in `view/title` and `view/item/context`

**`apix-vscode/src/extension.ts`**
- Registers `MocksProvider`, wires up all three mock commands
- Refreshes mocks view on engine start

TypeScript compiles cleanly (`npm run compile`).

Closes #112