### PR TITLE
fix: align VS Code extension license to Apache-2.0 (#173)

### DIFF
--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "Intercept, inspect, and debug HTTP/HTTPS traffic directly in VS Code",
   "version": "1.0.0",
   "publisher": "mnafshin",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mnafshin/apix"


### PR DESCRIPTION
Closes #173\n\nRoot LICENSE is Apache 2.0; extension `package.json` incorrectly declared MIT. Aligned to Apache-2.0.