### PR TITLE
fix: correct plugin runtime path in docs (internal/pluginrt) (#167)

### DIFF
--- a/docs/capabilities-map.md
+++ b/docs/capabilities-map.md
@@ -8,7 +8,7 @@ This map shows shipped vs planned capabilities and the primary surface (engine, 
 | gRPC streaming API | Shipped | Engine, CLI, VS Code | pkg/api/proto/apix.proto |
 | Breakpoints (pause/resume) | Shipped | Engine, VS Code | docs/how-to/breakpoints.md |
 | Replay requests | Shipped | Engine, CLI, VS Code | internal/replay |
-| Plugins runtime | Shipped (limited) | Engine | plugin runtime under internal/plugins |
+| Plugins runtime | Shipped (limited) | Engine | plugin runtime under internal/pluginrt |
 | Observability (metrics/slowlog) | Shipped | Engine | internal/metrics |
 | Remote engine / MCP | Planned | Engine, VS Code | roadmap: issue tracker |
 | Cookbook / Recipes | Planned | Docs | follow-up after docs restructure |

--- a/docs/design-principles.md
+++ b/docs/design-principles.md
@@ -172,7 +172,7 @@ The layered architecture (proxy → engine → storage) is what allows each laye
 | Orchestration | `internal/engine/` | Store transactions, evaluate breakpoints, publish to subscribers |
 | Persistence | `internal/storage/` | SQLite queries, schema, migrations |
 | API | `internal/server/` | Translate between gRPC proto messages and domain types |
-| Extension | `internal/plugins/`, `internal/pluginrt/` | Safe, sandboxed request/response modification |
+| Extension | `internal/pluginrt/` | Safe, sandboxed request/response modification |
 | Config | `internal/config/` | Load and validate YAML configuration |
 
 **Known gaps (tracked as issues):**


### PR DESCRIPTION
Closes #167\n\n`capabilities-map.md` and `design-principles.md` referenced the non-existent `internal/plugins` directory. The actual path is `internal/pluginrt`.