### PR TITLE
docs: correct E2E test scope description (#168)

### DIFF
--- a/docs/testing_strategy.md
+++ b/docs/testing_strategy.md
@@ -7,7 +7,7 @@ This document explains current and planned testing layers and how they map to pr
 Layers
 - Unit tests (Go/TS) — fast, exercise logic
 - Integration tests — engine + storage + proxy behavior
-- E2E tests — engine + extension + CLI in an integration environment
+- E2E tests — Go full-stack: proxy → engine → storage → gRPC response path (no VS Code extension or CLI involved)
 - Resilience/fault-injection — simulate upstream failures and flaky networks
 - Release smoke tests — minimal checks that the built binaries start and respond
 


### PR DESCRIPTION
Closes #168\n\nE2E tests cover Go full-stack (proxy → engine → storage → gRPC). The previous description falsely implied extension + CLI involvement.