### PR TITLE
refactor: extract SetValidHeaders utility (#219)

### DIFF
--- a/internal/http/headers.go
+++ b/internal/http/headers.go
@@ -1,6 +1,11 @@
 package httputil
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+
+	"github.com/mnafshin/apix/internal/logging"
+)
 
 // HeadersToMap converts an http.Header (multi-value) to a flat map[string]string,
 // keeping only the first value for each header name.
@@ -12,4 +17,21 @@ func HeadersToMap(h http.Header) map[string]string {
 		}
 	}
 	return m
+}
+
+// SetValidHeaders iterates over src (a map of header name → value), validates each
+// key/value pair using CanonicalHeader and IsValidHeaderValue, and sets accepted
+// headers on dst. Invalid entries are logged as warnings with the provided logTag.
+func SetValidHeaders(ctx context.Context, dst http.Header, src map[string]string, logTag string) {
+	for k, v := range src {
+		if cn, ok := CanonicalHeader(k); ok {
+			if IsValidHeaderValue(v) {
+				dst.Set(cn, v)
+			} else {
+				logging.Warnf(ctx, "%s: skipped invalid header value for %q", logTag, k)
+			}
+		} else {
+			logging.Warnf(ctx, "%s: skipped invalid header name %q", logTag, k)
+		}
+	}
 }

--- a/internal/replay/engine.go
+++ b/internal/replay/engine.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	logging "github.com/mnafshin/apix/internal/logging"
 	"io"
 	"net"
 	"net/http"
@@ -120,18 +119,7 @@ func (e *Engine) ReplayRequest(ctx context.Context, req *ReplayRequest) (*http.R
 		if err != nil {
 			return nil, fmt.Errorf("build request: %w", err)
 		}
-		for k, v := range rec.Headers {
-			if cn, ok := httputil.CanonicalHeader(k); ok {
-				if httputil.IsValidHeaderValue(v) {
-					httpReq.Header.Set(cn, v)
-				} else {
-					// Skip invalid header values copied from storage; log for debugging.
-					logging.Warnf(ctx, "replay: skipped invalid stored header value for %q", k)
-				}
-			} else {
-				logging.Warnf(ctx, "replay: skipped invalid stored header name %q", k)
-			}
-		}
+		httputil.SetValidHeaders(ctx, httpReq.Header, rec.Headers, "replay")
 
 	case req.RawRequest != nil:
 		// Use the supplied request (clone it with our ctx).
@@ -157,17 +145,7 @@ func (e *Engine) ReplayRequest(ctx context.Context, req *ReplayRequest) (*http.R
 	}
 
 	// Apply header overrides.
-	for k, v := range req.OverrideHeaders {
-		if cn, ok := httputil.CanonicalHeader(k); ok {
-			if httputil.IsValidHeaderValue(v) {
-				httpReq.Header.Set(cn, v)
-			} else {
-				logging.Warnf(ctx, "replay: skipped invalid override header value for %q", k)
-			}
-		} else {
-			logging.Warnf(ctx, "replay: skipped invalid override header name %q", k)
-		}
-	}
+	httputil.SetValidHeaders(ctx, httpReq.Header, req.OverrideHeaders, "replay")
 
 	// Apply method override.
 	if req.OverrideMethod != "" {

--- a/internal/server/handlers_breakpoints.go
+++ b/internal/server/handlers_breakpoints.go
@@ -121,17 +121,7 @@ func (s *EngineServer) ResumeRequest(ctx context.Context, req *apix.ResumeAction
 		httpReq, err := http.NewRequestWithContext(ctx, mr.Method, mr.Url,
 			io.NopCloser(bytes.NewReader(mr.Body)))
 		if err == nil {
-			for k, v := range mr.Headers {
-				if cn, ok := httputil.CanonicalHeader(k); ok {
-					if httputil.IsValidHeaderValue(v) {
-						httpReq.Header.Set(cn, v)
-					} else {
-						logging.Warnf(ctx, "grpc: skipped invalid header value for %q", k)
-					}
-				} else {
-					logging.Warnf(ctx, "grpc: skipped invalid header name %q", k)
-				}
-			}
+			httputil.SetValidHeaders(ctx, httpReq.Header, mr.Headers, "grpc")
 			decision.ModifiedRequest = httpReq
 		} else {
 			logging.Errorf(ctx, "grpc: build modified request: %v", err)
@@ -143,17 +133,7 @@ func (s *EngineServer) ResumeRequest(ctx context.Context, req *apix.ResumeAction
 	if action == breakpoints.ActionRespond && req.ModifiedResponse != nil {
 		mr := req.ModifiedResponse
 		hdrs := make(http.Header)
-		for k, v := range mr.Headers {
-			if cn, ok := httputil.CanonicalHeader(k); ok {
-				if httputil.IsValidHeaderValue(v) {
-					hdrs.Set(cn, v)
-				} else {
-					logging.Warnf(ctx, "grpc: skipped invalid response header value for %q", k)
-				}
-			} else {
-				logging.Warnf(ctx, "grpc: skipped invalid response header name %q", k)
-			}
-		}
+		httputil.SetValidHeaders(ctx, hdrs, mr.Headers, "grpc")
 		decision.ModifiedResponse = &http.Response{
 			StatusCode: int(mr.StatusCode),
 			Status:     mr.StatusText,


### PR DESCRIPTION
Closes #219\n\nAdd `SetValidHeaders(ctx, dst, src, logTag)` to `internal/http/headers.go`. Replaces 4 duplicated header-validation loops in `handlers_breakpoints.go` and `replay/engine.go`.