### PR TITLE
fix: silence golangci-lint G705/G115/ST1023 CI failures

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -894,7 +894,7 @@ func (a *app) cmdExport(args []string) error {
 		return fmt.Errorf("unsupported export format %q (use ndjson or har)", opts.format)
 	}
 
-	var dest io.Writer = a.out
+	dest := a.out
 	if opts.output != "" {
 		f, err := os.Create(opts.output)
 		if err != nil {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -377,7 +377,7 @@ func (p *HTTPProxy) applyRequestRewriteRules(ctx context.Context, w http.Respons
 	}
 	w.WriteHeader(synth.StatusCode)
 	if len(synth.Body) > 0 {
-		_, _ = w.Write(synth.Body)
+		_, _ = w.Write(synth.Body) //nolint:gosec // G705: proxy intentionally echoes response body to client
 	}
 	return true
 }
@@ -556,7 +556,7 @@ func writeProxyResponse(w http.ResponseWriter, resp *plugins.ProxyResponse, body
 
 	w.WriteHeader(resp.StatusCode)
 	if len(body) > 0 {
-		if _, err := w.Write(body); err != nil {
+		if _, err := w.Write(body); err != nil { //nolint:gosec // G705: proxy intentionally writes upstream response body to client
 			rid := resp.Headers.Get(logging.RequestIDHeader)
 			ctx := context.Background()
 			if rid != "" {

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -460,27 +460,27 @@ bodyPattern, statusCode, action, paramKey, paramValue, bodyTemplate, responseSta
 }
 
 func buildRewriteRule(id, name string, enabledInt, priority int, urlPattern, method, headerName, headerValue,
-bodyPattern string, statusCode, action int, paramKey, paramValue string, bodyTemplate []byte,
-responseStatus int, responseBody []byte, responseContentType string) *apix.RewriteRule {
-return &apix.RewriteRule{
-Id:       id,
-Name:     name,
-Enabled:  enabledInt == 1,
-Priority: int32(priority),
-Match: &apix.MatchCriteria{
-UrlPattern:  urlPattern,
-Method:      method,
-HeaderName:  headerName,
-HeaderValue: headerValue,
-BodyPattern: bodyPattern,
-StatusCode:  int32(statusCode),
-},
-Action:              apix.RewriteAction(action),
-ParamKey:            paramKey,
-ParamValue:          paramValue,
-BodyTemplate:        bodyTemplate,
-ResponseStatus:      int32(responseStatus),
-ResponseBody:        responseBody,
-ResponseContentType: responseContentType,
-}
+	bodyPattern string, statusCode, action int, paramKey, paramValue string, bodyTemplate []byte,
+	responseStatus int, responseBody []byte, responseContentType string) *apix.RewriteRule {
+	return &apix.RewriteRule{
+		Id:      id,
+		Name:    name,
+		Enabled: enabledInt == 1,
+		Priority: int32(priority), //nolint:gosec // G115: priority is bounded by DB constraints
+		Match: &apix.MatchCriteria{
+			UrlPattern:  urlPattern,
+			Method:      method,
+			HeaderName:  headerName,
+			HeaderValue: headerValue,
+			BodyPattern: bodyPattern,
+			StatusCode:  int32(statusCode), //nolint:gosec // G115: HTTP status codes fit in int32
+		},
+		Action:              apix.RewriteAction(action), //nolint:gosec // G115: action is a bounded enum from DB
+		ParamKey:            paramKey,
+		ParamValue:          paramValue,
+		BodyTemplate:        bodyTemplate,
+		ResponseStatus:      int32(responseStatus), //nolint:gosec // G115: HTTP status codes fit in int32
+		ResponseBody:        responseBody,
+		ResponseContentType: responseContentType,
+	}
 }


### PR DESCRIPTION
Fixes CI Lint workflow failures introduced by recent refactoring PRs.

**Issues fixed:**
- `G705` (gosec XSS taint): 2 `w.Write()` calls in `internal/proxy/http.go` — proxy intentionally echoes upstream body; not user-generated XSS
- `G115` (gosec int overflow): 4 `int→int32` casts in `buildRewriteRule` — values are HTTP status codes and DB-bounded enums, all fit within int32
- `ST1023` (staticcheck): redundant `io.Writer` type on `dest` variable in CLI export handler