### PR TITLE
fix: resolve TypeScript errors in VS Code extension (mocksProvider wiring)

### DIFF
--- a/apix-vscode/src/engineClient.ts
+++ b/apix-vscode/src/engineClient.ts
@@ -13,6 +13,8 @@ import {
     HttpResponse,
     PluginInfo,
     WebSocketFrame,
+    RewriteRule,
+    RewriteRuleList,
 } from './types';
 
 const PROTO_PATH = path.resolve(__dirname, '../../proto/apix.proto');
@@ -331,5 +333,32 @@ export class EngineClient {
     /** Close the gRPC channel. */
     close(): void {
         this.client?.close();
+    }
+
+    async listRewriteRules(): Promise<RewriteRuleList> {
+        this.ensureStub();
+        return new Promise((resolve, reject) => {
+            this.stub.listRewriteRules({}, this.metadata, (err: grpc.ServiceError | null, response: any) => {
+                if (err) { reject(err); } else { resolve(response as RewriteRuleList); }
+            });
+        });
+    }
+
+    async toggleRewriteRule(ruleId: string): Promise<RewriteRule> {
+        this.ensureStub();
+        return new Promise((resolve, reject) => {
+            this.stub.toggleRewriteRule({ ruleId }, this.metadata, (err: grpc.ServiceError | null, response: any) => {
+                if (err) { reject(err); } else { resolve(response as RewriteRule); }
+            });
+        });
+    }
+
+    async deleteRewriteRule(ruleId: string): Promise<void> {
+        this.ensureStub();
+        return new Promise((resolve, reject) => {
+            this.stub.deleteRewriteRule({ ruleId }, this.metadata, (err: grpc.ServiceError | null) => {
+                if (err) { reject(err); } else { resolve(); }
+            });
+        });
     }
 }

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -3,6 +3,7 @@ import { EngineClient } from './engineClient';
 import { TrafficPanel } from './trafficPanel';
 import { BreakpointsProvider, BreakpointItem } from './breakpointsProvider';
 import { TrafficProvider, TrafficItem } from './trafficProvider';
+import { MocksProvider, MockItem } from './mocksProvider';
 import { EngineProcessManager } from './engineProcessManager';
 import { ReplayPanel } from './replayPanel';
 import { RequestEditor } from './requestEditor';
@@ -15,6 +16,7 @@ let statusBarItem: vscode.StatusBarItem | undefined;
 let pausedRequestsStream: { cancel: () => void } | undefined;
 let trafficProvider: TrafficProvider | undefined;
 let breakpointsProvider: BreakpointsProvider | undefined;
+let mocksProvider: MocksProvider | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -42,6 +44,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     trafficProvider = new TrafficProvider(engineClient, outputChannel);
     breakpointsProvider = new BreakpointsProvider(engineClient, outputChannel);
+    mocksProvider = new MocksProvider(engineClient, outputChannel);
 
     const trafficViewDisposable = vscode.window.registerTreeDataProvider(
         'apix.trafficView',
@@ -53,9 +56,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         breakpointsProvider
     );
 
+    const mocksViewDisposable = vscode.window.registerTreeDataProvider(
+        'apix.mocksView',
+        mocksProvider
+    );
+
     context.subscriptions.push(
         trafficViewDisposable,
         breakpointsViewDisposable,
+        mocksViewDisposable,
 
         vscode.commands.registerCommand('apix.startEngine', () =>
             startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!)

--- a/apix-vscode/src/types.ts
+++ b/apix-vscode/src/types.ts
@@ -102,3 +102,31 @@ export interface PluginInfo {
     description: string;
     enabled: boolean;
 }
+
+export interface MatchCriteria {
+    urlPattern: string;
+    method: string;
+    headerName: string;
+    headerValue: string;
+    bodyPattern: string;
+    statusCode: number;
+}
+
+export interface RewriteRule {
+    id: string;
+    name: string;
+    enabled: boolean;
+    priority: number;
+    match?: MatchCriteria;
+    action: string;       // RewriteAction enum string e.g. "ADD_REQUEST_HEADER"
+    paramKey: string;
+    paramValue: string;
+    bodyTemplate: Uint8Array | string;
+    responseStatus: number;
+    responseBody: Uint8Array | string;
+    responseContentType: string;
+}
+
+export interface RewriteRuleList {
+    rules: RewriteRule[];
+}


### PR DESCRIPTION
Fixes CI `VS Code Extension Build` type check failures.

**Root cause:** `dry-and-mock` agent (PR #225) added `mocksProvider.ts` but didn't complete the wiring in `extension.ts` or add the supporting types/methods.

**Changes:**
- `types.ts`: Add `RewriteRule`, `MatchCriteria`, `RewriteRuleList` interfaces mirroring proto definitions
- `engineClient.ts`: Add `listRewriteRules()`, `toggleRewriteRule(id)`, `deleteRewriteRule(id)` gRPC methods
- `extension.ts`: Import `MocksProvider`/`MockItem`, declare module-level `mocksProvider` variable, instantiate `MocksProvider`, register `apix.mocksView` tree data provider

**Errors fixed:**
- `TS2304`: Cannot find name `mocksProvider` / `MockItem` / `MocksProvider`
- `TS2339`: Property `toggleRewriteRule`/`deleteRewriteRule`/`listRewriteRules` does not exist on `EngineClient`
- `TS2305`: Module `./types` has no exported member `RewriteRule`
- `TS7006`: Parameter `rule` implicitly has an `any` type