### PR TITLE
refactor: extract shared plugin panic recovery helpers (#214)

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -274,29 +274,7 @@ func (p *HTTPProxy) readRequestBody(r *http.Request, maxBytes int64) ([]byte, er
 // runPluginRequest runs the OnRequest plugin chain with panic recovery.
 // Returns the (possibly modified) ProxyRequest, or an error on failure.
 func (p *HTTPProxy) runPluginRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
-	if p.plugins == nil {
-		return req, nil
-	}
-	var runErr error
-	func() {
-		defer func() {
-			if rec := recover(); rec != nil {
-				logging.Errorf(ctx, "HTTP proxy panic in plugin OnRequest (recovered): %v", rec)
-				runErr = fmt.Errorf("plugin panic")
-			}
-		}()
-		modified, err := p.plugins.RunRequest(ctx, req)
-		if err != nil {
-			logging.Errorf(ctx, "plugin OnRequest error: %v", err)
-			runErr = err
-			return
-		}
-		req = modified
-	}()
-	if runErr != nil {
-		return nil, runErr
-	}
-	return req, nil
+	return runPluginRequest(ctx, p.plugins, req, "http proxy")
 }
 
 // writeMockedResponse writes a plugin-provided mocked response to w.
@@ -432,37 +410,16 @@ func (p *HTTPProxy) runPluginResponse(ctx context.Context, req *plugins.ProxyReq
 	if p.plugins == nil {
 		return resp, body, nil
 	}
-	var pluginErr error
-	func() {
-		defer func() {
-			if rec := recover(); rec != nil {
-				logging.Errorf(ctx, "HTTP proxy panic in plugin OnResponse (recovered): %v", rec)
-			}
-		}()
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-		modResp, err := p.plugins.RunResponse(ctx, req, resp)
-		if err != nil {
-			logging.Errorf(ctx, "plugin OnResponse error: %v", err)
-			pluginErr = err
-			return
-		}
-		if modResp != nil {
-			resp = modResp
-			if modResp.Body != nil {
-				limited := io.LimitReader(modResp.Body, maxBodyBytes)
-				newBody, readErr := io.ReadAll(limited)
-				if readErr != nil {
-					logging.Errorf(ctx, "plugin modified response body read error: %v", readErr)
-				} else {
-					body = newBody
-				}
-			}
-		}
-	}()
-	if pluginErr != nil {
-		return nil, nil, pluginErr
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	modResp := runPluginResponse(ctx, p.plugins, req, resp, "http proxy")
+	if modResp == nil {
+		return resp, body, nil
 	}
-	return resp, body, nil
+	if modResp.Body != nil {
+		newBody := drainPluginResponseBody(ctx, modResp, maxBodyBytes, "http proxy")
+		return modResp, newBody, nil
+	}
+	return modResp, body, nil
 }
 
 func (p *HTTPProxy) handleWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Request, tx *Transaction, start time.Time) {

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -174,26 +174,11 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	}
 
 	// Run plugin OnRequest chain with panic recovery.
-	if p.plugins != nil {
-		var pluginErr error
-		func() {
-			defer func() {
-				if rec := recover(); rec != nil {
-					pluginErr = fmt.Errorf("panic in plugin OnRequest: %v", rec)
-					logging.Errorf(ctx, "TLS proxy panic in plugin OnRequest (recovered): %v", rec)
-				}
-			}()
-			modified, err := p.plugins.RunRequest(ctx, proxyReq)
-			if err != nil {
-				pluginErr = err
-				return
-			}
-			proxyReq = modified
-		}()
-		if pluginErr != nil {
-			writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("plugin error: %v", pluginErr))
-			return
-		}
+	var err error
+	proxyReq, err = runPluginRequest(ctx, p.plugins, proxyReq, "tls proxy")
+	if err != nil {
+		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("plugin error: %v", err))
+		return
 	}
 
 	// Mocked response short-circuit.
@@ -205,9 +190,9 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	// Breakpoint check.
 	tx := &Transaction{ID: reqID, Request: proxyReq, RequestBody: bodyBytes, OriginalRequestHeaders: origHeaders}
 	if p.engine != nil {
-		modified, action, err := p.engine.PauseRequest(tx)
-		if err != nil {
-			logging.Errorf(ctx, "tls proxy: pause request: %v", err)
+		modified, action, bpErr := p.engine.PauseRequest(tx)
+		if bpErr != nil {
+			logging.Errorf(ctx, "tls proxy: pause request: %v", bpErr)
 		}
 		tx = modified
 		switch action {
@@ -230,24 +215,24 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	}
 
 	// Build and send upstream request using the shared pooled transport.
-	upReq, err := http.NewRequestWithContext(ctx, proxyReq.Method, proxyReq.URL.String(), proxyReq.Body)
-	if err != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("build upstream request: %v", err))
+	upReq, upErr := http.NewRequestWithContext(ctx, proxyReq.Method, proxyReq.URL.String(), proxyReq.Body)
+	if upErr != nil {
+		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("build upstream request: %v", upErr))
 		return
 	}
 	upReq.Header = proxyReq.Headers.Clone()
 
-	upResp, err := p.transport.RoundTrip(upReq)
-	if err != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("upstream error: %v", err))
+	upResp, upErr := p.transport.RoundTrip(upReq)
+	if upErr != nil {
+		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("upstream error: %v", upErr))
 		return
 	}
 	defer func() { _ = upResp.Body.Close() }()
 
 	// Apply the same body size limit to response bodies
-	respBody, err := httputil.ReadLimitedBody(upResp.Body, maxBodyBytes)
-	if err != nil {
-		writeHTTPError(conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("response body too large: %v", err))
+	respBody, readErr := httputil.ReadLimitedBody(upResp.Body, maxBodyBytes)
+	if readErr != nil {
+		writeHTTPError(conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("response body too large: %v", readErr))
 		return
 	}
 	proxyResp := &plugins.ProxyResponse{
@@ -259,21 +244,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	}
 
 	// Run plugin OnResponse chain with panic recovery.
-	if p.plugins != nil {
-		func() {
-			defer func() {
-				if rec := recover(); rec != nil {
-					logging.Errorf(ctx, "TLS proxy panic in plugin OnResponse (recovered): %v", rec)
-				}
-			}()
-			modResp, err := p.plugins.RunResponse(ctx, proxyReq, proxyResp)
-			if err != nil {
-				logging.Errorf(ctx, "tls proxy: plugin OnResponse: %v", err)
-			} else if modResp != nil {
-				proxyResp = modResp
-			}
-		}()
-	}
+	proxyResp = runPluginResponse(ctx, p.plugins, proxyReq, proxyResp, "tls proxy")
 
 	// Buffer the final response body (plugins may have modified it) so we can
 	// both persist it and still write it to the client.

--- a/internal/proxy/plugin_runner.go
+++ b/internal/proxy/plugin_runner.go
@@ -1,0 +1,79 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	logging "github.com/mnafshin/apix/internal/logging"
+	"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// runPluginRequest executes the OnRequest chain of chain with panic recovery.
+// Returns the (possibly modified) request, or an error if the chain failed.
+// Callers may pass nil for chain — the original req is returned unchanged.
+func runPluginRequest(ctx context.Context, chain PluginChain, req *plugins.ProxyRequest, logTag string) (*plugins.ProxyRequest, error) {
+	if chain == nil {
+		return req, nil
+	}
+	var runErr error
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				logging.Errorf(ctx, "%s: panic in plugin OnRequest (recovered): %v", logTag, rec)
+				runErr = fmt.Errorf("plugin panic")
+			}
+		}()
+		modified, err := chain.RunRequest(ctx, req)
+		if err != nil {
+			logging.Errorf(ctx, "%s: plugin OnRequest error: %v", logTag, err)
+			runErr = err
+			return
+		}
+		req = modified
+	}()
+	if runErr != nil {
+		return nil, runErr
+	}
+	return req, nil
+}
+
+// runPluginResponse executes the OnResponse chain of chain with panic recovery.
+// Returns the (possibly modified) response, or the original resp on failure.
+// Callers may pass nil for chain — the original resp is returned unchanged.
+func runPluginResponse(ctx context.Context, chain PluginChain, req *plugins.ProxyRequest, resp *plugins.ProxyResponse, logTag string) *plugins.ProxyResponse {
+	if chain == nil {
+		return resp
+	}
+	func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				logging.Errorf(ctx, "%s: panic in plugin OnResponse (recovered): %v", logTag, rec)
+			}
+		}()
+		modResp, err := chain.RunResponse(ctx, req, resp)
+		if err != nil {
+			logging.Errorf(ctx, "%s: plugin OnResponse error: %v", logTag, err)
+			return
+		}
+		if modResp != nil {
+			resp = modResp
+		}
+	}()
+	return resp
+}
+
+// drainPluginResponseBody reads the response body from a plugin-modified response.
+// Returns updated body bytes (or original body on read error).
+func drainPluginResponseBody(ctx context.Context, resp *plugins.ProxyResponse, maxBytes int64, logTag string) []byte {
+	if resp.Body == nil {
+		return nil
+	}
+	limited := io.LimitReader(resp.Body, maxBytes)
+	b, err := io.ReadAll(limited)
+	if err != nil {
+		logging.Errorf(ctx, "%s: read plugin response body: %v", logTag, err)
+		return nil
+	}
+	return b
+}


### PR DESCRIPTION
Closes #214\n\nAdds `internal/proxy/plugin_runner.go` with three package-level functions that consolidate the identical IIFE panic-recovery patterns duplicated across `http.go` and `https.go`:\n- `runPluginRequest` — OnRequest with panic recovery\n- `runPluginResponse` — OnResponse with panic recovery\n- `drainPluginResponseBody` — body read helper\n\nReduces proxy KISS violation by removing 4 duplicated anonymous-function blocks.