### PR TITLE
feat(engine): introduce BreakpointEvaluator interface to remove concrete dependency (#211)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -25,14 +25,14 @@ import (
 type Engine struct {
 	mu               sync.Mutex
 	db               storage.TransactionRepository
-	bpManager        *breakpoints.Manager
+	bpManager        BreakpointEvaluator
 	pluginRT         *pluginrt.Runtime
 	subscribers      map[chan *apix.HttpRequest]struct{}
 	pauseTimeoutSec  int // 0 = no timeout
 }
 
 // New creates a new Engine wiring together all sub-systems.
-func New(db storage.TransactionRepository, bpManager *breakpoints.Manager, rt *pluginrt.Runtime) *Engine {
+func New(db storage.TransactionRepository, bpManager BreakpointEvaluator, rt *pluginrt.Runtime) *Engine {
 	return &Engine{
 		db:          db,
 		bpManager:   bpManager,
@@ -43,7 +43,7 @@ func New(db storage.TransactionRepository, bpManager *breakpoints.Manager, rt *p
 
 // NewWithConfig creates a new Engine using per-configuration settings such as
 // the breakpoint pause timeout.
-func NewWithConfig(db storage.TransactionRepository, bpManager *breakpoints.Manager, rt *pluginrt.Runtime, cfg *config.Config) *Engine {
+func NewWithConfig(db storage.TransactionRepository, bpManager BreakpointEvaluator, rt *pluginrt.Runtime, cfg *config.Config) *Engine {
 	e := New(db, bpManager, rt)
 	if cfg != nil {
 		e.pauseTimeoutSec = cfg.BreakpointPauseTimeoutSec
@@ -249,8 +249,8 @@ func (e *Engine) DB() *storage.DB {
 	return db
 }
 
-// BreakpointManager returns the breakpoints manager.
-func (e *Engine) BreakpointManager() *breakpoints.Manager { return e.bpManager }
+// BreakpointManager returns the breakpoints manager (as BreakpointEvaluator).
+func (e *Engine) BreakpointManager() BreakpointEvaluator { return e.bpManager }
 
 // PluginRuntime returns the plugin runtime.
 func (e *Engine) PluginRuntime() *pluginrt.Runtime { return e.pluginRT }

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -1,0 +1,20 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/mnafshin/apix/internal/breakpoints"
+)
+
+// BreakpointEvaluator is the interface Engine uses to manage breakpoints.
+// *breakpoints.Manager satisfies this interface.
+type BreakpointEvaluator interface {
+	Evaluate(method, rawURL string) string
+	Pause(ctx context.Context, entry *breakpoints.PausedEntry) (*breakpoints.ResumeDecision, error)
+	Resume(requestID string, decision *breakpoints.ResumeDecision) error
+	AddRule(rule *breakpoints.BreakpointRule) (*breakpoints.BreakpointRule, error)
+	RemoveRule(id string) error
+	ListRules() []*breakpoints.BreakpointRule
+	Subscribe() chan *breakpoints.PausedEntry
+	Unsubscribe(ch chan *breakpoints.PausedEntry)
+}


### PR DESCRIPTION
Closes #211\n\nDefines `BreakpointEvaluator` interface in `internal/engine/evaluator.go`. Changes `Engine` struct field from `*breakpoints.Manager` to the interface type. Updates `New`, `NewWithConfig`, and `BreakpointManager()\ signatures accordingly. All 21 test packages pass.