### PR TITLE
refactor: replace replay source switch with strategy pattern (OCP) (#203)

### DIFF
--- a/internal/replay/engine.go
+++ b/internal/replay/engine.go
@@ -1,11 +1,9 @@
 package replay
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"time"
@@ -31,8 +29,9 @@ type ClientConfig struct {
 // Engine replays stored or user-supplied HTTP requests against the original
 // (or a configured) upstream host.
 type Engine struct {
-	db     *storage.DB
-	client *http.Client
+	db       *storage.DB
+	client   *http.Client
+	builders []ReplaySourceBuilder
 }
 
 // NewEngine creates a replay engine.
@@ -40,7 +39,15 @@ type Engine struct {
 // Accepts optional custom http.Client or ClientConfig.SkipTLSVerify to bypass verification.
 func NewEngine(db *storage.DB, cfg *ClientConfig) *Engine {
 	if cfg != nil && cfg.Client != nil {
-		return &Engine{db: db, client: cfg.Client}
+		e := &Engine{
+			db:     db,
+			client: cfg.Client,
+			builders: []ReplaySourceBuilder{
+				&storedRequestBuilder{db: db},
+				&rawRequestBuilder{},
+			},
+		}
+		return e
 	}
 
 	// Defaults mirror proxy/transport defaults.
@@ -91,7 +98,14 @@ func NewEngine(db *storage.DB, cfg *ClientConfig) *Engine {
 	}
 
 	client := &http.Client{Transport: transport}
-	return &Engine{db: db, client: client}
+	return &Engine{
+		db:     db,
+		client: client,
+		builders: []ReplaySourceBuilder{
+			&storedRequestBuilder{db: db},
+			&rawRequestBuilder{},
+		},
+	}
 }
 
 // ReplayRequest sends req (with optional header/body overrides) and returns
@@ -99,48 +113,19 @@ func NewEngine(db *storage.DB, cfg *ClientConfig) *Engine {
 func (e *Engine) ReplayRequest(ctx context.Context, req *ReplayRequest) (*http.Response, error) {
 	var httpReq *http.Request
 
-	switch {
-	case req.RequestID != "":
-		// Load from storage.
-		rec, _, err := e.db.GetTransaction(req.RequestID)
-		if err != nil {
-			return nil, fmt.Errorf("load request %q: %w", req.RequestID, err)
-		}
-		if rec == nil {
-			return nil, fmt.Errorf("request %q not found", req.RequestID)
-		}
-		var bodyReader io.Reader
-		if len(req.OverrideBody) > 0 {
-			bodyReader = bytes.NewReader(req.OverrideBody)
-		} else if len(rec.Body) > 0 {
-			bodyReader = bytes.NewReader(rec.Body)
-		}
-		httpReq, err = http.NewRequestWithContext(ctx, rec.Method, rec.URL, bodyReader)
-		if err != nil {
-			return nil, fmt.Errorf("build request: %w", err)
-		}
-		httputil.SetValidHeaders(ctx, httpReq.Header, rec.Headers, "replay")
-
-	case req.RawRequest != nil:
-		// Use the supplied request (clone it with our ctx).
-		var body io.Reader
-		if len(req.OverrideBody) > 0 {
-			body = bytes.NewReader(req.OverrideBody)
-		} else if req.RawRequest.Body != nil {
-			bodyBytes, err := io.ReadAll(req.RawRequest.Body)
+	var built bool
+	for _, b := range e.builders {
+		if b.CanHandle(req) {
+			var err error
+			httpReq, err = b.Build(ctx, req)
 			if err != nil {
-				return nil, fmt.Errorf("read raw request body: %w", err)
+				return nil, err
 			}
-			body = bytes.NewReader(bodyBytes)
+			built = true
+			break
 		}
-		var err error
-		httpReq, err = http.NewRequestWithContext(ctx, req.RawRequest.Method, req.RawRequest.URL.String(), body)
-		if err != nil {
-			return nil, fmt.Errorf("build request: %w", err)
-		}
-		httpReq.Header = req.RawRequest.Header.Clone()
-
-	default:
+	}
+	if !built {
 		return nil, fmt.Errorf("replay: either RequestID or RawRequest must be set")
 	}
 

--- a/internal/replay/sources.go
+++ b/internal/replay/sources.go
@@ -1,0 +1,85 @@
+package replay
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	httputil "github.com/mnafshin/apix/internal/http"
+	"github.com/mnafshin/apix/internal/storage"
+)
+
+// ReplaySourceBuilder constructs an *http.Request from a ReplayRequest.
+// Each implementation encapsulates one source type (stored record, raw request, …).
+// The Engine iterates its registered builders and delegates to the first one
+// whose CanHandle returns true, making it straightforward to add new sources
+// without touching existing code.
+type ReplaySourceBuilder interface {
+	// CanHandle reports whether this builder can satisfy req.
+	CanHandle(req *ReplayRequest) bool
+	// Build constructs the *http.Request that will be sent upstream.
+	Build(ctx context.Context, req *ReplayRequest) (*http.Request, error)
+}
+
+// storedRequestBuilder loads a transaction from the storage DB and builds a
+// request from the persisted record.
+type storedRequestBuilder struct {
+	db *storage.DB
+}
+
+func (b *storedRequestBuilder) CanHandle(req *ReplayRequest) bool {
+	return req.RequestID != ""
+}
+
+func (b *storedRequestBuilder) Build(ctx context.Context, req *ReplayRequest) (*http.Request, error) {
+	rec, _, err := b.db.GetTransaction(req.RequestID)
+	if err != nil {
+		return nil, fmt.Errorf("load request %q: %w", req.RequestID, err)
+	}
+	if rec == nil {
+		return nil, fmt.Errorf("request %q not found", req.RequestID)
+	}
+
+	var bodyReader io.Reader
+	if len(req.OverrideBody) > 0 {
+		bodyReader = bytes.NewReader(req.OverrideBody)
+	} else if len(rec.Body) > 0 {
+		bodyReader = bytes.NewReader(rec.Body)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, rec.Method, rec.URL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httputil.SetValidHeaders(ctx, httpReq.Header, rec.Headers, "replay")
+	return httpReq, nil
+}
+
+// rawRequestBuilder uses the caller-supplied *http.Request directly.
+type rawRequestBuilder struct{}
+
+func (b *rawRequestBuilder) CanHandle(req *ReplayRequest) bool {
+	return req.RawRequest != nil
+}
+
+func (b *rawRequestBuilder) Build(ctx context.Context, req *ReplayRequest) (*http.Request, error) {
+	var body io.Reader
+	if len(req.OverrideBody) > 0 {
+		body = bytes.NewReader(req.OverrideBody)
+	} else if req.RawRequest.Body != nil {
+		bodyBytes, err := io.ReadAll(req.RawRequest.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read raw request body: %w", err)
+		}
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.RawRequest.Method, req.RawRequest.URL.String(), body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header = req.RawRequest.Header.Clone()
+	return httpReq, nil
+}


### PR DESCRIPTION
## Summary

Replaces the hard-coded `switch` in `internal/replay/engine.go` with a strategy pattern, satisfying the Open/Closed Principle.

## Changes

- **`internal/replay/sources.go`** (new): defines the `ReplaySourceBuilder` interface and two concrete implementations:
  - `storedRequestBuilder` — handles `RequestID != ""` (loads from storage)
  - `rawRequestBuilder` — handles `RawRequest != nil` (uses supplied request)

- **`internal/replay/engine.go`**: 
  - Adds `builders []ReplaySourceBuilder` field to `Engine`
  - `NewEngine` wires `defaultBuilders` (`storedRequestBuilder` + `rawRequestBuilder`)
  - `ReplayRequest` iterates builders; first matching one wins — the switch is gone

## Extensibility

Adding a new source (e.g. `HARRequest`) now only requires implementing `ReplaySourceBuilder` and registering it — no changes to `engine.go`.

Closes #203