### PR TITLE
refactor: split TrafficEngine interface (ISP) (#208)

### DIFF
--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -19,18 +19,30 @@ type ProxyRequest = plugins.ProxyRequest
 // ProxyResponse is an alias for the plugins-layer response type.
 type ProxyResponse = plugins.ProxyResponse
 
-// TrafficEngine is the interface the proxy uses to store and publish traffic.
+// TransactionStore is the narrow interface for persisting and publishing traffic.
 // Implemented by internal/engine.Engine.
-type TrafficEngine interface {
+type TransactionStore interface {
 	// StoreTransaction persists and publishes a completed HTTP transaction.
 	StoreTransaction(tx *Transaction) error
 	// StoreWebSocketFrame persists a relayed WebSocket frame.
 	StoreWebSocketFrame(frame *WebSocketFrame) error
+	// RewriteRules loads the current list of enabled rewrite rules from storage.
+	RewriteRules() ([]*RewriteRuleProto, error)
+}
+
+// RequestPauser is the narrow interface for breakpoint pause/resume.
+// Implemented by internal/engine.Engine.
+type RequestPauser interface {
 	// PauseRequest holds a request at a breakpoint and blocks until resumed.
 	// Returns the (possibly modified) request and the resume action.
 	PauseRequest(tx *Transaction) (*Transaction, ResumeAction, error)
-	// RewriteRules loads the current list of enabled rewrite rules from storage.
-	RewriteRules() ([]*RewriteRuleProto, error)
+}
+
+// TrafficEngine composes all proxy interfaces.
+// Implemented by internal/engine.Engine.
+type TrafficEngine interface {
+	TransactionStore
+	RequestPauser
 }
 
 // PluginChain is an ordered list of plugins applied to each request/response.

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -112,7 +112,7 @@ func copyWebSocketResponseHeaders(headers http.Header) http.Header {
 	return out
 }
 
-func relayWebSocket(ctx context.Context, engine TrafficEngine, transactionID string, clientConn, upstreamConn *websocket.Conn) {
+func relayWebSocket(ctx context.Context, engine TransactionStore, transactionID string, clientConn, upstreamConn *websocket.Conn) {
 	var forwardCloseOnce sync.Once
 	var shutdownOnce sync.Once
 	shutdown := func() {
@@ -193,7 +193,7 @@ func isExpectedWebSocketClose(err error) bool {
 	return strings.Contains(err.Error(), "use of closed network connection")
 }
 
-func recordWebSocketFrame(ctx context.Context, engine TrafficEngine, transactionID, direction string, opcode int, payload []byte) {
+func recordWebSocketFrame(ctx context.Context, engine TransactionStore, transactionID, direction string, opcode int, payload []byte) {
 	if engine == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Closes #208

Splits the monolithic `TrafficEngine` interface in `internal/proxy/types.go` into two narrower interfaces following the Interface Segregation Principle:

- `TransactionStore` — `StoreTransaction`, `StoreWebSocketFrame`, `RewriteRules`
- `RequestPauser` — `PauseRequest`
- `TrafficEngine` now composes both (backward-compatible)

## Changes

- `internal/proxy/types.go`: split interface definition
- `internal/proxy/websocket.go`: `relayWebSocket` and `recordWebSocketFrame` now accept `TransactionStore` (narrowest needed interface)

## Tests

- `go build ./...` ✅
- `go test ./...` ✅ (all proxy, engine, server tests pass)
- `cd apix-vscode && npx tsc --noEmit` ✅