### PR TITLE
refactor: inject narrow interfaces into EngineServer (ISP+DIP) (#209, #210)

### DIFF
--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -22,9 +22,12 @@ apix "github.com/mnafshin/apix/pkg/api/generated"
 // EngineServer implements the apix.EngineServer gRPC interface.
 type EngineServer struct {
 apix.UnimplementedEngineServer
-engine       *engine.Engine
-replayEngine *replay.Engine
-cfg          *config.Config
+traffic       TrafficSubscriber
+breakpointMgr BreakpointManagerServer
+db            ServerRepository
+plugins       PluginLister
+replayEngine  *replay.Engine
+cfg           *config.Config
 }
 
 func int32FromInt(v int, field string) (int32, error) {
@@ -35,11 +38,16 @@ return int32(v), nil
 }
 
 // NewEngineServer wires the gRPC server to all sub-systems.
+// The concrete *engine.Engine is the composition root — it satisfies all
+// narrow interfaces defined in interfaces.go.
 func NewEngineServer(eng *engine.Engine, re *replay.Engine, cfg *config.Config) *EngineServer {
 return &EngineServer{
-engine:       eng,
-replayEngine: re,
-cfg:          cfg,
+traffic:       eng,
+breakpointMgr: eng.BreakpointManager(),
+db:            eng.DB(),
+plugins:       eng.PluginRuntime(),
+replayEngine:  re,
+cfg:           cfg,
 }
 }
 

--- a/internal/server/handlers_breakpoints.go
+++ b/internal/server/handlers_breakpoints.go
@@ -27,12 +27,12 @@ func (s *EngineServer) SetBreakpoint(ctx context.Context, req *apix.BreakpointRu
 	if rule.ID == "" {
 		rule.ID = uuid.NewString()
 	}
-	added, err := s.engine.BreakpointManager().AddRule(rule)
+	added, err := s.breakpointMgr.AddRule(rule)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid breakpoint: %v", err)
 	}
 	// Persist to storage.
-	if err := s.engine.DB().SaveBreakpoint(added.ID, added.URLPattern, added.Methods, added.Enabled, added.Label); err != nil {
+	if err := s.db.SaveBreakpoint(added.ID, added.URLPattern, added.Methods, added.Enabled, added.Label); err != nil {
 		logging.Errorf(ctx, "grpc: save breakpoint: %v", err)
 	}
 	return &apix.BreakpointResponse{
@@ -47,17 +47,17 @@ func (s *EngineServer) SetBreakpoint(ctx context.Context, req *apix.BreakpointRu
 }
 
 func (s *EngineServer) DeleteBreakpoint(ctx context.Context, req *apix.BreakpointID) (*apix.Empty, error) {
-	if err := s.engine.BreakpointManager().RemoveRule(req.Id); err != nil {
+	if err := s.breakpointMgr.RemoveRule(req.Id); err != nil {
 		return nil, status.Errorf(codes.NotFound, "breakpoint not found: %v", err)
 	}
-	if err := s.engine.DB().DeleteBreakpoint(req.Id); err != nil {
+	if err := s.db.DeleteBreakpoint(req.Id); err != nil {
 		logging.Errorf(ctx, "grpc: delete breakpoint from storage: %v", err)
 	}
 	return &apix.Empty{}, nil
 }
 
 func (s *EngineServer) ListBreakpoints(ctx context.Context, _ *apix.Empty) (*apix.BreakpointList, error) {
-	rules := s.engine.BreakpointManager().ListRules()
+	rules := s.breakpointMgr.ListRules()
 	list := make([]*apix.BreakpointRule, 0, len(rules))
 	for _, r := range rules {
 		list = append(list, &apix.BreakpointRule{
@@ -72,8 +72,8 @@ func (s *EngineServer) ListBreakpoints(ctx context.Context, _ *apix.Empty) (*api
 }
 
 func (s *EngineServer) WatchPausedRequests(_ *apix.Empty, stream grpc.ServerStreamingServer[apix.PausedRequest]) error {
-	ch := s.engine.BreakpointManager().Subscribe()
-	defer s.engine.BreakpointManager().Unsubscribe(ch)
+	ch := s.breakpointMgr.Subscribe()
+	defer s.breakpointMgr.Unsubscribe(ch)
 
 	for {
 		select {
@@ -144,7 +144,7 @@ func (s *EngineServer) ResumeRequest(ctx context.Context, req *apix.ResumeAction
 		}
 	}
 
-	if err := s.engine.BreakpointManager().Resume(req.RequestId, decision); err != nil {
+	if err := s.breakpointMgr.Resume(req.RequestId, decision); err != nil {
 		return nil, status.Errorf(codes.NotFound, "resume request: %v", err)
 	}
 	return &apix.Empty{}, nil

--- a/internal/server/handlers_plugins.go
+++ b/internal/server/handlers_plugins.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *EngineServer) ListPlugins(ctx context.Context, _ *apix.PluginListRequest) (*apix.PluginListResponse, error) {
-	metas := s.engine.PluginRuntime().List()
+	metas := s.plugins.List()
 	infos := make([]*apix.PluginInfo, 0, len(metas))
 	for _, m := range metas {
 		infos = append(infos, &apix.PluginInfo{

--- a/internal/server/handlers_rewrite.go
+++ b/internal/server/handlers_rewrite.go
@@ -13,7 +13,7 @@ func (s *EngineServer) AddRewriteRule(ctx context.Context, rule *apix.RewriteRul
 	if rule.Id == "" {
 		rule.Id = uuid.NewString()
 	}
-	if err := s.engine.DB().AddRewriteRule(rule); err != nil {
+	if err := s.db.AddRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "add rewrite rule: %v", err)
 	}
 	return rule, nil
@@ -23,7 +23,7 @@ func (s *EngineServer) UpdateRewriteRule(ctx context.Context, rule *apix.Rewrite
 	if rule.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	if err := s.engine.DB().UpdateRewriteRule(rule); err != nil {
+	if err := s.db.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "update rewrite rule: %v", err)
 	}
 	return rule, nil
@@ -33,14 +33,14 @@ func (s *EngineServer) DeleteRewriteRule(ctx context.Context, req *apix.RewriteR
 	if req.RuleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	if err := s.engine.DB().DeleteRewriteRule(req.RuleId); err != nil {
+	if err := s.db.DeleteRewriteRule(req.RuleId); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete rewrite rule: %v", err)
 	}
 	return &apix.Empty{}, nil
 }
 
 func (s *EngineServer) ListRewriteRules(ctx context.Context, _ *apix.Empty) (*apix.RewriteRuleList, error) {
-	rules, err := s.engine.DB().ListRewriteRules()
+	rules, err := s.db.ListRewriteRules()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "list rewrite rules: %v", err)
 	}
@@ -51,7 +51,7 @@ func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteR
 	if req.RuleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	rule, err := s.engine.DB().GetRewriteRule(req.RuleId)
+	rule, err := s.db.GetRewriteRule(req.RuleId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get rewrite rule: %v", err)
 	}
@@ -59,7 +59,7 @@ func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteR
 		return nil, status.Errorf(codes.NotFound, "rule %q not found", req.RuleId)
 	}
 	rule.Enabled = !rule.Enabled
-	if err := s.engine.DB().UpdateRewriteRule(rule); err != nil {
+	if err := s.db.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "toggle rewrite rule: %v", err)
 	}
 	return rule, nil

--- a/internal/server/handlers_traffic.go
+++ b/internal/server/handlers_traffic.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (s *EngineServer) CaptureTraffic(_ *apix.CaptureRequest, stream grpc.ServerStreamingServer[apix.HttpRequest]) error {
-	ch := s.engine.Subscribe()
-	defer s.engine.Unsubscribe(ch)
+	ch := s.traffic.Subscribe()
+	defer s.traffic.Unsubscribe(ch)
 
 	for {
 		select {
@@ -34,7 +34,7 @@ func (s *EngineServer) GetHistory(req *apix.HistoryQuery, stream grpc.ServerStre
 	if limit <= 0 {
 		limit = 100
 	}
-	reqs, resps, err := s.engine.DB().ListTransactions(
+	reqs, resps, err := s.db.ListTransactions(
 		limit, int(req.Offset),
 		req.UrlFilter, req.MethodFilter, int(req.StatusFilter), req.BodyFilter,
 	)
@@ -98,7 +98,7 @@ func (s *EngineServer) GetWebSocketFrames(req *apix.GetWebSocketFramesRequest, s
 		return status.Error(codes.InvalidArgument, "transaction_id is required")
 	}
 
-	frames, err := s.engine.DB().ListWebSocketFrames(req.TransactionId)
+	frames, err := s.db.ListWebSocketFrames(req.TransactionId)
 	if err != nil {
 		return status.Errorf(codes.Internal, "list websocket frames: %v", err)
 	}
@@ -121,14 +121,14 @@ func (s *EngineServer) GetWebSocketFrames(req *apix.GetWebSocketFramesRequest, s
 }
 
 func (s *EngineServer) ClearHistory(ctx context.Context, _ *apix.Empty) (*apix.Empty, error) {
-	if err := s.engine.DB().DeleteAllTransactions(); err != nil {
+	if err := s.db.DeleteAllTransactions(); err != nil {
 		return nil, status.Errorf(codes.Internal, "clear history: %v", err)
 	}
 	return &apix.Empty{}, nil
 }
 
 func (s *EngineServer) ExportHAR(_ context.Context, req *apix.ExportHARRequest) (*apix.ExportHARResponse, error) {
-	requests, responses, err := s.engine.DB().ExportTransactions(req.TransactionIds)
+	requests, responses, err := s.db.ExportTransactions(req.TransactionIds)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "export HAR: %v", err)
 	}
@@ -153,11 +153,11 @@ func (s *EngineServer) ImportHAR(ctx context.Context, req *apix.ImportHARRequest
 		default:
 		}
 
-		if err := s.engine.DB().SaveRequest(tx.Request); err != nil {
+		if err := s.db.SaveRequest(tx.Request); err != nil {
 			return nil, status.Errorf(codes.Internal, "import HAR request: %v", err)
 		}
 		if tx.Response != nil {
-			if err := s.engine.DB().SaveResponse(tx.Response); err != nil {
+			if err := s.db.SaveResponse(tx.Response); err != nil {
 				return nil, status.Errorf(codes.Internal, "import HAR response: %v", err)
 			}
 		}

--- a/internal/server/interfaces.go
+++ b/internal/server/interfaces.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+"github.com/mnafshin/apix/internal/breakpoints"
+"github.com/mnafshin/apix/internal/pluginrt"
+"github.com/mnafshin/apix/internal/storage"
+apix "github.com/mnafshin/apix/pkg/api/generated"
+)
+
+// TrafficSubscriber provides pub/sub for captured HTTP traffic.
+type TrafficSubscriber interface {
+Subscribe() chan *apix.HttpRequest
+Unsubscribe(ch chan *apix.HttpRequest)
+}
+
+// BreakpointManagerServer is the interface EngineServer uses for breakpoint management.
+// *breakpoints.Manager satisfies this interface.
+type BreakpointManagerServer interface {
+AddRule(rule *breakpoints.BreakpointRule) (*breakpoints.BreakpointRule, error)
+RemoveRule(id string) error
+ListRules() []*breakpoints.BreakpointRule
+Subscribe() chan *breakpoints.PausedEntry
+Unsubscribe(ch chan *breakpoints.PausedEntry)
+Resume(requestID string, decision *breakpoints.ResumeDecision) error
+}
+
+// ServerRepository is the storage interface used by all gRPC handlers.
+// *storage.DB satisfies this interface.
+type ServerRepository interface {
+SaveRequest(r *storage.RequestRecord) error
+SaveResponse(r *storage.ResponseRecord) error
+SaveBreakpoint(id, urlPattern string, methods []string, enabled bool, label string) error
+DeleteBreakpoint(id string) error
+ListTransactions(limit, offset int, urlFilter, methodFilter string, statusFilter int, bodyFilter string) ([]*storage.RequestRecord, []*storage.ResponseRecord, error)
+ExportTransactions(transactionIDs []string) ([]*storage.RequestRecord, []*storage.ResponseRecord, error)
+DeleteAllTransactions() error
+AddRewriteRule(rule *apix.RewriteRule) error
+UpdateRewriteRule(rule *apix.RewriteRule) error
+DeleteRewriteRule(id string) error
+GetRewriteRule(id string) (*apix.RewriteRule, error)
+ListRewriteRules() ([]*apix.RewriteRule, error)
+ListWebSocketFrames(transactionID string) ([]*storage.WebSocketFrameRecord, error)
+}
+
+// PluginLister lists installed plugins.
+type PluginLister interface {
+List() []pluginrt.PluginMeta
+}


### PR DESCRIPTION
## Summary

Define four narrow interfaces in `internal/server/interfaces.go` and replace the monolithic `*engine.Engine` field in `EngineServer` with those interfaces.

### New interfaces (`internal/server/interfaces.go`)

| Interface | Methods | Satisfied by |
|---|---|---|
| `TrafficSubscriber` | `Subscribe`, `Unsubscribe` | `*engine.Engine` |
| `BreakpointManagerServer` | `AddRule`, `RemoveRule`, `ListRules`, `Subscribe`, `Unsubscribe`, `Resume` | `*breakpoints.Manager` |
| `ServerRepository` | all storage methods used by gRPC handlers | `*storage.DB` |
| `PluginLister` | `List` | `*pluginrt.Runtime` |

### Changes to `EngineServer`

```go
// Before
type EngineServer struct {
    apix.UnimplementedEngineServer
    engine       *engine.Engine
    replayEngine *replay.Engine
    cfg          *config.Config
}

// After
type EngineServer struct {
    apix.UnimplementedEngineServer
    traffic       TrafficSubscriber
    breakpointMgr BreakpointManagerServer
    db            ServerRepository
    plugins       PluginLister
    replayEngine  *replay.Engine
    cfg           *config.Config
}
```

`NewEngineServer` remains the composition root — it still accepts concrete types and wires them.

All test packages pass.

Closes #209
Closes #210