### PR TITLE
fix(proxy): replace unbounded cert cache with LRU (max 1000) (#181)

### DIFF
--- a/internal/proxy/cert.go
+++ b/internal/proxy/cert.go
@@ -21,7 +21,7 @@ type CertAuthority struct {
 	mu       sync.RWMutex
 	caCert   *x509.Certificate
 	caKey    *rsa.PrivateKey
-	cache    map[string]*tls.Certificate
+	cache    *certLRU
 	certPath string
 	keyPath  string
 }
@@ -29,7 +29,7 @@ type CertAuthority struct {
 // NewCertAuthority loads or generates a CA at the given paths.
 func NewCertAuthority(certPath, keyPath string) (*CertAuthority, error) {
 	ca := &CertAuthority{
-		cache:    make(map[string]*tls.Certificate),
+		cache:    newCertLRU(1000),
 		certPath: certPath,
 		keyPath:  keyPath,
 	}
@@ -131,12 +131,9 @@ func (ca *CertAuthority) save() error {
 
 // CertForHost returns (cached or newly generated) a TLS certificate for host.
 func (ca *CertAuthority) CertForHost(host string) (*tls.Certificate, error) {
-	ca.mu.RLock()
-	if cert, ok := ca.cache[host]; ok {
-		ca.mu.RUnlock()
+	if cert, ok := ca.cache.get(host); ok {
 		return cert, nil
 	}
-	ca.mu.RUnlock()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -174,9 +171,7 @@ func (ca *CertAuthority) CertForHost(host string) (*tls.Certificate, error) {
 		PrivateKey:  key,
 	}
 
-	ca.mu.Lock()
-	ca.cache[host] = tlsCert
-	ca.mu.Unlock()
+	ca.cache.put(host, tlsCert)
 	return tlsCert, nil
 }
 

--- a/internal/proxy/cert_lru.go
+++ b/internal/proxy/cert_lru.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"container/list"
+	"crypto/tls"
+	"sync"
+)
+
+type certLRU struct {
+	capacity int
+	list     *list.List
+	entries  map[string]*list.Element
+	mu       sync.Mutex
+}
+
+type certLRUEntry struct {
+	host string
+	cert *tls.Certificate
+}
+
+func newCertLRU(capacity int) *certLRU {
+	return &certLRU{
+		capacity: capacity,
+		list:     list.New(),
+		entries:  make(map[string]*list.Element),
+	}
+}
+
+func (c *certLRU) get(host string) (*tls.Certificate, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem, ok := c.entries[host]
+	if !ok {
+		return nil, false
+	}
+	c.list.MoveToFront(elem)
+	return elem.Value.(*certLRUEntry).cert, true
+}
+
+func (c *certLRU) put(host string, cert *tls.Certificate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem, ok := c.entries[host]; ok {
+		elem.Value.(*certLRUEntry).cert = cert
+		c.list.MoveToFront(elem)
+		return
+	}
+	if c.list.Len() >= c.capacity {
+		tail := c.list.Back()
+		if tail != nil {
+			c.list.Remove(tail)
+			delete(c.entries, tail.Value.(*certLRUEntry).host)
+		}
+	}
+	elem := c.list.PushFront(&certLRUEntry{host: host, cert: cert})
+	c.entries[host] = elem
+}


### PR DESCRIPTION
Fixes #181 — replaces the unbounded map[string]*tls.Certificate cache in CertAuthority with a bounded LRU (default 1000 entries) using stdlib container/list. Evicts least-recently-used cert when capacity is reached.