### PR TITLE
refactor(engine): simplify header fallback in StoreTransaction (#215)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -67,17 +67,11 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 	req := tx.Request
 	if req != nil {
 		// Prefer storing the original headers captured before plugins modified them.
-		var hdrSrc http.Header
-		if len(tx.OriginalRequestHeaders) > 0 {
-			hdrSrc = tx.OriginalRequestHeaders
-		} else if req.Raw != nil {
-			hdrSrc = req.Raw.Header
-		} else if req.Headers != nil {
-			hdrSrc = req.Headers
-		} else {
-			hdrSrc = http.Header{}
+		var rawHeader http.Header
+		if req.Raw != nil {
+			rawHeader = req.Raw.Header
 		}
-		hdrs := httputil.HeadersToMap(hdrSrc)
+		hdrs := httputil.HeadersToMap(firstNonEmptyHeader(tx.OriginalRequestHeaders, rawHeader, req.Headers))
 
 		rec := &storage.RequestRecord{
 			ID:         tx.ID,

--- a/internal/engine/headers.go
+++ b/internal/engine/headers.go
@@ -1,0 +1,13 @@
+package engine
+
+import "net/http"
+
+// firstNonEmptyHeader returns the first non-empty http.Header from the candidates.
+func firstNonEmptyHeader(candidates ...http.Header) http.Header {
+	for _, h := range candidates {
+		if len(h) > 0 {
+			return h
+		}
+	}
+	return http.Header{}
+}


### PR DESCRIPTION
Fixes #215 — extracts `firstNonEmptyHeader` helper to replace the verbose 4-level if/else chain in `StoreTransaction`. The existing `httputil.HeadersToMap` is reused unchanged.