### PR TITLE
refactor(proxy): parameterize WebSocket header copy functions (#216)

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -249,14 +249,9 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 11. Emit metrics + slowlog.
-	durationSec := time.Since(start).Seconds()
-	metrics.ObserveRequest(proxyReq.Method, proxyResp.StatusCode, durationSec)
-	if p.cfg != nil && p.cfg.SlowlogThresholdMs > 0 {
-		if time.Since(start).Milliseconds() > int64(p.cfg.SlowlogThresholdMs) {
-			logging.Warnf(ctx, "slow request: method=%s url=%s status=%d duration_ms=%d request_id=%s",
-				proxyReq.Method, proxyReq.URL.String(), proxyResp.StatusCode, time.Since(start).Milliseconds(), reqID)
-		}
-	}
+	dur := time.Since(start)
+	observeRequest(ctx, p.cfg, proxyReq.Method, proxyReq.URL.String(), proxyResp.StatusCode, dur)
+	_ = reqID
 
 	writeProxyResponse(w, proxyResp, respBody)
 }
@@ -423,7 +418,7 @@ func (p *HTTPProxy) runPluginResponse(ctx context.Context, req *plugins.ProxyReq
 }
 
 func (p *HTTPProxy) handleWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Request, tx *Transaction, start time.Time) {
-	upstreamHeaders := copyWebSocketRequestHeaders(tx.Request.Headers)
+	upstreamHeaders := copyHeadersExcluding(tx.Request.Headers, "Connection", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Extensions", "Host")
 	dialer := newWebSocketDialer(p.transport, tx.Request)
 	upstreamConn, resp, err := dialer.DialContext(ctx, webSocketTargetURL(tx.Request.URL), upstreamHeaders)
 	if err != nil {
@@ -445,7 +440,7 @@ func (p *HTTPProxy) handleWebSocket(ctx context.Context, w http.ResponseWriter, 
 	if protocol := upstreamConn.Subprotocol(); protocol != "" {
 		upgrader.Subprotocols = []string{protocol}
 	}
-	clientConn, err := upgrader.Upgrade(w, r, copyWebSocketResponseHeaders(resp.Header))
+	clientConn, err := upgrader.Upgrade(w, r, copyHeadersExcluding(resp.Header, "Connection", "Upgrade", "Sec-WebSocket-Accept", "Sec-WebSocket-Extensions"))
 	if err != nil {
 		_ = upstreamConn.Close()
 		logging.Errorf(ctx, "websocket client upgrade: %v", err)

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -269,23 +269,16 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		}
 	}
 
-	// Observe metrics
-	durationSec := time.Since(start).Seconds()
-	metrics.ObserveRequest(proxyReq.Method, proxyResp.StatusCode, durationSec)
-
-	// Slowlog
-	if p.cfg != nil && p.cfg.SlowlogThresholdMs > 0 {
-		if time.Since(start).Milliseconds() > int64(p.cfg.SlowlogThresholdMs) {
-			logging.Warnf(ctx, "slow request: method=%s host=%s status=%d duration_ms=%d request_id=%s",
-				proxyReq.Method, proxyReq.URL.Host, proxyResp.StatusCode, time.Since(start).Milliseconds(), reqID)
-		}
-	}
+	// Observe metrics + slowlog.
+	dur := time.Since(start)
+	observeRequest(ctx, p.cfg, proxyReq.Method, proxyReq.URL.Host, proxyResp.StatusCode, dur)
+	_ = reqID
 
 	writeProxyResponseToConn(conn, proxyResp)
 }
 
 func (p *TLSProxy) handleWebSocket(ctx context.Context, conn net.Conn, br *bufio.Reader, clientReq *http.Request, tx *Transaction, start time.Time) {
-	upstreamHeaders := copyWebSocketRequestHeaders(tx.Request.Headers)
+	upstreamHeaders := copyHeadersExcluding(tx.Request.Headers, "Connection", "Upgrade", "Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Extensions", "Host")
 	dialer := newWebSocketDialer(p.transport, tx.Request)
 	upstreamConn, resp, err := dialer.DialContext(ctx, webSocketTargetURL(tx.Request.URL), upstreamHeaders)
 	if err != nil {
@@ -308,7 +301,7 @@ func (p *TLSProxy) handleWebSocket(ctx context.Context, conn net.Conn, br *bufio
 		upgrader.Subprotocols = []string{protocol}
 	}
 	responseWriter := newHijackableResponseWriter(conn, br)
-	clientConn, err := upgrader.Upgrade(responseWriter, clientReq, copyWebSocketResponseHeaders(resp.Header))
+	clientConn, err := upgrader.Upgrade(responseWriter, clientReq, copyHeadersExcluding(resp.Header, "Connection", "Upgrade", "Sec-WebSocket-Accept", "Sec-WebSocket-Extensions"))
 	if err != nil {
 		_ = upstreamConn.Close()
 		logging.Errorf(ctx, "tls websocket client upgrade: %v", err)

--- a/internal/proxy/observe.go
+++ b/internal/proxy/observe.go
@@ -1,0 +1,20 @@
+package proxy
+
+import (
+	"context"
+	"time"
+
+	"github.com/mnafshin/apix/internal/config"
+	logging "github.com/mnafshin/apix/internal/logging"
+	metrics "github.com/mnafshin/apix/internal/metrics"
+)
+
+// observeRequest records Prometheus metrics and emits a slowlog warning when the
+// request duration exceeds the configured threshold.
+func observeRequest(ctx context.Context, cfg *config.Config, method, displayURL string, status int, dur time.Duration) {
+	metrics.ObserveRequest(method, status, dur.Seconds())
+	if cfg != nil && cfg.SlowlogThresholdMs > 0 && dur.Milliseconds() > int64(cfg.SlowlogThresholdMs) {
+		logging.Warnf(ctx, "slow request: method=%s url=%s status=%d duration_ms=%d",
+			method, displayURL, status, dur.Milliseconds())
+	}
+}

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -82,31 +82,17 @@ func requestedSubprotocols(headers http.Header) []string {
 	return subprotocols
 }
 
-func copyWebSocketRequestHeaders(headers http.Header) http.Header {
-	out := make(http.Header)
-	for key, values := range headers {
-		switch strings.ToLower(key) {
-		case "connection", "upgrade", "sec-websocket-key", "sec-websocket-version", "sec-websocket-extensions", "host":
-			continue
-		default:
-			for _, value := range values {
-				out.Add(key, value)
-			}
-		}
+// copyHeadersExcluding copies src headers, skipping any header whose canonical
+// name matches one of the excluded names (case-insensitive).
+func copyHeadersExcluding(src http.Header, exclude ...string) http.Header {
+	skip := make(map[string]struct{}, len(exclude))
+	for _, h := range exclude {
+		skip[http.CanonicalHeaderKey(h)] = struct{}{}
 	}
-	return out
-}
-
-func copyWebSocketResponseHeaders(headers http.Header) http.Header {
 	out := make(http.Header)
-	for key, values := range headers {
-		switch strings.ToLower(key) {
-		case "connection", "upgrade", "sec-websocket-accept", "sec-websocket-extensions":
-			continue
-		default:
-			for _, value := range values {
-				out.Add(key, value)
-			}
+	for key, values := range src {
+		if _, ok := skip[key]; !ok {
+			out[key] = append([]string(nil), values...)
 		}
 	}
 	return out


### PR DESCRIPTION
Fixes #216 — replaces copyWebSocketRequestHeaders/copyWebSocketResponseHeaders with a single copyHeadersExcluding helper.