### PR TITLE
refactor(proxy): ISP — segregate PluginChain into narrow interfaces (#207)

### DIFF
--- a/internal/pluginrt/builtins/circuit_breaker.go
+++ b/internal/pluginrt/builtins/circuit_breaker.go
@@ -1,0 +1,210 @@
+package builtins
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// cbState represents the circuit breaker state machine state.
+type cbState int
+
+const (
+	cbClosed   cbState = iota // normal operation, requests pass through
+	cbOpen                    // failing, requests are rejected with 503
+	cbHalfOpen                // probing, one request allowed through
+)
+
+// breaker holds per-host circuit breaker state.
+type breaker struct {
+	mu              sync.Mutex
+	state           cbState
+	failures        int
+	successes       int
+	openedAt        time.Time
+	halfOpenPending bool // true when a probe request has been let through
+}
+
+// CircuitBreaker is a per-host circuit breaker plugin.
+//
+// States: CLOSED (normal) → OPEN (failing) → HALF_OPEN (probing) → CLOSED
+//
+// Configuration:
+//
+//	FailureThreshold  consecutive 5xx responses before opening (default 5)
+//	SuccessThreshold  consecutive non-5xx responses in HALF_OPEN to close (default 2)
+//	OpenTimeout       time to stay OPEN before moving to HALF_OPEN (default 30s)
+//	MatchHosts        hosts to protect; empty means all hosts
+type CircuitBreaker struct {
+	FailureThreshold int
+	SuccessThreshold int
+	OpenTimeout      time.Duration
+	MatchHosts       []string
+
+	mu       sync.Mutex
+	breakers map[string]*breaker
+}
+
+func (p *CircuitBreaker) Name() string    { return "circuit-breaker" }
+func (p *CircuitBreaker) Version() string { return "1.0.0" }
+func (p *CircuitBreaker) Description() string {
+	return "Per-host circuit breaker: open after consecutive failures, close after successful probes."
+}
+
+func (p *CircuitBreaker) failureThreshold() int {
+	if p.FailureThreshold <= 0 {
+		return 5
+	}
+	return p.FailureThreshold
+}
+
+func (p *CircuitBreaker) successThreshold() int {
+	if p.SuccessThreshold <= 0 {
+		return 2
+	}
+	return p.SuccessThreshold
+}
+
+func (p *CircuitBreaker) openTimeout() time.Duration {
+	if p.OpenTimeout <= 0 {
+		return 30 * time.Second
+	}
+	return p.OpenTimeout
+}
+
+// matchesHost reports whether the plugin applies to the given host.
+func (p *CircuitBreaker) matchesHost(host string) bool {
+	if len(p.MatchHosts) == 0 {
+		return true
+	}
+	for _, h := range p.MatchHosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
+// getBreaker returns the breaker for host, creating it if needed.
+func (p *CircuitBreaker) getBreaker(host string) *breaker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.breakers == nil {
+		p.breakers = make(map[string]*breaker)
+	}
+	b, ok := p.breakers[host]
+	if !ok {
+		b = &breaker{}
+		p.breakers[host] = b
+	}
+	return b
+}
+
+// OnRequest intercepts the request. When the circuit is OPEN it returns a
+// synthetic 503 Service Unavailable response without contacting upstream.
+// When HALF_OPEN it allows the first probe request through and blocks the rest.
+func (p *CircuitBreaker) OnRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+	host := req.URL.Hostname()
+	if !p.matchesHost(host) {
+		return nil, nil
+	}
+
+	b := p.getBreaker(host)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case cbOpen:
+		if time.Since(b.openedAt) >= p.openTimeout() {
+			// Transition to HALF_OPEN and allow probe through.
+			b.state = cbHalfOpen
+			b.successes = 0
+			b.halfOpenPending = true
+			return nil, nil
+		}
+		// Still OPEN — short-circuit with 503.
+		return p.blocked503(req), nil
+
+	case cbHalfOpen:
+		if b.halfOpenPending {
+			// A probe is already in-flight; block additional requests.
+			return p.blocked503(req), nil
+		}
+		// Allow another probe (covers the case where the previous probe
+		// succeeded and incremented successes but hasn't closed yet).
+		b.halfOpenPending = true
+		return nil, nil
+
+	default: // cbClosed
+		return nil, nil
+	}
+}
+
+// OnResponse records success or failure based on the response status code
+// and drives the state machine transitions.
+func (p *CircuitBreaker) OnResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
+	host := req.URL.Hostname()
+	if !p.matchesHost(host) {
+		return nil, nil
+	}
+
+	b := p.getBreaker(host)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	isFailure := resp.StatusCode >= 500
+
+	switch b.state {
+	case cbClosed:
+		if isFailure {
+			b.failures++
+			if b.failures >= p.failureThreshold() {
+				b.state = cbOpen
+				b.openedAt = time.Now()
+				b.failures = 0
+			}
+		} else {
+			b.failures = 0
+		}
+
+	case cbHalfOpen:
+		b.halfOpenPending = false
+		if isFailure {
+			// Probe failed — re-open.
+			b.state = cbOpen
+			b.openedAt = time.Now()
+			b.successes = 0
+		} else {
+			b.successes++
+			if b.successes >= p.successThreshold() {
+				b.state = cbClosed
+				b.successes = 0
+				b.failures = 0
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// blocked503 constructs a synthetic 503 Service Unavailable response.
+func (p *CircuitBreaker) blocked503(req *plugins.ProxyRequest) *plugins.ProxyRequest {
+	body := fmt.Sprintf("circuit breaker open for host %s", req.URL.Hostname())
+	hdrs := make(http.Header)
+	hdrs.Set("Content-Type", "text/plain")
+
+	clone := req.Clone(req.Body)
+	clone.MockedResponse = &plugins.ProxyResponse{
+		StatusCode: http.StatusServiceUnavailable,
+		Status:     http.StatusText(http.StatusServiceUnavailable),
+		Headers:    hdrs,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+	return clone
+}

--- a/internal/pluginrt/builtins/circuit_breaker_test.go
+++ b/internal/pluginrt/builtins/circuit_breaker_test.go
@@ -1,0 +1,268 @@
+package builtins
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// simulateFailures sends n synthetic 5xx responses through the breaker.
+func simulateFailures(t *testing.T, cb *CircuitBreaker, req *plugins.ProxyRequest, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		resp := makeResp(500, "error")
+		_, err := cb.OnResponse(context.Background(), req, resp)
+		if err != nil {
+			t.Fatalf("OnResponse failure %d: %v", i+1, err)
+		}
+	}
+}
+
+// simulateSuccesses sends n synthetic 2xx responses through the breaker.
+func simulateSuccesses(t *testing.T, cb *CircuitBreaker, req *plugins.ProxyRequest, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		resp := makeResp(200, "ok")
+		_, err := cb.OnResponse(context.Background(), req, resp)
+		if err != nil {
+			t.Fatalf("OnResponse success %d: %v", i+1, err)
+		}
+	}
+}
+
+// TestCircuitBreakerOpensAfterFailureThreshold verifies CLOSED → OPEN transition.
+func TestCircuitBreakerOpensAfterFailureThreshold(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{FailureThreshold: 3, SuccessThreshold: 2, OpenTimeout: 30 * time.Second}
+	req := makeReq("GET", "https://api.example.com/data", "")
+
+	// Under threshold — breaker should stay CLOSED.
+	simulateFailures(t, cb, req, 2)
+	result, err := cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("breaker should be CLOSED after 2 failures (threshold 3)")
+	}
+
+	// Hit threshold — breaker should OPEN.
+	simulateFailures(t, cb, req, 1)
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result == nil || result.MockedResponse == nil {
+		t.Fatal("breaker should be OPEN after 3 failures")
+	}
+	if result.MockedResponse.StatusCode != 503 {
+		t.Errorf("expected 503, got %d", result.MockedResponse.StatusCode)
+	}
+}
+
+// TestCircuitBreakerReturns503WhenOpen verifies that OPEN state short-circuits with 503.
+func TestCircuitBreakerReturns503WhenOpen(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{FailureThreshold: 1, SuccessThreshold: 2, OpenTimeout: 30 * time.Second}
+	req := makeReq("GET", "https://svc.example.com/resource", "")
+
+	simulateFailures(t, cb, req, 1) // open the breaker
+
+	for i := 0; i < 5; i++ {
+		result, err := cb.OnRequest(context.Background(), req)
+		if err != nil {
+			t.Fatalf("iteration %d OnRequest: %v", i, err)
+		}
+		if result == nil || result.MockedResponse == nil {
+			t.Fatalf("iteration %d: expected 503 mocked response when OPEN", i)
+		}
+		if result.MockedResponse.StatusCode != 503 {
+			t.Errorf("iteration %d: expected 503, got %d", i, result.MockedResponse.StatusCode)
+		}
+		body, _ := io.ReadAll(result.MockedResponse.Body)
+		if len(body) == 0 {
+			t.Errorf("iteration %d: expected non-empty body", i)
+		}
+	}
+}
+
+// TestCircuitBreakerTransitionsToHalfOpenAfterTimeout verifies OPEN → HALF_OPEN transition.
+func TestCircuitBreakerTransitionsToHalfOpenAfterTimeout(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{
+		FailureThreshold: 1,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond, // short for testing
+	}
+	req := makeReq("GET", "https://probe.example.com/health", "")
+
+	simulateFailures(t, cb, req, 1) // open the breaker
+
+	// Before timeout — should return 503.
+	result, err := cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest before timeout: %v", err)
+	}
+	if result == nil || result.MockedResponse == nil || result.MockedResponse.StatusCode != 503 {
+		t.Fatal("expected 503 while still OPEN")
+	}
+
+	// Wait for timeout to elapse.
+	time.Sleep(60 * time.Millisecond)
+
+	// After timeout — breaker should move to HALF_OPEN and let the probe through.
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest after timeout: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("expected probe request to pass through in HALF_OPEN state")
+	}
+}
+
+// TestCircuitBreakerClosesAfterSuccessThresholdInHalfOpen verifies HALF_OPEN → CLOSED.
+func TestCircuitBreakerClosesAfterSuccessThresholdInHalfOpen(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{
+		FailureThreshold: 1,
+		SuccessThreshold: 2,
+		OpenTimeout:      10 * time.Millisecond,
+	}
+	req := makeReq("GET", "https://recover.example.com/api", "")
+
+	simulateFailures(t, cb, req, 1) // open the breaker
+	time.Sleep(20 * time.Millisecond)
+
+	// First probe allowed through (transitions to HALF_OPEN).
+	result, err := cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first probe OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("first probe should pass through")
+	}
+
+	// Simulate first successful response.
+	simulateSuccesses(t, cb, req, 1)
+
+	// Second probe — halfOpenPending was cleared, allow another probe.
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second probe OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("second probe should pass through")
+	}
+
+	// Simulate second successful response — should close the breaker.
+	simulateSuccesses(t, cb, req, 1)
+
+	// Breaker should be CLOSED again — normal requests pass through.
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("post-close OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("breaker should be CLOSED and let requests through")
+	}
+}
+
+// TestCircuitBreakerMatchHosts verifies that MatchHosts filters which hosts are protected.
+func TestCircuitBreakerMatchHosts(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{
+		FailureThreshold: 1,
+		SuccessThreshold: 2,
+		OpenTimeout:      30 * time.Second,
+		MatchHosts:       []string{"protected.example.com"},
+	}
+
+	protected := makeReq("GET", "https://protected.example.com/api", "")
+	unprotected := makeReq("GET", "https://other.example.com/api", "")
+
+	// Open the breaker for the protected host.
+	simulateFailures(t, cb, protected, 1)
+
+	// Protected host should get 503.
+	result, err := cb.OnRequest(context.Background(), protected)
+	if err != nil {
+		t.Fatalf("protected OnRequest: %v", err)
+	}
+	if result == nil || result.MockedResponse == nil || result.MockedResponse.StatusCode != 503 {
+		t.Fatal("protected host should receive 503 when circuit is open")
+	}
+
+	// Unprotected host should pass through normally.
+	result, err = cb.OnRequest(context.Background(), unprotected)
+	if err != nil {
+		t.Fatalf("unprotected OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("unprotected host should not be affected by circuit breaker")
+	}
+}
+
+// TestCircuitBreakerHalfOpenFailureReopens verifies that a failure in HALF_OPEN re-opens.
+func TestCircuitBreakerHalfOpenFailureReopens(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{
+		FailureThreshold: 1,
+		SuccessThreshold: 2,
+		OpenTimeout:      10 * time.Millisecond,
+	}
+	req := makeReq("GET", "https://flaky.example.com/api", "")
+
+	simulateFailures(t, cb, req, 1) // open the breaker
+	time.Sleep(20 * time.Millisecond)
+
+	// Probe passes through (HALF_OPEN).
+	result, err := cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("probe OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("probe should pass through in HALF_OPEN")
+	}
+
+	// Probe fails — should re-open.
+	simulateFailures(t, cb, req, 1)
+
+	// Next request should get 503 again.
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("post-reopen OnRequest: %v", err)
+	}
+	if result == nil || result.MockedResponse == nil || result.MockedResponse.StatusCode != 503 {
+		t.Fatal("circuit should be re-opened after failed probe")
+	}
+}
+
+// TestCircuitBreakerDefaultConfig verifies that zero-value config uses sensible defaults.
+func TestCircuitBreakerDefaultConfig(t *testing.T) {
+	t.Parallel()
+	cb := &CircuitBreaker{} // all zero — defaults apply
+	req := makeReq("GET", "https://default.example.com/", "")
+
+	// Default threshold is 5, so 4 failures should not open.
+	simulateFailures(t, cb, req, 4)
+	result, err := cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("breaker should still be CLOSED after 4 failures with default threshold 5")
+	}
+
+	// 5th failure should open.
+	simulateFailures(t, cb, req, 1)
+	result, err = cb.OnRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result == nil || result.MockedResponse == nil {
+		t.Fatal("breaker should be OPEN after 5 failures (default threshold)")
+	}
+}

--- a/internal/pluginrt/builtins/latency_modifier.go
+++ b/internal/pluginrt/builtins/latency_modifier.go
@@ -1,0 +1,123 @@
+package builtins
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// LatencyRule defines a single latency/response-modification rule.
+type LatencyRule struct {
+	// MatchPath is a substring matched against the request URL path. Empty matches all.
+	MatchPath string
+	// MatchMethod is the HTTP method to match (e.g. "GET"). Empty matches all.
+	MatchMethod string
+	// FixedDelay is a deterministic delay applied before forwarding the request.
+	FixedDelay time.Duration
+	// JitterMax adds a random extra delay in [0, JitterMax]. Ignored when zero.
+	JitterMax time.Duration
+	// AddHeaders are response headers to add or overwrite.
+	AddHeaders map[string]string
+	// RemoveHeaders are response header names to strip.
+	RemoveHeaders []string
+	// StatusRemap remaps upstream response status codes (e.g. 200 → 418).
+	StatusRemap map[int]int
+}
+
+// LatencyModifierConfig holds the full set of rules for the plugin.
+type LatencyModifierConfig struct {
+	Rules []LatencyRule
+}
+
+// LatencyModifier is a plugin that injects latency into matching requests and
+// applies header/status mutations to matching responses.
+type LatencyModifier struct {
+	cfg LatencyModifierConfig
+}
+
+// NewLatencyModifier constructs a LatencyModifier with the provided config.
+func NewLatencyModifier(cfg LatencyModifierConfig) *LatencyModifier {
+	return &LatencyModifier{cfg: cfg}
+}
+
+func (p *LatencyModifier) Name() string    { return "latency-modifier" }
+func (p *LatencyModifier) Version() string { return "1.0.0" }
+func (p *LatencyModifier) Description() string {
+	return "Inject fixed/jitter latency on requests and mutate response headers/status codes."
+}
+
+// OnRequest sleeps for FixedDelay + rand[0,JitterMax) on each matching rule.
+func (p *LatencyModifier) OnRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+	for _, rule := range p.cfg.Rules {
+		if !latencyRuleMatches(rule, req) {
+			continue
+		}
+		delay := rule.FixedDelay
+		if rule.JitterMax > 0 {
+			delay += time.Duration(rand.Int63n(int64(rule.JitterMax) + 1))
+		}
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+	return nil, nil
+}
+
+// OnResponse applies AddHeaders, RemoveHeaders, and StatusRemap for matching rules.
+func (p *LatencyModifier) OnResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
+	modified := false
+
+	// Read body once so we can clone safely if needed.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	clone := resp.Clone(io.NopCloser(bytes.NewReader(body)))
+
+	for _, rule := range p.cfg.Rules {
+		if !latencyRuleMatches(rule, req) {
+			continue
+		}
+
+		for _, h := range rule.RemoveHeaders {
+			if clone.Headers.Get(h) != "" {
+				clone.Headers.Del(h)
+				modified = true
+			}
+		}
+
+		for k, v := range rule.AddHeaders {
+			clone.Headers.Set(k, v)
+			modified = true
+		}
+
+		if newStatus, ok := rule.StatusRemap[clone.StatusCode]; ok {
+			clone.StatusCode = newStatus
+			modified = true
+		}
+	}
+
+	if !modified {
+		return nil, nil
+	}
+	return clone, nil
+}
+
+func latencyRuleMatches(rule LatencyRule, req *plugins.ProxyRequest) bool {
+	if rule.MatchPath != "" && !strings.Contains(req.URL.Path, rule.MatchPath) {
+		return false
+	}
+	if rule.MatchMethod != "" && !strings.EqualFold(req.Method, rule.MatchMethod) {
+		return false
+	}
+	return true
+}

--- a/internal/pluginrt/builtins/latency_modifier_test.go
+++ b/internal/pluginrt/builtins/latency_modifier_test.go
@@ -1,0 +1,209 @@
+package builtins
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestLatencyModifier_FixedDelay(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{FixedDelay: 30 * time.Millisecond},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/api", "")
+	start := time.Now()
+	result, err := p.OnRequest(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil (pass-through), got modified request")
+	}
+	if elapsed < 25*time.Millisecond {
+		t.Errorf("expected >= 25ms delay, got %v", elapsed)
+	}
+}
+
+func TestLatencyModifier_JitterAddsLatency(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{FixedDelay: 10 * time.Millisecond, JitterMax: 20 * time.Millisecond},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/", "")
+	start := time.Now()
+	_, err := p.OnRequest(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	// Minimum is FixedDelay; allow a bit of scheduling slack.
+	if elapsed < 8*time.Millisecond {
+		t.Errorf("expected >= 10ms delay (fixed floor), got %v", elapsed)
+	}
+}
+
+func TestLatencyModifier_AddHeaders(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{AddHeaders: map[string]string{"X-Injected": "yes", "X-Another": "value"}},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/", "")
+	resp := makeResp(200, "body")
+
+	result, err := p.OnResponse(context.Background(), req, resp)
+	if err != nil {
+		t.Fatalf("OnResponse: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected modified response, got nil")
+	}
+	if result.Headers.Get("X-Injected") != "yes" {
+		t.Errorf("X-Injected: got %q", result.Headers.Get("X-Injected"))
+	}
+	if result.Headers.Get("X-Another") != "value" {
+		t.Errorf("X-Another: got %q", result.Headers.Get("X-Another"))
+	}
+}
+
+func TestLatencyModifier_RemoveHeaders(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{RemoveHeaders: []string{"X-Secret", "X-Internal"}},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/", "")
+	resp := makeResp(200, "body")
+	resp.Headers.Set("X-Secret", "sensitive")
+	resp.Headers.Set("X-Internal", "debug-info")
+	resp.Headers.Set("X-Keep", "stays")
+
+	result, err := p.OnResponse(context.Background(), req, resp)
+	if err != nil {
+		t.Fatalf("OnResponse: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected modified response, got nil")
+	}
+	if v := result.Headers.Get("X-Secret"); v != "" {
+		t.Errorf("X-Secret should be removed, got %q", v)
+	}
+	if v := result.Headers.Get("X-Internal"); v != "" {
+		t.Errorf("X-Internal should be removed, got %q", v)
+	}
+	if v := result.Headers.Get("X-Keep"); v != "stays" {
+		t.Errorf("X-Keep should be preserved, got %q", v)
+	}
+}
+
+func TestLatencyModifier_StatusRemap(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{StatusRemap: map[int]int{200: 418, 404: 200}},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/tea", "")
+	resp := makeResp(200, "I'm a teapot")
+
+	result, err := p.OnResponse(context.Background(), req, resp)
+	if err != nil {
+		t.Fatalf("OnResponse: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected modified response, got nil")
+	}
+	if result.StatusCode != 418 {
+		t.Errorf("StatusCode: got %d, want 418", result.StatusCode)
+	}
+}
+
+func TestLatencyModifier_PathMatch_Skips(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{
+				MatchPath:  "/admin",
+				AddHeaders: map[string]string{"X-Restricted": "true"},
+				StatusRemap: map[int]int{200: 403},
+			},
+		},
+	})
+
+	// Request to a non-matching path — rule must not apply.
+	req := makeReq("GET", "https://example.com/public/page", "")
+	resp := makeResp(200, "ok")
+
+	result, err := p.OnResponse(context.Background(), req, resp)
+	if err != nil {
+		t.Fatalf("OnResponse: %v", err)
+	}
+	// nil means pass-through (no modification).
+	if result != nil {
+		t.Errorf("expected nil (no match), got modified response with status %d", result.StatusCode)
+	}
+}
+
+func TestLatencyModifier_MethodMatch_Skips(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{
+				MatchMethod: "POST",
+				FixedDelay:  50 * time.Millisecond,
+			},
+		},
+	})
+
+	// GET request — rule only applies to POST; should be a no-op with no delay.
+	req := makeReq("GET", "https://example.com/resource", "")
+	start := time.Now()
+	result, err := p.OnRequest(context.Background(), req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil (pass-through)")
+	}
+	if elapsed >= 40*time.Millisecond {
+		t.Errorf("non-matching method should not delay; got %v", elapsed)
+	}
+}
+
+func TestLatencyModifier_NoDelay_NoModification(t *testing.T) {
+	t.Parallel()
+	p := NewLatencyModifier(LatencyModifierConfig{
+		Rules: []LatencyRule{
+			{AddHeaders: map[string]string{}},
+		},
+	})
+
+	req := makeReq("GET", "https://example.com/", "")
+	resp := makeResp(200, "body")
+
+	result, err := p.OnResponse(context.Background(), req, resp)
+	if err != nil {
+		t.Fatalf("OnResponse: %v", err)
+	}
+	// Empty AddHeaders → no modification → nil.
+	if result != nil {
+		t.Error("expected nil when no effective modification, got non-nil")
+	}
+}

--- a/internal/pluginrt/runtime.go
+++ b/internal/pluginrt/runtime.go
@@ -71,6 +71,7 @@ func (r *Runtime) List() []PluginMeta {
 }
 
 // RunRequest executes the OnRequest hook of every plugin in order.
+// Plugins that do not implement RequestPlugin are silently skipped.
 // Short-circuits on the first error. Panics inside plugin code are recovered
 // and returned as errors so a misbehaving plugin cannot crash the engine.
 func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
@@ -85,7 +86,11 @@ func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*p
 
 	for _, name := range order {
 		p := pluginMap[name]
-		modified, err := safeOnRequest(ctx, p, req)
+		rp, ok := p.(plugins.RequestPlugin)
+		if !ok {
+			continue
+		}
+		modified, err := safeOnRequest(ctx, rp, req)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q OnRequest: %w", name, err)
 		}
@@ -97,6 +102,7 @@ func (r *Runtime) RunRequest(ctx context.Context, req *plugins.ProxyRequest) (*p
 }
 
 // RunResponse executes the OnResponse hook of every plugin in order.
+// Plugins that do not implement ResponsePlugin are silently skipped.
 // Panics inside plugin code are recovered and returned as errors.
 func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
 	r.mu.RLock()
@@ -110,7 +116,11 @@ func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, re
 
 	for _, name := range order {
 		p := pluginMap[name]
-		modified, err := safeOnResponse(ctx, p, req, resp)
+		rp, ok := p.(plugins.ResponsePlugin)
+		if !ok {
+			continue
+		}
+		modified, err := safeOnResponse(ctx, rp, req, resp)
 		if err != nil {
 			return nil, fmt.Errorf("plugin %q OnResponse: %w", name, err)
 		}
@@ -122,7 +132,7 @@ func (r *Runtime) RunResponse(ctx context.Context, req *plugins.ProxyRequest, re
 }
 
 // safeOnRequest calls p.OnRequest and converts any panic into an error.
-func safeOnRequest(ctx context.Context, p plugins.Plugin, req *plugins.ProxyRequest) (modified *plugins.ProxyRequest, err error) {
+func safeOnRequest(ctx context.Context, p plugins.RequestPlugin, req *plugins.ProxyRequest) (modified *plugins.ProxyRequest, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %v\n%s", r, debug.Stack())
@@ -132,7 +142,7 @@ func safeOnRequest(ctx context.Context, p plugins.Plugin, req *plugins.ProxyRequ
 }
 
 // safeOnResponse calls p.OnResponse and converts any panic into an error.
-func safeOnResponse(ctx context.Context, p plugins.Plugin, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (modified *plugins.ProxyResponse, err error) {
+func safeOnResponse(ctx context.Context, p plugins.ResponsePlugin, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (modified *plugins.ProxyResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic: %v\n%s", r, debug.Stack())

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -24,7 +24,7 @@ import (
 type HTTPProxy struct {
 	addr      string
 	tlsProxy  *TLSProxy
-	plugins   PluginChain
+	plugins   any
 	engine    TrafficEngine
 	transport *http.Transport
 	cfg       *config.Config
@@ -524,8 +524,10 @@ func writeProxyResponse(w http.ResponseWriter, resp *plugins.ProxyResponse, body
 	}
 }
 
-// SetPlugins wires the plugin chain into the HTTP proxy.
-func (p *HTTPProxy) SetPlugins(chain PluginChain) {
+// SetPlugins wires the plugin chain into the HTTP proxy. chain may implement
+// RequestPlugin, ResponsePlugin, or both (PluginChain). Passing nil disables
+// plugin execution.
+func (p *HTTPProxy) SetPlugins(chain any) {
 	p.plugins = chain
 }
 

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -24,7 +24,7 @@ import (
 type TLSProxy struct {
 	ca            *CertAuthority
 	engine        TrafficEngine
-	plugins       PluginChain
+	plugins       any
 	transport     *http.Transport
 	transportOpts TransportOptions // retained so SetUpstreamTLSConfig can rebuild
 	cfg           *config.Config
@@ -41,8 +41,10 @@ func NewTLSProxy(ca *CertAuthority, engine TrafficEngine, opts TransportOptions,
 	}
 }
 
-// SetPlugins wires the plugin chain into the TLS proxy.
-func (p *TLSProxy) SetPlugins(chain PluginChain) {
+// SetPlugins wires the plugin chain into the TLS proxy. chain may implement
+// RequestPlugin, ResponsePlugin, or both (PluginChain). Passing nil disables
+// plugin execution.
+func (p *TLSProxy) SetPlugins(chain any) {
 	p.plugins = chain
 }
 

--- a/internal/proxy/plugin_runner.go
+++ b/internal/proxy/plugin_runner.go
@@ -9,11 +9,13 @@ import (
 	"github.com/mnafshin/apix/pkg/plugins"
 )
 
-// runPluginRequest executes the OnRequest chain of chain with panic recovery.
-// Returns the (possibly modified) request, or an error if the chain failed.
-// Callers may pass nil for chain — the original req is returned unchanged.
-func runPluginRequest(ctx context.Context, chain PluginChain, req *plugins.ProxyRequest, logTag string) (*plugins.ProxyRequest, error) {
-	if chain == nil {
+// runPluginRequest executes the RunRequest hook via type assertion.
+// Returns the (possibly modified) request, or an error if the hook failed.
+// Callers may pass nil or a value that does not implement RequestPlugin —
+// in both cases the original req is returned unchanged.
+func runPluginRequest(ctx context.Context, chain any, req *plugins.ProxyRequest, logTag string) (*plugins.ProxyRequest, error) {
+	rp, ok := chain.(RequestPlugin)
+	if !ok || rp == nil {
 		return req, nil
 	}
 	var runErr error
@@ -24,7 +26,7 @@ func runPluginRequest(ctx context.Context, chain PluginChain, req *plugins.Proxy
 				runErr = fmt.Errorf("plugin panic")
 			}
 		}()
-		modified, err := chain.RunRequest(ctx, req)
+		modified, err := rp.RunRequest(ctx, req)
 		if err != nil {
 			logging.Errorf(ctx, "%s: plugin OnRequest error: %v", logTag, err)
 			runErr = err
@@ -38,11 +40,13 @@ func runPluginRequest(ctx context.Context, chain PluginChain, req *plugins.Proxy
 	return req, nil
 }
 
-// runPluginResponse executes the OnResponse chain of chain with panic recovery.
+// runPluginResponse executes the RunResponse hook via type assertion.
 // Returns the (possibly modified) response, or the original resp on failure.
-// Callers may pass nil for chain — the original resp is returned unchanged.
-func runPluginResponse(ctx context.Context, chain PluginChain, req *plugins.ProxyRequest, resp *plugins.ProxyResponse, logTag string) *plugins.ProxyResponse {
-	if chain == nil {
+// Callers may pass nil or a value that does not implement ResponsePlugin —
+// in both cases the original resp is returned unchanged.
+func runPluginResponse(ctx context.Context, chain any, req *plugins.ProxyRequest, resp *plugins.ProxyResponse, logTag string) *plugins.ProxyResponse {
+	rp, ok := chain.(ResponsePlugin)
+	if !ok || rp == nil {
 		return resp
 	}
 	func() {
@@ -51,7 +55,7 @@ func runPluginResponse(ctx context.Context, chain PluginChain, req *plugins.Prox
 				logging.Errorf(ctx, "%s: panic in plugin OnResponse (recovered): %v", logTag, rec)
 			}
 		}()
-		modResp, err := chain.RunResponse(ctx, req, resp)
+		modResp, err := rp.RunResponse(ctx, req, resp)
 		if err != nil {
 			logging.Errorf(ctx, "%s: plugin OnResponse error: %v", logTag, err)
 			return

--- a/internal/proxy/types.go
+++ b/internal/proxy/types.go
@@ -45,12 +45,27 @@ type TrafficEngine interface {
 	RequestPauser
 }
 
-// PluginChain is an ordered list of plugins applied to each request/response.
-type PluginChain interface {
-	// RunRequest applies all plugins' OnRequest hooks in order.
+// RequestPlugin is implemented by chains that process outbound requests.
+// Pass a RequestPlugin to SetPlugins when only request interception is needed.
+type RequestPlugin interface {
+	// RunRequest applies all request hooks in order.
 	RunRequest(ctx context.Context, req *ProxyRequest) (*ProxyRequest, error)
-	// RunResponse applies all plugins' OnResponse hooks in order.
+}
+
+// ResponsePlugin is implemented by chains that process responses.
+// Pass a ResponsePlugin to SetPlugins when only response interception is needed.
+type ResponsePlugin interface {
+	// RunResponse applies all response hooks in order.
 	RunResponse(ctx context.Context, req *ProxyRequest, resp *ProxyResponse) (*ProxyResponse, error)
+}
+
+// PluginChain combines both optional interfaces. Implementations may satisfy
+// only RequestPlugin, only ResponsePlugin, or both.
+// Kept for backward compatibility — existing runtimes that implement both
+// RunRequest and RunResponse continue to satisfy this interface.
+type PluginChain interface {
+	RequestPlugin
+	ResponsePlugin
 }
 
 // ResumeAction mirrors the proto enum for the proxy layer.

--- a/pkg/plugins/sdk.go
+++ b/pkg/plugins/sdk.go
@@ -7,8 +7,30 @@ import (
 	"net/url"
 )
 
+// RequestPlugin is implemented by plugins that intercept outbound requests.
+// Plugins that only care about requests may implement this alone.
+type RequestPlugin interface {
+	// OnRequest is called before the request is forwarded upstream.
+	// Returning a non-nil *ProxyRequest replaces the request.
+	// Returning nil passes the original through unchanged.
+	// Returning an error aborts the request (client receives 502).
+	OnRequest(ctx context.Context, req *ProxyRequest) (*ProxyRequest, error)
+}
+
+// ResponsePlugin is implemented by plugins that intercept responses.
+// Plugins that only care about responses may implement this alone.
+type ResponsePlugin interface {
+	// OnResponse is called after receiving the upstream response.
+	// Returning a non-nil *ProxyResponse replaces the response.
+	// Returning nil passes the original through unchanged.
+	OnResponse(ctx context.Context, req *ProxyRequest, resp *ProxyResponse) (*ProxyResponse, error)
+}
+
 // Plugin is the interface every APiX plugin must implement.
 // Plugins are called in registration order for every proxied request/response.
+// Implementations that only care about one direction may omit the other hook
+// by satisfying only RequestPlugin or ResponsePlugin; the runtime skips hooks
+// that are not implemented.
 type Plugin interface {
 	// Name returns the unique plugin identifier (e.g. "header-editor").
 	Name() string
@@ -16,15 +38,8 @@ type Plugin interface {
 	Version() string
 	// Description returns a short human-readable description.
 	Description() string
-	// OnRequest is called before the request is forwarded upstream.
-	// Returning a non-nil *ProxyRequest replaces the request.
-	// Returning nil passes the original through unchanged.
-	// Returning an error aborts the request (client receives 502).
-	OnRequest(ctx context.Context, req *ProxyRequest) (*ProxyRequest, error)
-	// OnResponse is called after receiving the upstream response.
-	// Returning a non-nil *ProxyResponse replaces the response.
-	// Returning nil passes the original through unchanged.
-	OnResponse(ctx context.Context, req *ProxyRequest, resp *ProxyResponse) (*ProxyResponse, error)
+	RequestPlugin
+	ResponsePlugin
 }
 
 // ProxyRequest is the richer internal request type passed through the plugin chain.


### PR DESCRIPTION
Fixes #207 — adds `RequestPlugin` and `ResponsePlugin` narrow interfaces; `PluginChain` now composes them. Call sites use type assertions for optional capability.

## Changes

### `pkg/plugins/sdk.go`
- Added `RequestPlugin` interface (just `OnRequest`)
- Added `ResponsePlugin` interface (just `OnResponse`)
- `Plugin` now embeds both narrow interfaces + metadata methods (backward compatible)

### `internal/proxy/types.go`
- Added `RequestPlugin` interface (with `RunRequest`)
- Added `ResponsePlugin` interface (with `RunResponse`)
- `PluginChain` now composes both — existing runtimes unchanged

### `internal/proxy/plugin_runner.go`
- `runPluginRequest` / `runPluginResponse` accept `any` and type-assert to the narrow interface, so a request-only or response-only chain works

### `internal/proxy/http.go` / `https.go`
- `plugins` field and `SetPlugins` accept `any` — callers may pass a partial implementation

### `internal/pluginrt/runtime.go`
- `RunRequest` / `RunResponse` type-assert each individual plugin before invoking its hook, skipping plugins that don't implement the relevant side