### PR TITLE
feat(plugins): fault-injection (chaos) plugin (#154)

### DIFF
--- a/internal/pluginrt/builtins/fault_injection.go
+++ b/internal/pluginrt/builtins/fault_injection.go
@@ -1,0 +1,108 @@
+package builtins
+
+import (
+"bytes"
+"context"
+"io"
+"math/rand"
+"net/http"
+"strings"
+"time"
+
+"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// FaultRule defines a single fault injection rule.
+type FaultRule struct {
+// MatchPath is a substring matched against the request URL path. Empty matches all.
+MatchPath string
+// MatchMethod is the HTTP method to match (e.g. "GET"). Empty matches all.
+MatchMethod string
+// Percentage is the probability (0.0–100.0) that a matching request is affected.
+Percentage float64
+// FaultType is one of "abort", "delay", or "header".
+FaultType string
+// AbortStatus is the HTTP status code returned for abort faults (default 503).
+AbortStatus int
+// DelayDuration is how long to sleep for delay faults.
+DelayDuration time.Duration
+// HeaderName is the header to inject for header faults.
+HeaderName string
+// HeaderValue is the value of the injected header.
+HeaderValue string
+}
+
+// FaultInjection is a chaos/fault injection plugin that can abort requests,
+// introduce latency, or inject headers based on configurable rules.
+type FaultInjection struct {
+Rules []FaultRule
+}
+
+func (p *FaultInjection) Name() string    { return "fault-injection" }
+func (p *FaultInjection) Version() string { return "1.0.0" }
+func (p *FaultInjection) Description() string {
+return "Chaos/fault injection: abort, delay, or inject headers for matched requests."
+}
+
+func (p *FaultInjection) OnRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+modified := false
+clone := req.Clone(req.Body)
+
+for _, rule := range p.Rules {
+if !faultMatchesRule(rule, req) {
+continue
+}
+if rule.Percentage < 100.0 && rand.Float64()*100.0 >= rule.Percentage {
+continue
+}
+
+switch rule.FaultType {
+case "abort":
+status := rule.AbortStatus
+if status == 0 {
+status = http.StatusServiceUnavailable
+}
+clone.MockedResponse = &plugins.ProxyResponse{
+StatusCode: status,
+Status:     http.StatusText(status),
+Headers:    make(http.Header),
+Body:       io.NopCloser(bytes.NewReader([]byte("fault injected"))),
+}
+modified = true
+
+case "delay":
+time.Sleep(rule.DelayDuration)
+modified = true
+
+case "header":
+if rule.HeaderName != "" {
+body, err := io.ReadAll(clone.Body)
+if err != nil {
+return nil, err
+}
+clone = clone.Clone(io.NopCloser(bytes.NewReader(body)))
+clone.Headers.Set(rule.HeaderName, rule.HeaderValue)
+modified = true
+}
+}
+}
+
+if !modified {
+return nil, nil
+}
+return clone, nil
+}
+
+func (p *FaultInjection) OnResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
+return nil, nil
+}
+
+func faultMatchesRule(rule FaultRule, req *plugins.ProxyRequest) bool {
+if rule.MatchPath != "" && !strings.Contains(req.URL.Path, rule.MatchPath) {
+return false
+}
+if rule.MatchMethod != "" && !strings.EqualFold(req.Method, rule.MatchMethod) {
+return false
+}
+return true
+}

--- a/internal/pluginrt/builtins/fault_injection_test.go
+++ b/internal/pluginrt/builtins/fault_injection_test.go
@@ -1,0 +1,217 @@
+package builtins
+
+import (
+"context"
+"io"
+"net/http"
+"testing"
+"time"
+)
+
+func TestFaultInjection_AbortFault(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 100, FaultType: "abort", AbortStatus: http.StatusTeapot},
+},
+}
+req := makeReq("GET", "https://example.com/api", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil {
+t.Fatal("expected modified request, got nil")
+}
+if result.MockedResponse == nil {
+t.Fatal("expected MockedResponse to be set for abort fault")
+}
+if result.MockedResponse.StatusCode != http.StatusTeapot {
+t.Errorf("StatusCode: got %d want %d", result.MockedResponse.StatusCode, http.StatusTeapot)
+}
+body, _ := io.ReadAll(result.MockedResponse.Body)
+if string(body) != "fault injected" {
+t.Errorf("body: got %q want %q", string(body), "fault injected")
+}
+}
+
+func TestFaultInjection_AbortDefaultStatus(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 100, FaultType: "abort"},
+},
+}
+req := makeReq("GET", "https://example.com/", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result.MockedResponse.StatusCode != http.StatusServiceUnavailable {
+t.Errorf("default abort status: got %d want 503", result.MockedResponse.StatusCode)
+}
+}
+
+func TestFaultInjection_DelayFault(t *testing.T) {
+t.Parallel()
+delay := 50 * time.Millisecond
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 100, FaultType: "delay", DelayDuration: delay},
+},
+}
+req := makeReq("GET", "https://example.com/slow", "")
+start := time.Now()
+result, err := p.OnRequest(context.Background(), req)
+elapsed := time.Since(start)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil {
+t.Fatal("expected modified request (delay applied), got nil")
+}
+if elapsed < delay {
+t.Errorf("delay fault: elapsed %v < expected %v", elapsed, delay)
+}
+}
+
+func TestFaultInjection_HeaderFault(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 100, FaultType: "header", HeaderName: "X-Chaos", HeaderValue: "injected"},
+},
+}
+req := makeReq("GET", "https://example.com/", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil {
+t.Fatal("expected modified request, got nil")
+}
+if result.Headers.Get("X-Chaos") != "injected" {
+t.Errorf("X-Chaos: got %q want %q", result.Headers.Get("X-Chaos"), "injected")
+}
+}
+
+func TestFaultInjection_PercentageZeroNeverTriggers(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 0, FaultType: "abort", AbortStatus: 503},
+},
+}
+for i := 0; i < 200; i++ {
+req := makeReq("GET", "https://example.com/", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result != nil {
+t.Fatalf("Percentage=0: expected nil on iteration %d, got modified request", i)
+}
+}
+}
+
+func TestFaultInjection_Percentage100AlwaysTriggers(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{Percentage: 100, FaultType: "abort", AbortStatus: 503},
+},
+}
+for i := 0; i < 50; i++ {
+req := makeReq("GET", "https://example.com/", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil || result.MockedResponse == nil {
+t.Fatalf("Percentage=100: expected abort on iteration %d, got nil", i)
+}
+}
+}
+
+func TestFaultInjection_PathMatch(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{MatchPath: "/api/", Percentage: 100, FaultType: "abort", AbortStatus: 503},
+},
+}
+
+reqMatch := makeReq("GET", "https://example.com/api/users", "")
+result, err := p.OnRequest(context.Background(), reqMatch)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil || result.MockedResponse == nil {
+t.Error("expected abort for /api/users")
+}
+
+reqNoMatch := makeReq("GET", "https://example.com/health", "")
+result2, err := p.OnRequest(context.Background(), reqNoMatch)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result2 != nil {
+t.Error("expected nil (no match) for /health")
+}
+}
+
+func TestFaultInjection_MethodMatch(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{
+{MatchMethod: "POST", Percentage: 100, FaultType: "abort", AbortStatus: 503},
+},
+}
+
+reqPost := makeReq("POST", "https://example.com/data", "")
+result, err := p.OnRequest(context.Background(), reqPost)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result == nil || result.MockedResponse == nil {
+t.Error("expected abort for POST")
+}
+
+reqGet := makeReq("GET", "https://example.com/data", "")
+result2, err := p.OnRequest(context.Background(), reqGet)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result2 != nil {
+t.Error("expected nil (no match) for GET")
+}
+}
+
+func TestFaultInjection_NoRulesPassThrough(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{}
+req := makeReq("GET", "https://example.com/", "")
+result, err := p.OnRequest(context.Background(), req)
+if err != nil {
+t.Fatalf("OnRequest: %v", err)
+}
+if result != nil {
+t.Error("expected nil pass-through with no rules")
+}
+}
+
+func TestFaultInjection_OnResponsePassThrough(t *testing.T) {
+t.Parallel()
+p := &FaultInjection{
+Rules: []FaultRule{{Percentage: 100, FaultType: "abort"}},
+}
+req := makeReq("GET", "https://example.com/", "")
+resp := makeResp(200, "ok")
+result, err := p.OnResponse(context.Background(), req, resp)
+if err != nil {
+t.Fatalf("OnResponse: %v", err)
+}
+if result != nil {
+t.Error("expected nil from OnResponse (pass-through)")
+}
+}


### PR DESCRIPTION
Implements #154 — chaos/fault injection plugin with abort, delay, and header fault types.