### PR TITLE
feat(plugins): add traffic-shaping plugin (concurrency + bandwidth) (#160)

### DIFF
--- a/internal/pluginrt/builtins/traffic_shaping.go
+++ b/internal/pluginrt/builtins/traffic_shaping.go
@@ -1,0 +1,138 @@
+package builtins
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mnafshin/apix/pkg/plugins"
+)
+
+// TrafficShapingConfig holds the configuration for the TrafficShaping plugin.
+type TrafficShapingConfig struct {
+	// MaxConcurrent is the maximum number of in-flight requests allowed concurrently.
+	// Zero means unlimited.
+	MaxConcurrent int
+	// BandwidthBPS limits response body read throughput in bytes per second.
+	// Zero means unlimited.
+	BandwidthBPS int64
+	// MatchPath is a substring filter on the request URL path. Empty matches all.
+	MatchPath string
+	// RejectWith is the HTTP status code returned when concurrency is exceeded.
+	// Defaults to 503 when zero.
+	RejectWith int
+}
+
+// TrafficShaping is a plugin that enforces concurrency limits and bandwidth
+// throttling on proxied requests.
+type TrafficShaping struct {
+	cfg      TrafficShapingConfig
+	mu       sync.Mutex
+	inflight int
+}
+
+func (p *TrafficShaping) Name() string    { return "traffic-shaping" }
+func (p *TrafficShaping) Version() string { return "1.0.0" }
+func (p *TrafficShaping) Description() string {
+	return "Enforces concurrency limits and per-response bandwidth throttling."
+}
+
+func (p *TrafficShaping) rejectStatus() int {
+	if p.cfg.RejectWith == 0 {
+		return http.StatusServiceUnavailable
+	}
+	return p.cfg.RejectWith
+}
+
+func (p *TrafficShaping) matchesPath(req *plugins.ProxyRequest) bool {
+	if p.cfg.MatchPath == "" {
+		return true
+	}
+	return strings.Contains(req.URL.Path, p.cfg.MatchPath)
+}
+
+// OnRequest enforces the concurrency limit. If the limit is exceeded, a
+// synthetic rejection response is set on the request without hitting upstream.
+func (p *TrafficShaping) OnRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+	if !p.matchesPath(req) {
+		return nil, nil
+	}
+
+	if p.cfg.MaxConcurrent > 0 {
+		p.mu.Lock()
+		if p.inflight >= p.cfg.MaxConcurrent {
+			p.mu.Unlock()
+			status := p.rejectStatus()
+			hdrs := make(http.Header)
+			hdrs.Set("Content-Type", "text/plain")
+			clone := req.Clone(req.Body)
+			clone.MockedResponse = &plugins.ProxyResponse{
+				StatusCode: status,
+				Status:     http.StatusText(status),
+				Headers:    hdrs,
+				Body:       io.NopCloser(bytes.NewBufferString("too many concurrent requests")),
+			}
+			return clone, nil
+		}
+		p.inflight++
+		p.mu.Unlock()
+	}
+
+	return nil, nil
+}
+
+// OnResponse decrements the in-flight counter and optionally wraps the response
+// body with a throttled reader to enforce bandwidth limits.
+func (p *TrafficShaping) OnResponse(ctx context.Context, req *plugins.ProxyRequest, resp *plugins.ProxyResponse) (*plugins.ProxyResponse, error) {
+	if !p.matchesPath(req) {
+		return nil, nil
+	}
+
+	if p.cfg.MaxConcurrent > 0 {
+		p.mu.Lock()
+		if p.inflight > 0 {
+			p.inflight--
+		}
+		p.mu.Unlock()
+	}
+
+	if p.cfg.BandwidthBPS > 0 {
+		throttled := resp.Clone(io.NopCloser(&throttledReader{
+			r:           resp.Body,
+			bytesPerSec: p.cfg.BandwidthBPS,
+		}))
+		return throttled, nil
+	}
+
+	return nil, nil
+}
+
+// throttledReader wraps an io.Reader and enforces a bytes-per-second limit by
+// sleeping after each read to maintain the configured throughput rate.
+type throttledReader struct {
+	r           io.Reader
+	bytesPerSec int64
+	lastRead    time.Time
+}
+
+func (t *throttledReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 && t.bytesPerSec > 0 {
+		// Calculate how long this chunk should have taken at the target rate.
+		expected := time.Duration(float64(n) / float64(t.bytesPerSec) * float64(time.Second))
+		if !t.lastRead.IsZero() {
+			elapsed := time.Since(t.lastRead)
+			if elapsed < expected {
+				time.Sleep(expected - elapsed)
+			}
+		} else {
+			time.Sleep(expected)
+		}
+		t.lastRead = time.Now()
+	}
+	return n, err
+}

--- a/internal/pluginrt/builtins/traffic_shaping_test.go
+++ b/internal/pluginrt/builtins/traffic_shaping_test.go
@@ -1,0 +1,159 @@
+package builtins
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrencyLimit verifies that the second concurrent request is rejected
+// when MaxConcurrent=1.
+func TestConcurrencyLimit(t *testing.T) {
+	p := &TrafficShaping{cfg: TrafficShapingConfig{MaxConcurrent: 1}}
+	ctx := context.Background()
+	req1 := makeReq("GET", "http://example.com/api", "")
+	req2 := makeReq("GET", "http://example.com/api", "")
+
+	// First request should go through.
+	result1, err := p.OnRequest(ctx, req1)
+	if err != nil {
+		t.Fatalf("unexpected error on first request: %v", err)
+	}
+	if result1 != nil && result1.MockedResponse != nil {
+		t.Fatal("first request should not be rejected")
+	}
+
+	// Second concurrent request should be rejected.
+	result2, err := p.OnRequest(ctx, req2)
+	if err != nil {
+		t.Fatalf("unexpected error on second request: %v", err)
+	}
+	if result2 == nil || result2.MockedResponse == nil {
+		t.Fatal("second request should have a MockedResponse set")
+	}
+	if result2.MockedResponse.StatusCode != 503 {
+		t.Errorf("expected status 503, got %d", result2.MockedResponse.StatusCode)
+	}
+	body, _ := io.ReadAll(result2.MockedResponse.Body)
+	if string(body) != "too many concurrent requests" {
+		t.Errorf("unexpected rejection body: %q", string(body))
+	}
+}
+
+// TestInflightDecrementedAfterResponse verifies that after OnResponse the
+// in-flight counter drops and the next request is allowed through.
+func TestInflightDecrementedAfterResponse(t *testing.T) {
+	p := &TrafficShaping{cfg: TrafficShapingConfig{MaxConcurrent: 1}}
+	ctx := context.Background()
+	req := makeReq("GET", "http://example.com/api", "")
+
+	// Consume the slot.
+	p.OnRequest(ctx, req) //nolint:errcheck
+
+	// Release the slot via OnResponse.
+	p.OnResponse(ctx, req, makeResp(200, "")) //nolint:errcheck
+
+	// Next request should now go through.
+	req2 := makeReq("GET", "http://example.com/api", "")
+	result, err := p.OnRequest(ctx, req2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("request after response should not be rejected")
+	}
+}
+
+// TestCustomRejectStatus verifies that the RejectWith status code is used.
+func TestCustomRejectStatus(t *testing.T) {
+	p := &TrafficShaping{cfg: TrafficShapingConfig{MaxConcurrent: 1, RejectWith: 429}}
+	ctx := context.Background()
+
+	p.OnRequest(ctx, makeReq("GET", "http://example.com/", "")) //nolint:errcheck
+	result, _ := p.OnRequest(ctx, makeReq("GET", "http://example.com/", ""))
+	if result == nil || result.MockedResponse == nil {
+		t.Fatal("expected rejection")
+	}
+	if result.MockedResponse.StatusCode != 429 {
+		t.Errorf("expected 429, got %d", result.MockedResponse.StatusCode)
+	}
+}
+
+// TestBandwidthThrottling verifies that reading N bytes takes at least N/BPS seconds.
+func TestBandwidthThrottling(t *testing.T) {
+	const bps = 1000          // 1 KB/s
+	const dataSize = 500      // 500 bytes → should take ~0.5 s
+	data := strings.Repeat("x", dataSize)
+
+	p := &TrafficShaping{cfg: TrafficShapingConfig{BandwidthBPS: bps}}
+	ctx := context.Background()
+	req := makeReq("GET", "http://example.com/download", "")
+	resp := makeResp(200, data)
+
+	modResp, err := p.OnResponse(ctx, req, resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if modResp == nil {
+		t.Fatal("expected a modified response with throttled body")
+	}
+
+	start := time.Now()
+	buf, err := io.ReadAll(modResp.Body)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("error reading throttled body: %v", err)
+	}
+	if string(buf) != data {
+		t.Error("throttled body content mismatch")
+	}
+
+	expected := time.Duration(float64(dataSize) / float64(bps) * float64(time.Second))
+	if elapsed < expected {
+		t.Errorf("read too fast: elapsed %v, expected at least %v", elapsed, expected)
+	}
+}
+
+// TestMatchPath verifies that requests not matching MatchPath are not affected.
+func TestMatchPath(t *testing.T) {
+	p := &TrafficShaping{cfg: TrafficShapingConfig{MaxConcurrent: 1, MatchPath: "/api"}}
+	ctx := context.Background()
+
+	// Fill the slot for /api.
+	p.OnRequest(ctx, makeReq("GET", "http://example.com/api", "")) //nolint:errcheck
+
+	// A request to a different path should not be rejected.
+	result, err := p.OnRequest(ctx, makeReq("GET", "http://example.com/static/file.js", ""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil && result.MockedResponse != nil {
+		t.Fatal("non-matching path should not be rejected")
+	}
+}
+
+// TestConcurrentSafety exercises the plugin under parallel load to detect races.
+func TestConcurrentSafety(t *testing.T) {
+	p := &TrafficShaping{cfg: TrafficShapingConfig{MaxConcurrent: 5}}
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := makeReq("GET", "http://example.com/stress", "")
+			result, _ := p.OnRequest(ctx, req)
+			if result == nil || result.MockedResponse == nil {
+				// Request went through — simulate work then release.
+				time.Sleep(5 * time.Millisecond)
+				p.OnResponse(ctx, req, makeResp(200, "")) //nolint:errcheck
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Implements the traffic-shaping plugin as described in issue #160.

## Changes
- New plugin `TrafficShaping` in `internal/pluginrt/builtins/traffic_shaping.go`
- Concurrency limiting: rejects requests with configurable status (default 503) when in-flight count exceeds `MaxConcurrent`
- Bandwidth throttling: wraps response body with a `throttledReader` to enforce `BandwidthBPS` bytes/sec limit
- Path filtering via `MatchPath` substring match
- Full test coverage in `traffic_shaping_test.go`

Closes #160

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>