### PR TITLE
fix(lint): resolve errcheck/gosec/unused in plugin builtins

### DIFF
--- a/internal/pluginrt/builtins/fault_injection.go
+++ b/internal/pluginrt/builtins/fault_injection.go
@@ -52,7 +52,7 @@ func (p *FaultInjection) OnRequest(ctx context.Context, req *plugins.ProxyReques
 		if !matchesRule(rule, req) {
 			continue
 		}
-		if rule.Percentage < 100.0 && rand.Float64()*100.0 >= rule.Percentage {
+		if rule.Percentage < 100.0 && rand.Float64()*100.0 >= rule.Percentage { //nolint:gosec
 			continue
 		}
 

--- a/internal/pluginrt/builtins/latency_modifier.go
+++ b/internal/pluginrt/builtins/latency_modifier.go
@@ -59,7 +59,7 @@ func (p *LatencyModifier) OnRequest(ctx context.Context, req *plugins.ProxyReque
 		}
 		delay := rule.FixedDelay
 		if rule.JitterMax > 0 {
-			delay += time.Duration(rand.Int63n(int64(rule.JitterMax) + 1))
+			delay += time.Duration(rand.Int63n(int64(rule.JitterMax) + 1)) //nolint:gosec
 		}
 		if delay > 0 {
 			select {

--- a/internal/pluginrt/builtins/load_generator.go
+++ b/internal/pluginrt/builtins/load_generator.go
@@ -236,7 +236,7 @@ func (p *LoadGenerator) doRequest(raw *http.Request, body []byte) {
 	clone.Body = io.NopCloser(bytes.NewReader(body))
 
 	start := time.Now()
-	resp, err := http.DefaultClient.Do(clone)
+	resp, err := http.DefaultClient.Do(clone) //nolint:gosec
 	latMs := time.Since(start).Milliseconds()
 
 	result := LoadResult{LatencyMs: latMs}
@@ -245,7 +245,7 @@ func (p *LoadGenerator) doRequest(raw *http.Request, body []byte) {
 	} else {
 		result.StatusCode = resp.StatusCode
 		io.Copy(io.Discard, resp.Body) //nolint:errcheck
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	p.mu.Lock()

--- a/internal/pluginrt/builtins/retry_policy.go
+++ b/internal/pluginrt/builtins/retry_policy.go
@@ -37,13 +37,6 @@ type RetryRule struct {
 
 var defaultMatchMethods = []string{http.MethodGet, http.MethodHead, http.MethodOptions}
 
-func (r *RetryRule) maxAttempts() int {
-	if r.MaxAttempts <= 0 {
-		return 3
-	}
-	return r.MaxAttempts
-}
-
 func (r *RetryRule) backoffBase() time.Duration {
 	if r.BackoffBase <= 0 {
 		return 100 * time.Millisecond


### PR DESCRIPTION
Fixes golangci-lint failures from new plugin builtins