### PR TITLE
fix(vscode): lazy activation events (#70)

### DIFF
--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -24,10 +24,21 @@
     "mitm"
   ],
   "activationEvents": [
-    "onCommand:apix.openTrafficPanel",
+    "onCommand:apix.startEngine",
+    "onCommand:apix.stopEngine",
+    "onCommand:apix.clearHistory",
+    "onCommand:apix.addBreakpoint",
+    "onCommand:apix.deleteBreakpoint",
+    "onCommand:apix.toggleBreakpoint",
+    "onCommand:apix.replayRequest",
+    "onCommand:apix.copyAsCurl",
     "onCommand:apix.exportHAR",
     "onCommand:apix.importHAR",
-    "onCommand:apix.copyAsCurl",
+    "onCommand:apix.openTrafficPanel",
+    "onCommand:apix.refreshTraffic",
+    "onCommand:apix.mocks.refresh",
+    "onCommand:apix.mocks.toggle",
+    "onCommand:apix.mocks.delete",
     "onView:apix.trafficView",
     "onView:apix.breakpointsView",
     "onView:apix.mocksView"


### PR DESCRIPTION
Closes #70

Replaces the eager `onStartupFinished` activation with per-command and per-view lazy triggers. All 15 contributed commands and 3 contributed views are now listed in `activationEvents`, so the extension only activates when the user explicitly invokes an APiX command or opens an APiX view.