### PR TITLE
docs: fix markdownlint MD012 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,3 @@ make proto
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).
-


### PR DESCRIPTION
Fixes failing docs-sync workflow by removing extra trailing blank line in README.