### PR TITLE
fix: update markdown links to reflect new docs structure

### DIFF
--- a/docs/ARCHITECTURE/design-principles.md
+++ b/docs/ARCHITECTURE/design-principles.md
@@ -263,7 +263,7 @@ Some of these principles can be checked automatically. The following tools are b
 | DIP | `go test ./internal/engine/...` | Engine unit tests (once `TransactionRepository` interface exists) |
 | Plugin wiring | Integration test in `tests/integration/` | Verifies plugins execute on live requests |
 
-See [testing_strategy.md](testing_strategy.md) for the full testing philosophy.
+See [testing_strategy.md](../testing/testing_strategy.md) for the full testing philosophy.
 
 ---
 

--- a/docs/how-to/first-capture.md
+++ b/docs/how-to/first-capture.md
@@ -35,7 +35,7 @@ Open a second terminal and send any HTTP or HTTPS request through the proxy:
 # Plain HTTP
 curl -x http://localhost:8080 http://httpbin.org/get
 
-# HTTPS (you will see a TLS warning until you install the APiX CA — see proxy_mitm.md)
+# HTTPS (you will see a TLS warning until you install the APiX CA — see ../ARCHITECTURE/proxy_mitm.md)
 curl -x http://localhost:8080 https://httpbin.org/get --insecure
 ```
 
@@ -89,11 +89,11 @@ curl  ──► APiX proxy (:8080) ──► real upstream
 | Symptom | Fix |
 |---|---|
 | `curl: (7) Failed to connect to localhost port 8080` | Engine is not running. Start `./apix-engine` first. |
-| HTTPS request fails with `SSL: no alternative certificate subject name matches target host name` | Install the APiX CA certificate. See [proxy_mitm.md](../proxy_mitm.md). |
+| HTTPS request fails with `SSL: no alternative certificate subject name matches target host name` | Install the APiX CA certificate. See [proxy_mitm.md](../ARCHITECTURE/proxy_mitm.md). |
 | `history list` shows nothing | Make sure curl is proxied (`-x http://localhost:8080`) and try again. |
 
 ## Next steps
 
 - **[First breakpoint](first-breakpoint.md)** — pause a request before it reaches the server and edit it in place.
 - **[Replay](replay.md)** — re-send a captured request, optionally with modifications.
-- **[HTTPS interception](../proxy_mitm.md)** — install the CA cert to capture HTTPS traffic without warnings.
+- **[HTTPS interception](../ARCHITECTURE/proxy_mitm.md)** — install the CA cert to capture HTTPS traffic without warnings.

--- a/docs/how-to/replay.md
+++ b/docs/how-to/replay.md
@@ -123,4 +123,4 @@ Output:
 ## Next steps
 
 - **[First breakpoint](first-breakpoint.md)** — pause and edit requests before they hit the server.
-- **[gRPC API reference](../grpc_protobuf.md)** — drive replay programmatically.
+- **[gRPC API reference](../ARCHITECTURE/grpc_protobuf.md)** — drive replay programmatically.


### PR DESCRIPTION
## Summary
Fixed broken internal markdown links after documentation reorganization.

## Changes
- `docs/ARCHITECTURE/design-principles.md`: Updated reference to testing_strategy.md
- `docs/how-to/first-capture.md`: Updated 3 references to proxy_mitm.md
- `docs/how-to/replay.md`: Updated reference to grpc_protobuf.md

## Why
These links were broken because the files moved to new subdirectories (ARCHITECTURE/, testing/) during the docs consolidation in PR #279.

## Testing
- ✅ All tests pass
- ✅ All lints pass