### PR TITLE
fix: correct CONTRIBUTING.md relative path in design-principles.md

### DIFF
--- a/docs/ARCHITECTURE/design-principles.md
+++ b/docs/ARCHITECTURE/design-principles.md
@@ -276,4 +276,4 @@ When opening a PR that touches the engine, proxy, or gRPC server, please check:
 3. **Does the change reach across a layer boundary?** → e.g. proxy calling storage directly, or gRPC handler calling `engine.DB()`.
 4. **Does the change add an abstraction with only one implementation?** → Only add interfaces when you need to mock, swap, or test in isolation.
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full development workflow.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for the full development workflow.


### PR DESCRIPTION
## Summary
Fixed relative path reference to CONTRIBUTING.md in design-principles.md.

## Issue
From `docs/ARCHITECTURE/design-principles.md`, the correct relative path to CONTRIBUTING.md at the repository root requires going up **two** levels: `../../CONTRIBUTING.md` not `../CONTRIBUTING.md`.

## Verification
- ✅ Path verified: from docs/ARCHITECTURE, `../../CONTRIBUTING.md` correctly resolves to root CONTRIBUTING.md
- ✅ All tests pass

This resolves the final lychee link check error.