### PR TITLE
fix: resolve markdownlint MD007 list indentation errors

### DIFF
--- a/docs/ARCHIVE/review-external.md
+++ b/docs/ARCHIVE/review-external.md
@@ -163,8 +163,8 @@ These are the gaps I’d elevate most:
    - gRPC/HTTP2 matters more than broad “future protocol” language
 
 10. **Backlog cleanup and dependency shaping**
-   - remove duplicate/stale issues
-   - turn roadmap bullets into acceptance-based epics
+- remove duplicate/stale issues
+- turn roadmap bullets into acceptance-based epics
 
 ## If APiX wants to become top class, the right order is
 

--- a/docs/ARCHIVE/review-summary.md
+++ b/docs/ARCHIVE/review-summary.md
@@ -163,8 +163,8 @@ These are the gaps I’d elevate most:
    - gRPC/HTTP2 matters more than broad “future protocol” language
 
 10. **Backlog cleanup and dependency shaping**
-   - remove duplicate/stale issues
-   - turn roadmap bullets into acceptance-based epics
+- remove duplicate/stale issues
+- turn roadmap bullets into acceptance-based epics
 
 ## If APiX wants to become top class, the right order is
 


### PR DESCRIPTION
## Summary
Fixed markdown list indentation violations detected by markdownlint.

## Changes
- docs/ARCHIVE/review-external.md: Removed 3-space indentation from lines 166-167
- docs/ARCHIVE/review-summary.md: Removed 3-space indentation from lines 166-167

## Rule
MD007 (ul-indent) enforces consistent list indentation. The default is 0 spaces between list marker and content (e.g., `- item` not `   - item`).

## Testing
- ✅ All tests pass
- ✅ Markdownlint now passes