### PR TITLE
fix: wire plugin runtime into HTTP and TLS proxies

### DIFF
--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -177,7 +177,9 @@ func main() {
 		ExpectContinueTimeout: time.Duration(cfg.UpstreamExpectContinueTimeoutSec) * time.Second,
 	}
 	tlsProxy := proxy.NewTLSProxy(ca, eng, transportOpts, cfg)
+	tlsProxy.SetPlugins(pluginRT)
 	httpProxy := proxy.NewHTTPProxy(":"+cfg.HTTPPort, tlsProxy, eng, transportOpts, cfg)
+	httpProxy.SetPlugins(pluginRT)
 
 	// 9. Start gRPC server.
 	wg.Add(1)


### PR DESCRIPTION
## Summary
SetPlugins() was never called on either proxy in `main.go`, so all registered plugins (HeaderEditor, MockResponse, EnvSubst) were silently ignored at runtime.

## Changes
- Call `tlsProxy.SetPlugins(pluginRT)` and `httpProxy.SetPlugins(pluginRT)` after proxy construction in `cmd/apix-engine/main.go`

## Testing
All 29 test suites pass.

Fixes #286