### PR TITLE
fix: log warning when subscriber channels are full

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -104,11 +104,18 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 			subscribers = append(subscribers, ch)
 		}
 		e.mu.Unlock()
+		var dropped int
 		for _, sub := range subscribers {
 			select {
 			case sub <- protoReq:
 			default:
+				dropped++
 			}
+		}
+		if dropped > 0 {
+			logging.Warnf(context.Background(),
+				"dropped traffic event for %d/%d subscriber(s) — channel full",
+				dropped, len(subscribers))
 		}
 	}
 


### PR DESCRIPTION
## Summary
The publish loop silently dropped traffic events when a subscriber's channel buffer was full. Now counts dropped sends per publish cycle and emits a warning log so operators can detect slow consumers.

## Changes
- Add drop counter in the non-blocking send loop in `engine.StoreTransaction()`
- Log warning via `logging.Warnf` when drops occur, including count and total subscribers

Fixes #287