### PR TITLE
perf: upgrade Engine mutex to sync.RWMutex

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -23,7 +23,7 @@ import (
 // Engine is the central coordinator for APiX. It implements proxy.TrafficEngine
 // and provides helpers for all gRPC handlers.
 type Engine struct {
-	mu              sync.Mutex
+	mu              sync.RWMutex
 	db              storage.TransactionRepository
 	bpManager       BreakpointEvaluator
 	pluginRT        *pluginrt.Runtime
@@ -98,12 +98,12 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 			Timestamp: time.Now().UnixMilli(),
 			Protocol:  req.Protocol,
 		}
-		e.mu.Lock()
+		e.mu.RLock()
 		subscribers := make([]chan *apix.HttpRequest, 0, len(e.subscribers))
 		for ch := range e.subscribers {
 			subscribers = append(subscribers, ch)
 		}
-		e.mu.Unlock()
+		e.mu.RUnlock()
 		var dropped int
 		for _, sub := range subscribers {
 			select {


### PR DESCRIPTION
## Summary
The publish path only reads the subscriber map to take a snapshot, so it can use RLock instead of exclusive Lock. This allows concurrent StoreTransaction calls to snapshot subscribers in parallel.

## Changes
- Change `mu sync.Mutex` → `mu sync.RWMutex` in Engine struct
- Use `RLock/RUnlock` in the publish snapshot path
- Subscribe/Unsubscribe retain exclusive `Lock/Unlock`

## Testing
All tests pass including race detector (`go test -race`).

Fixes #288