### PR TITLE
fix(vscode): auto-reconnect engine streams after restart

### DIFF
--- a/apix-vscode/src/engineProcessManager.ts
+++ b/apix-vscode/src/engineProcessManager.ts
@@ -20,8 +20,14 @@ export class EngineProcessManager {
     private startPromise: Promise<void> | null = null;
     private restartAttempts = 0;
     private restartTimer: ReturnType<typeof setTimeout> | null = null;
+    private stopping = false;
+    private outputChannel: vscode.OutputChannel | null = null;
     /** Callback invoked after a successful auto-restart so streams can be re-established. */
     onRestart: (() => void) | null = null;
+    /** Callback invoked when an unexpected exit is detected. */
+    onUnexpectedExit: ((message: string) => void) | null = null;
+    /** Callback invoked when auto-restart has been scheduled. */
+    onRestarting: ((attempt: number, delayMs: number) => void) | null = null;
 
     constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -29,6 +35,7 @@ export class EngineProcessManager {
     async start(): Promise<void> {
         // Idempotent: if already running, return immediately
         if (this.isRunning()) { return; }
+        this.stopping = false;
         
         // If already starting, return the existing promise to prevent race condition
         if (this.isStarting && this.startPromise) { 
@@ -38,7 +45,10 @@ export class EngineProcessManager {
         this.isStarting = true;
         try {
             const binaryPath = this._binaryPath();
-            const outputChannel = vscode.window.createOutputChannel('APiX Engine');
+            if (!this.outputChannel) {
+                this.outputChannel = vscode.window.createOutputChannel('APiX Engine');
+            }
+            const outputChannel = this.outputChannel;
             outputChannel.show(true);
 
             this.startPromise = new Promise((resolve, reject) => {
@@ -92,15 +102,11 @@ export class EngineProcessManager {
                         if (this.process === proc) {
                             this.process = null;
                         }
-                        if (code !== 0 && code !== null) {
+                        if (!this.stopping && code !== 0 && code !== null) {
                             const msg = `APiX Engine exited unexpectedly (code ${code}, signal ${signal})`;
                             outputChannel.appendLine(`[APiX] ${msg}`);
-                            vscode.window.showErrorMessage(msg, 'Restart').then(choice => {
-                                if (choice === 'Restart') { 
-                                    // Don't await — let user see error message first
-                                    void this.start();
-                                }
-                            });
+                            this.onUnexpectedExit?.(msg);
+                            this.scheduleAutoRestart();
                         }
                     });
                 } catch (err) {
@@ -111,6 +117,7 @@ export class EngineProcessManager {
             });
             
             await this.startPromise;
+            this.restartAttempts = 0;
         } finally {
             // Ensure cleanup (though resolveOnce should have already done this)
             if (this.startPromise === null) {
@@ -121,6 +128,11 @@ export class EngineProcessManager {
 
     /** Stop the engine subprocess gracefully (SIGTERM → wait 3s → SIGKILL). */
     stop(): void {
+        this.stopping = true;
+        if (this.restartTimer) {
+            clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
         if (!this.process) { return; }
         const proc = this.process;
         this.process = null;
@@ -134,6 +146,42 @@ export class EngineProcessManager {
     /** Returns true if the engine process is currently running. */
     isRunning(): boolean {
         return this.process !== null && !this.process.killed;
+    }
+
+    private scheduleAutoRestart(): void {
+        if (this.stopping || this.isStarting || this.isRunning()) {
+            return;
+        }
+        if (this.restartTimer) {
+            clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
+        if (this.restartAttempts >= MAX_RESTART_ATTEMPTS) {
+            const msg = `APiX Engine failed to restart after ${MAX_RESTART_ATTEMPTS} attempts.`;
+            this.outputChannel?.appendLine(`[APiX] ${msg}`);
+            void vscode.window.showErrorMessage(msg);
+            return;
+        }
+
+        this.restartAttempts += 1;
+        const delayMs = Math.min(BACKOFF_INITIAL_MS * Math.pow(2, this.restartAttempts - 1), BACKOFF_MAX_MS);
+        this.outputChannel?.appendLine(`[APiX] Auto-restart attempt ${this.restartAttempts}/${MAX_RESTART_ATTEMPTS} in ${delayMs}ms`);
+        this.onRestarting?.(this.restartAttempts, delayMs);
+
+        this.restartTimer = setTimeout(async () => {
+            this.restartTimer = null;
+            if (this.stopping) {
+                return;
+            }
+            try {
+                await this.start();
+                this.onRestart?.();
+            } catch (err: any) {
+                const msg = err?.message || String(err);
+                this.outputChannel?.appendLine(`[APiX] Auto-restart attempt ${this.restartAttempts} failed: ${msg}`);
+                this.scheduleAutoRestart();
+            }
+        }, delayMs);
     }
 
     /** Resolve the path to the bundled engine binary. */

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -18,6 +18,8 @@ let trafficProvider: TrafficProvider | undefined;
 let breakpointsProvider: BreakpointsProvider | undefined;
 let mocksProvider: MocksProvider | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let pausedRetryTimer: ReturnType<typeof setTimeout> | undefined;
+let pausedRetryDelayMs = 1000;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const config = vscode.workspace.getConfiguration('apix');
@@ -41,6 +43,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     processManager = new EngineProcessManager(context);
     engineClient = new EngineClient(host, grpcPort, tlsEnabled, authToken);
+    processManager.onUnexpectedExit = (message: string) => {
+        statusBarItem!.text = '$(debug-disconnect) APiX: Disconnected';
+        statusBarItem!.tooltip = message;
+        statusBarItem!.command = 'apix.startEngine';
+    };
+    processManager.onRestarting = (attempt: number, delayMs: number) => {
+        statusBarItem!.text = '$(sync~spin) APiX: Reconnecting...';
+        statusBarItem!.tooltip = `APiX: reconnect attempt ${attempt} in ${Math.round(delayMs / 1000)}s`;
+        statusBarItem!.command = 'apix.startEngine';
+    };
+    processManager.onRestart = () => {
+        outputChannel?.appendLine('[APiX] Engine restarted; re-initializing extension streams…');
+        startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!, mocksProvider)
+            .catch(err => outputChannel?.appendLine(`APiX: reconnect failed — ${err?.message || err}`));
+    };
 
     trafficProvider = new TrafficProvider(engineClient, outputChannel);
     breakpointsProvider = new BreakpointsProvider(engineClient, outputChannel);
@@ -153,13 +170,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!)
             .catch(err => outputChannel?.appendLine(`APiX: auto-start failed — ${err?.message || err}`));
 
-        // Re-establish gRPC streams after auto-restart (exponential backoff kicks in
-        // when engine exits unexpectedly; this callback runs once the new process is ready).
-        processManager!.onRestart = () => {
-            outputChannel?.appendLine('[APiX] Reconnecting gRPC streams after engine restart…');
-            startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!)
-                .catch(err => outputChannel?.appendLine(`APiX: reconnect failed — ${err?.message || err}`));
-        };
     }
 }
 
@@ -167,6 +177,10 @@ export function deactivate(): void {
     // Cancel any active streams
     pausedRequestsStream?.cancel();
     pausedRequestsStream = undefined;
+    if (pausedRetryTimer) {
+        clearTimeout(pausedRetryTimer);
+        pausedRetryTimer = undefined;
+    }
     
     // Stop engine process
     processManager?.stop();
@@ -198,7 +212,13 @@ async function startEngine(
     mocksProvider?: MocksProvider
 ): Promise<void> {
     if (pm.isRunning()) {
-        vscode.window.showInformationMessage('APiX Engine is already running.');
+        statusBarItem!.text = '$(circle-filled) APiX: Running';
+        statusBarItem!.tooltip = 'APiX: Running — click to open traffic panel';
+        statusBarItem!.command = 'apix.openTrafficPanel';
+        breakpointsProvider.refresh();
+        trafficProvider.refresh();
+        mocksProvider?.refresh();
+        _startWatchPausedRequests(context, client);
         return;
     }
     try {
@@ -235,6 +255,10 @@ async function startEngine(
 async function stopEngine(pm: EngineProcessManager): Promise<void> {
     pausedRequestsStream?.cancel();
     pausedRequestsStream = undefined;
+    if (pausedRetryTimer) {
+        clearTimeout(pausedRetryTimer);
+        pausedRetryTimer = undefined;
+    }
     pm.stop();
     statusBarItem!.text = '$(circle-outline) APiX: Stopped';
     statusBarItem!.tooltip = 'APiX HTTP Proxy — click to start';
@@ -244,17 +268,36 @@ async function stopEngine(pm: EngineProcessManager): Promise<void> {
 
 function _startWatchPausedRequests(context: vscode.ExtensionContext, client: EngineClient): void {
     try {
+        if (pausedRetryTimer) {
+            clearTimeout(pausedRetryTimer);
+            pausedRetryTimer = undefined;
+        }
         pausedRequestsStream?.cancel();
         const stream = client.watchPausedRequests(
             (paused) => {
+                pausedRetryDelayMs = 1000;
                 RequestEditor.showEditor(context.extensionUri, client, paused);
             },
             (err) => {
                 // Log to output channel so user can inspect stream errors
                 outputChannel?.appendLine(`[APiX] WatchPausedRequests stream error: ${err?.message || err}`);
+                if (processManager?.isRunning()) {
+                    const delay = pausedRetryDelayMs;
+                    pausedRetryDelayMs = Math.min(pausedRetryDelayMs * 2, 30000);
+                    pausedRetryTimer = setTimeout(() => {
+                        _startWatchPausedRequests(context, client);
+                    }, delay);
+                }
             },
             () => {
                 console.log('[APiX] WatchPausedRequests stream ended.');
+                if (processManager?.isRunning()) {
+                    const delay = pausedRetryDelayMs;
+                    pausedRetryDelayMs = Math.min(pausedRetryDelayMs * 2, 30000);
+                    pausedRetryTimer = setTimeout(() => {
+                        _startWatchPausedRequests(context, client);
+                    }, delay);
+                }
             }
         );
         pausedRequestsStream = stream;


### PR DESCRIPTION
## Summary
- add engine process auto-restart with exponential backoff in the VS Code extension
- propagate unexpected-exit/reconnecting state to the status bar
- reinitialize extension streams/providers on restart and retry paused-request stream subscription

Fixes #304