### PR TITLE
fix(cli): parse --header values with embedded colons

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -131,17 +131,25 @@ func (h *headerFlags) Set(v string) error {
 	return nil
 }
 
+func parseHeader(raw string) (string, string, error) {
+	idx := strings.Index(raw, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid header %q (want key:value)", raw)
+	}
+	key := strings.TrimSpace(raw[:idx])
+	if key == "" {
+		return "", "", fmt.Errorf("invalid header %q (empty key)", raw)
+	}
+	val := strings.TrimSpace(raw[idx+1:])
+	return key, val, nil
+}
+
 func (h headerFlags) Map() (map[string]string, error) {
 	out := make(map[string]string, len(h))
 	for _, raw := range h {
-		parts := strings.SplitN(raw, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid header %q (want key:value)", raw)
-		}
-		key := strings.TrimSpace(parts[0])
-		val := strings.TrimSpace(parts[1])
-		if key == "" {
-			return nil, fmt.Errorf("invalid header %q (empty key)", raw)
+		key, val, err := parseHeader(raw)
+		if err != nil {
+			return nil, err
 		}
 		out[key] = val
 	}

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -638,3 +638,30 @@ func TestCLIUnknownCommandJSONError(t *testing.T) {
 		t.Fatalf("unexpected message: %#v", errPayload["message"])
 	}
 }
+
+func TestHeaderFlagsMap_SplitsOnFirstColon(t *testing.T) {
+	t.Parallel()
+
+	headers, err := headerFlags{
+		"Authorization: Bearer token:abc:def",
+		"X-Time: 12:34:56",
+	}.Map()
+	if err != nil {
+		t.Fatalf("Map() error = %v", err)
+	}
+	if got := headers["Authorization"]; got != "Bearer token:abc:def" {
+		t.Fatalf("Authorization header = %q", got)
+	}
+	if got := headers["X-Time"]; got != "12:34:56" {
+		t.Fatalf("X-Time header = %q", got)
+	}
+}
+
+func TestHeaderFlagsMap_InvalidHeader(t *testing.T) {
+	t.Parallel()
+
+	_, err := headerFlags{"not-a-header"}.Map()
+	if err == nil {
+		t.Fatal("expected parse error for malformed header")
+	}
+}


### PR DESCRIPTION
## Summary
- use explicit first-colon parsing for CLI header flags
- preserve full header values containing additional colons
- add regression tests for embedded-colon values and malformed headers

Fixes #351