### PR TITLE
fix(cli): reject --output json for streaming commands

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -779,6 +779,13 @@ func historyItemToJSON(tx *apix.HttpTransaction) map[string]any {
 	return item
 }
 
+func validateStreamingOutput(output string) error {
+	if output == "json" {
+		return status.Error(codes.InvalidArgument, "--output json is not supported for streaming commands; use --output ndjson")
+	}
+	return nil
+}
+
 func (a *app) cmdWatch(args []string) error {
 	if len(args) > 0 && args[0] == "traffic" {
 		args = args[1:]
@@ -790,6 +797,9 @@ func (a *app) cmdWatch(args []string) error {
 	fs.StringVar(&opts.method, "method", "", "filter by HTTP method (case-insensitive)")
 	fs.StringVar(&opts.urlPattern, "url-pattern", "", "filter by URL substring")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateStreamingOutput(a.opts.output); err != nil {
 		return err
 	}
 	client, err := a.clientConn()
@@ -1133,6 +1143,9 @@ func (a *app) cmdPausedWatch(client apix.EngineClient, args []string) error {
 	fs.SetOutput(a.errw)
 	count := fs.Int("count", 0, "stop after N events")
 	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := validateStreamingOutput(a.opts.output); err != nil {
 		return err
 	}
 	ctx, cancel := a.streamContext()

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -665,3 +665,39 @@ func TestHeaderFlagsMap_InvalidHeader(t *testing.T) {
 		t.Fatal("expected parse error for malformed header")
 	}
 }
+
+func TestCLIWatchJSONOutputRejected(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+
+	exit, _, errOut := runCLI(t, stack.args("--output", "json", "watch", "traffic", "--count", "1")...)
+	if exit != 2 {
+		t.Fatalf("expected invalid-argument exit=2, got %d err=%s", exit, errOut)
+	}
+	payload := parseErrorEnvelope(t, errOut)
+	errPayload := payload["error"].(map[string]any)
+	if errPayload["code"] != "invalid_argument" {
+		t.Fatalf("unexpected code: %#v", errPayload["code"])
+	}
+	if !strings.Contains(errPayload["message"].(string), "--output ndjson") {
+		t.Fatalf("unexpected message: %#v", errPayload["message"])
+	}
+}
+
+func TestCLIPausedWatchJSONOutputRejected(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+
+	exit, _, errOut := runCLI(t, stack.args("--output", "json", "paused", "watch", "--count", "1")...)
+	if exit != 2 {
+		t.Fatalf("expected invalid-argument exit=2, got %d err=%s", exit, errOut)
+	}
+	payload := parseErrorEnvelope(t, errOut)
+	errPayload := payload["error"].(map[string]any)
+	if errPayload["code"] != "invalid_argument" {
+		t.Fatalf("unexpected code: %#v", errPayload["code"])
+	}
+	if !strings.Contains(errPayload["message"].(string), "--output ndjson") {
+		t.Fatalf("unexpected message: %#v", errPayload["message"])
+	}
+}


### PR DESCRIPTION
## Summary
- reject `--output json` for streaming commands with InvalidArgument
- keep `--output ndjson` as the valid streaming JSON format
- add regression tests for `watch traffic` and `paused watch`

Fixes #374