### PR TITLE
fix(vscode): recover cleanly from gRPC stream failures

### DIFF
--- a/apix-vscode/src/breakpointsProvider.ts
+++ b/apix-vscode/src/breakpointsProvider.ts
@@ -35,8 +35,7 @@ export class BreakpointsProvider implements vscode.TreeDataProvider<BreakpointIt
         } catch (err: any) {
             const msg = err?.message || String(err);
             this.output?.appendLine(`[APiX] Breakpoints view error: ${msg}`);
-            vscode.window.showErrorMessage(`APiX: Breakpoints view error — ${msg}`);
-            return [new ErrorItem(`Engine unreachable: ${msg}`)];
+            return [new ErrorItem(`Connection lost: ${msg}`, 'apix.refreshBreakpoints')];
         }
     }
 }
@@ -64,9 +63,15 @@ export class BreakpointItem extends vscode.TreeItem {
 
 /** Error item displayed when the engine is unreachable. */
 export class ErrorItem extends vscode.TreeItem {
-    constructor(message: string) {
+    constructor(message: string, refreshCommand?: string) {
         super(message, vscode.TreeItemCollapsibleState.None);
         this.iconPath = new vscode.ThemeIcon('error');
-        this.description = '';
+        this.description = refreshCommand ? 'Click to retry' : '';
+        if (refreshCommand) {
+            this.command = {
+                command: refreshCommand,
+                title: 'Retry',
+            };
+        }
     }
 }

--- a/apix-vscode/src/engineClient.ts
+++ b/apix-vscode/src/engineClient.ts
@@ -349,7 +349,8 @@ export class EngineClient {
     /** Start the real-time traffic capture stream (CaptureTraffic RPC). */
     captureTraffic(
         onData: (tx: HttpTransaction) => void,
-        onError: (err: Error) => void
+        onError: (err: Error) => void,
+        onEnd?: () => void
     ): grpc.ClientReadableStream<HttpTransaction> {
         this.ensureStub();
         const stream: grpc.ClientReadableStream<HttpRequest> = this.stub!.captureTraffic({}, this.metadata);
@@ -377,6 +378,7 @@ export class EngineClient {
             onData(tx);
         });
         stream.on('error', (err: Error) => onError(err));
+        stream.on('end', () => onEnd?.());
         return stream as unknown as grpc.ClientReadableStream<HttpTransaction>;
     }
 

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -139,6 +139,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand('apix.refreshTraffic', () => {
             trafficProvider?.refresh();
         }),
+        vscode.commands.registerCommand('apix.refreshBreakpoints', () => {
+            breakpointsProvider?.refresh();
+        }),
         vscode.commands.registerCommand('apix.mocks.refresh', () => {
             mocksProvider?.refresh();
         }),
@@ -181,6 +184,7 @@ export function deactivate(): void {
         clearTimeout(pausedRetryTimer);
         pausedRetryTimer = undefined;
     }
+    RequestEditor.closeAll();
     
     // Stop engine process
     processManager?.stop();
@@ -259,6 +263,7 @@ async function stopEngine(pm: EngineProcessManager): Promise<void> {
         clearTimeout(pausedRetryTimer);
         pausedRetryTimer = undefined;
     }
+    RequestEditor.closeAll();
     pm.stop();
     statusBarItem!.text = '$(circle-outline) APiX: Stopped';
     statusBarItem!.tooltip = 'APiX HTTP Proxy — click to start';
@@ -281,6 +286,8 @@ function _startWatchPausedRequests(context: vscode.ExtensionContext, client: Eng
             (err) => {
                 // Log to output channel so user can inspect stream errors
                 outputChannel?.appendLine(`[APiX] WatchPausedRequests stream error: ${err?.message || err}`);
+                RequestEditor.closeAll();
+                breakpointsProvider?.refresh();
                 if (processManager?.isRunning()) {
                     const delay = pausedRetryDelayMs;
                     pausedRetryDelayMs = Math.min(pausedRetryDelayMs * 2, 30000);
@@ -291,6 +298,8 @@ function _startWatchPausedRequests(context: vscode.ExtensionContext, client: Eng
             },
             () => {
                 console.log('[APiX] WatchPausedRequests stream ended.');
+                RequestEditor.closeAll();
+                breakpointsProvider?.refresh();
                 if (processManager?.isRunning()) {
                     const delay = pausedRetryDelayMs;
                     pausedRetryDelayMs = Math.min(pausedRetryDelayMs * 2, 30000);

--- a/apix-vscode/src/requestEditor.ts
+++ b/apix-vscode/src/requestEditor.ts
@@ -14,6 +14,7 @@ import { PausedRequest, ResumeAction, ResumeActionKind, HttpRequest, HttpRespons
  */
 export class RequestEditor {
     private static readonly viewType = 'apixRequestEditor';
+    private static readonly panels = new Set<vscode.WebviewPanel>();
 
     public static async showEditor(
         extensionUri: vscode.Uri,
@@ -26,6 +27,10 @@ export class RequestEditor {
             vscode.ViewColumn.Active,
             { enableScripts: true }
         );
+        RequestEditor.panels.add(panel);
+        panel.onDidDispose(() => {
+            RequestEditor.panels.delete(panel);
+        });
 
         panel.webview.html = RequestEditor._getHtml(panel.webview, paused);
 
@@ -77,6 +82,13 @@ export class RequestEditor {
                 vscode.window.showErrorMessage(`APiX: Failed to resume request — ${err?.message || err}`);
             }
         });
+    }
+
+    public static closeAll(): void {
+        for (const panel of RequestEditor.panels) {
+            panel.dispose();
+        }
+        RequestEditor.panels.clear();
     }
 
     private static _buildResumeAction(

--- a/apix-vscode/src/trafficPanel.ts
+++ b/apix-vscode/src/trafficPanel.ts
@@ -14,6 +14,9 @@ export class TrafficPanel {
     private readonly _panel: vscode.WebviewPanel;
     private readonly _extensionUri: vscode.Uri;
     private _disposables: vscode.Disposable[] = [];
+    private _captureStream: { cancel: () => void } | undefined;
+    private _captureRetryTimer: ReturnType<typeof setTimeout> | undefined;
+    private _captureRetryDelayMs = 1000;
 
     public static createOrShow(extensionUri: vscode.Uri, client: EngineClient): void {
         const column = vscode.window.activeTextEditor
@@ -66,19 +69,52 @@ export class TrafficPanel {
 
     /** Start the CaptureTraffic gRPC stream and push each transaction to the webview. */
     private _startCapture(): void {
+        if (this._captureRetryTimer) {
+            clearTimeout(this._captureRetryTimer);
+            this._captureRetryTimer = undefined;
+        }
+        this._captureStream?.cancel();
+        this._captureStream = undefined;
         try {
             const stream = this.client.captureTraffic(
                 (tx) => {
+                    this._captureRetryDelayMs = 1000;
                     if (this._panel.visible) {
                         this._panel.webview.postMessage({ type: 'transaction', data: tx });
+                        this._panel.webview.postMessage({ type: 'streamRecovered' });
                     }
                 },
-                (err) => console.error('[APiX] CaptureTraffic error:', err)
+                (err) => {
+                    const message = err?.message || String(err);
+                    this._panel.webview.postMessage({ type: 'streamError', data: message });
+                    this._scheduleCaptureRetry();
+                },
+                () => {
+                    this._panel.webview.postMessage({ type: 'streamError', data: 'Capture stream ended.' });
+                    this._scheduleCaptureRetry();
+                }
             );
-            this._disposables.push({ dispose: () => stream.cancel() });
+            this._captureStream = { cancel: () => stream.cancel() };
         } catch (err) {
-            console.error('[APiX] Failed to start capture stream:', err);
+            this._panel.webview.postMessage({ type: 'streamError', data: `Failed to start capture stream: ${err}` });
+            this._scheduleCaptureRetry();
         }
+    }
+
+    private _scheduleCaptureRetry(): void {
+        if (this._captureRetryTimer) {
+            return;
+        }
+        const delay = this._captureRetryDelayMs;
+        this._captureRetryDelayMs = Math.min(this._captureRetryDelayMs * 2, 30000);
+        this._captureRetryTimer = setTimeout(() => {
+            this._captureRetryTimer = undefined;
+            if (!this._panel.visible) {
+                this._scheduleCaptureRetry();
+                return;
+            }
+            this._startCapture();
+        }, delay);
     }
 
     private _handleWebviewMessage(message: { type: string; data: any }): void {
@@ -166,6 +202,7 @@ export class TrafficPanel {
     .badge { display: inline-block; padding: 1px 6px; border-radius: 999px; font-size: 11px; font-weight: 700; margin-right: 6px; }
     .badge-ws { background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
     .empty { text-align: center; padding: 40px; color: var(--vscode-descriptionForeground); }
+    #stream-error { display: none; margin-bottom: 8px; padding: 6px 8px; border-radius: 4px; border: 1px solid var(--vscode-inputValidation-errorBorder, #be1100); background: var(--vscode-inputValidation-errorBackground, #5a1d1d); color: var(--vscode-inputValidation-errorForeground, #fff); font-size: 12px; }
     #detail { display: none; position: fixed; top: 0; right: 0; width: 50%; height: 100%; background: var(--vscode-editor-background); border-left: 1px solid var(--vscode-panel-border); padding: 16px; overflow-y: auto; z-index: 10; box-sizing: border-box; }
     #detail.open { display: block; }
     #detail h3 { margin-top: 0; font-size: 14px; word-break: break-all; }
@@ -182,6 +219,7 @@ export class TrafficPanel {
   </style>
 </head>
 <body>
+  <div id="stream-error"></div>
   <div class="filter-bar">
     <div class="filter-row">
       <input type="text" id="filter" class="filter-url" placeholder="Filter by URL..." title="Filter by URL substring" />
@@ -246,6 +284,14 @@ export class TrafficPanel {
         if (msg.data && msg.data.requestId === currentFramesRequestId) {
           renderWebSocketFrames(msg.data.frames || []);
         }
+      } else if (msg.type === 'streamError') {
+        const el = document.getElementById('stream-error');
+        el.textContent = 'Connection lost — retrying… ' + (msg.data || '');
+        el.style.display = 'block';
+      } else if (msg.type === 'streamRecovered') {
+        const el = document.getElementById('stream-error');
+        el.style.display = 'none';
+        el.textContent = '';
       }
     });
 
@@ -600,6 +646,12 @@ export class TrafficPanel {
 
     public dispose(): void {
         TrafficPanel.currentPanel = undefined;
+        this._captureStream?.cancel();
+        this._captureStream = undefined;
+        if (this._captureRetryTimer) {
+            clearTimeout(this._captureRetryTimer);
+            this._captureRetryTimer = undefined;
+        }
         this._panel.dispose();
         while (this._disposables.length) {
             const d = this._disposables.pop();

--- a/apix-vscode/src/trafficProvider.ts
+++ b/apix-vscode/src/trafficProvider.ts
@@ -45,8 +45,7 @@ export class TrafficProvider implements vscode.TreeDataProvider<TrafficItem | Er
         } catch (err: any) {
             const msg = err?.message || String(err);
             this.output?.appendLine(`[APiX] Traffic view error: ${msg}`);
-            vscode.window.showErrorMessage(`APiX: Traffic view error — ${msg}`);
-            return [new ErrorItem(`Engine unreachable: ${msg}`)];
+            return [new ErrorItem(`Connection lost: ${msg}`, 'apix.refreshTraffic')];
         }
     }
 }
@@ -84,9 +83,15 @@ export class TrafficItem extends vscode.TreeItem {
 
 /** Error item displayed when the engine is unreachable. */
 export class ErrorItem extends vscode.TreeItem {
-    constructor(message: string) {
+    constructor(message: string, refreshCommand?: string) {
         super(message, vscode.TreeItemCollapsibleState.None);
         this.iconPath = new vscode.ThemeIcon('error');
-        this.description = '';
+        this.description = refreshCommand ? 'Click to retry' : '';
+        if (refreshCommand) {
+            this.command = {
+                command: refreshCommand,
+                title: 'Retry',
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show inline retryable error items in Traffic and Breakpoints tree views instead of stale/silent failures
- close stale paused-request editors when paused stream errors/ends and re-subscribe with backoff
- add capture stream error banner + auto-retry in TrafficPanel, including recovery signal
- add optional stream end callback in EngineClient captureTraffic

Fixes #306