### PR TITLE
fix(map-local): add alias support and integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Validate config:
 | `health_port` | `9092` | `/healthz` endpoint |
 | `mcp_enabled` / `mcp_port` | `false` / `9093` | MCP server |
 | `mcp_allow_replay` / `mcp_allow_compose` | `false` / `false` | Side-effect MCP tools |
-| `map_local_rules` | empty | URL regex -> local file response mapping |
+| `map_local_rules` | empty | URL regex -> local file response mapping (`file_path`, with `local_path` alias) |
 
 ## Security model
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -119,6 +119,28 @@ See [`how-to/replay.md`](how-to/replay.md) for step-by-step guide.
 
 ---
 
+### Map Local Rules
+
+Serve local files directly from the proxy when a request URL matches a configured regex.
+
+- Rules are configured in `config.yaml` under `map_local_rules`
+- `url_pattern` uses Go regex syntax and is validated on startup
+- `file_path` is the primary path key (`local_path` is accepted as an alias)
+- If a rule matches, APiX returns the local file and does not forward upstream
+- If the matched file is missing/unreadable, APiX returns `500` with an explicit map-local error
+- Content type is inferred from file extension or detected bytes when `content_type` is omitted
+- Map-local rules are config-driven (not persisted in SQLite)
+
+Example:
+```yaml
+map_local_rules:
+  - url_pattern: '^https://api.example.com/config$'
+    file_path: './mocks/config.json'
+    status_code: 200
+```
+
+---
+
 ### Request/Response Templates
 
 **Save and reuse request patterns** for frequently-used workflows.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,8 +86,17 @@ type Config struct {
 type MapLocalRule struct {
 	URLPattern  string `yaml:"url_pattern"`
 	FilePath    string `yaml:"file_path"`
+	// LocalPath is a backwards-compatible alias for file_path.
+	LocalPath   string `yaml:"local_path"`
 	ContentType string `yaml:"content_type"`
 	StatusCode  int    `yaml:"status_code"`
+}
+
+func (r MapLocalRule) EffectiveFilePath() string {
+	if r.FilePath != "" {
+		return r.FilePath
+	}
+	return r.LocalPath
 }
 
 // DefaultPath returns the config file path following these priorities:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -201,6 +201,29 @@ map_local_rules:
 	}
 }
 
+func TestLoadConfig_MapLocalRulesLocalPathAlias(t *testing.T) {
+	t.Parallel()
+	path := writeTemp(t, `
+map_local_rules:
+  - url_pattern: "^https://example\\.com/mock$"
+    local_path: "./mocks/mock.json"
+`)
+	cfg := LoadConfig(path)
+	if len(cfg.MapLocalRules) != 1 {
+		t.Fatalf("MapLocalRules: got %d want 1", len(cfg.MapLocalRules))
+	}
+	rule := cfg.MapLocalRules[0]
+	if rule.FilePath != "" {
+		t.Errorf("FilePath: got %q want empty when local_path used", rule.FilePath)
+	}
+	if rule.LocalPath != "./mocks/mock.json" {
+		t.Errorf("LocalPath: got %q", rule.LocalPath)
+	}
+	if got := rule.EffectiveFilePath(); got != "./mocks/mock.json" {
+		t.Errorf("EffectiveFilePath: got %q want ./mocks/mock.json", got)
+	}
+}
+
 func TestDefaultPath_EnvVar(t *testing.T) {
 	t.Setenv("APIX_CONFIG", "/custom/path/config.yaml")
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -190,8 +190,8 @@ func (c *Config) validate(allowBoundPorts bool) error {
 		} else if _, err := regexp.Compile(rule.URLPattern); err != nil {
 			errs = append(errs, fmt.Errorf("map_local_rules[%d].url_pattern %q is not a valid Go regexp: %w", i, rule.URLPattern, err))
 		}
-		if rule.FilePath == "" {
-			errs = append(errs, fmt.Errorf("map_local_rules[%d].file_path is empty — provide a readable local file path", i))
+		if rule.EffectiveFilePath() == "" {
+			errs = append(errs, fmt.Errorf("map_local_rules[%d].file_path is empty — provide file_path (or local_path) with a readable local file path", i))
 		}
 		if rule.StatusCode != 0 && (rule.StatusCode < 100 || rule.StatusCode > 599) {
 			errs = append(errs, fmt.Errorf("map_local_rules[%d].status_code must be 100-599 when set (got %d)", i, rule.StatusCode))

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -408,6 +408,27 @@ func TestValidate_MapLocalRules(t *testing.T) {
 	}
 }
 
+func TestValidate_MapLocalRulesLocalPathAlias(t *testing.T) {
+	t.Parallel()
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:            httpPort,
+		GRPCPort:            grpcPort,
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		MapLocalRules: []MapLocalRule{
+			{
+				URLPattern: "^https://example\\.com/mock$",
+				LocalPath:  "mock.json",
+				StatusCode: 200,
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid map-local config with local_path alias, got: %v", err)
+	}
+}
+
 func TestValidate_MapLocalRulesInvalid(t *testing.T) {
 	t.Parallel()
 	httpPort, grpcPort := mustFreePorts(t)

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -533,6 +533,7 @@ func (p *HTTPProxy) applyMapLocalRules(ctx context.Context, req *plugins.ProxyRe
 		}
 
 		filePath := rule.EffectiveFilePath()
+		// #nosec G304 -- map-local intentionally serves operator-configured local files.
 		body, err := os.ReadFile(filePath)
 		if err != nil {
 			msg := fmt.Sprintf("map-local read file %q: %v", filePath, err)

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -532,9 +532,10 @@ func (p *HTTPProxy) applyMapLocalRules(ctx context.Context, req *plugins.ProxyRe
 			continue
 		}
 
-		body, err := os.ReadFile(rule.FilePath)
+		filePath := rule.EffectiveFilePath()
+		body, err := os.ReadFile(filePath)
 		if err != nil {
-			msg := fmt.Sprintf("map-local read file %q: %v", rule.FilePath, err)
+			msg := fmt.Sprintf("map-local read file %q: %v", filePath, err)
 			logging.Errorf(ctx, "%s", msg)
 			return &plugins.ProxyResponse{
 				StatusCode: http.StatusInternalServerError,
@@ -549,7 +550,7 @@ func (p *HTTPProxy) applyMapLocalRules(ctx context.Context, req *plugins.ProxyRe
 		}
 		contentType := rule.ContentType
 		if contentType == "" {
-			contentType = detectContentType(rule.FilePath, body)
+			contentType = detectContentType(filePath, body)
 		}
 		return &plugins.ProxyResponse{
 			StatusCode: statusCode,

--- a/tests/integration/proxy_storage_test.go
+++ b/tests/integration/proxy_storage_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -43,6 +44,10 @@ type proxyStack struct {
 // newProxyStack starts a real HTTP proxy on a random port wired to an
 // in-memory engine and storage. Caller must call stop() to clean up.
 func newProxyStack(t *testing.T) *proxyStack {
+	return newProxyStackWithConfig(t, nil)
+}
+
+func newProxyStackWithConfig(t *testing.T, cfg *config.Config) *proxyStack {
 	t.Helper()
 
 	// Open in-memory database.
@@ -67,12 +72,23 @@ func newProxyStack(t *testing.T) *proxyStack {
 		t.Fatalf("NewCertAuthority: %v", err)
 	}
 
-	cfg := &config.Config{
-		HTTPReadHeaderTimeout: 10,
-		HTTPReadTimeout:       30,
-		HTTPWriteTimeout:      120,
-		HTTPIdleTimeout:       120,
-		MaxBodySizeMB:         32,
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	if cfg.HTTPReadHeaderTimeout == 0 {
+		cfg.HTTPReadHeaderTimeout = 10
+	}
+	if cfg.HTTPReadTimeout == 0 {
+		cfg.HTTPReadTimeout = 30
+	}
+	if cfg.HTTPWriteTimeout == 0 {
+		cfg.HTTPWriteTimeout = 120
+	}
+	if cfg.HTTPIdleTimeout == 0 {
+		cfg.HTTPIdleTimeout = 120
+	}
+	if cfg.MaxBodySizeMB == 0 {
+		cfg.MaxBodySizeMB = 32
 	}
 
 	// Wire up HTTP and TLS proxies.
@@ -214,6 +230,59 @@ func TestIntegration_ProxyStoresCorrectFields(t *testing.T) {
 	}
 	if !strings.Contains(string(respRec.Body), "stored response body") {
 		t.Errorf("stored response body: got %q", string(respRec.Body))
+	}
+}
+
+func TestIntegration_MapLocalRuleServesLocalFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mockPath := filepath.Join(dir, "mock.json")
+	const wantBody = `{"ok":true}`
+	if err := os.WriteFile(mockPath, []byte(wantBody), 0o600); err != nil {
+		t.Fatalf("write mock file: %v", err)
+	}
+
+	stack := newProxyStackWithConfig(t, &config.Config{
+		MapLocalRules: []config.MapLocalRule{
+			{
+				URLPattern: "^https?://.*/local-config$",
+				LocalPath:  mockPath,
+				StatusCode: http.StatusCreated,
+			},
+		},
+	})
+	defer stack.stop()
+
+	var upstreamCalled atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upstream"))
+	}))
+	defer upstream.Close()
+
+	resp, err := stack.client().Get(upstream.URL + "/local-config")
+	if err != nil {
+		t.Fatalf("proxy GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d want %d", resp.StatusCode, http.StatusCreated)
+	}
+	if string(body) != wantBody {
+		t.Fatalf("body: got %q want %q", string(body), wantBody)
+	}
+	if got := resp.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type: got %q want application/json", got)
+	}
+	if upstreamCalled.Load() != 0 {
+		t.Fatalf("upstream should not be called for map-local match, got %d calls", upstreamCalled.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept `local_path` as a backwards-compatible alias for `file_path` in `map_local_rules`
- use an `EffectiveFilePath` helper in proxy and config validation
- add config/validation tests for the alias and an integration test covering map-local end-to-end behavior
- document map-local runtime behavior and config keys

Fixes #296