### PR TITLE
fix(logging): preserve request context in error paths

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -73,6 +73,13 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 	)
 
 	req := tx.Request
+	logCtx := context.Background()
+	if req != nil && req.Raw != nil {
+		logCtx = req.Raw.Context()
+	}
+	if tx.ID != "" {
+		logCtx = logging.WithRequestID(logCtx, tx.ID)
+	}
 	if req != nil {
 		// Prefer storing the original headers captured before plugins modified them.
 		var rawHeader http.Header
@@ -117,7 +124,7 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 			}
 		}
 		if dropped > 0 {
-			logging.Warnf(context.Background(),
+			logging.Warnf(logCtx,
 				"dropped traffic event for %d/%d subscriber(s) — channel full",
 				dropped, len(subscribers))
 		}
@@ -140,7 +147,7 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 	if reqRec != nil && respRec != nil {
 		if saver, ok := e.db.(pairTransactionSaver); ok {
 			if err := saver.SaveTransaction(reqRec, respRec); err != nil {
-				logging.Errorf(context.Background(), "engine: save transaction: %v", err)
+				logging.Errorf(logCtx, "engine: save transaction: %v", err)
 				retErr = err
 			}
 			return retErr
@@ -149,13 +156,13 @@ func (e *Engine) StoreTransaction(tx *proxy.Transaction) error {
 
 	if reqRec != nil {
 		if err := e.db.SaveRequest(reqRec); err != nil {
-			logging.Errorf(context.Background(), "engine: save request: %v", err)
+			logging.Errorf(logCtx, "engine: save request: %v", err)
 			retErr = err
 		}
 	}
 	if respRec != nil {
 		if err := e.db.SaveResponse(respRec); err != nil {
-			logging.Errorf(context.Background(), "engine: save response: %v", err)
+			logging.Errorf(logCtx, "engine: save response: %v", err)
 			if retErr == nil {
 				retErr = err
 			}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -651,7 +651,7 @@ func (p *HTTPProxy) handleTunnelConn(ctx context.Context, conn net.Conn, br *buf
 			req.URL.Scheme = "http"
 		}
 		req = req.WithContext(ctx)
-		w := newHijackableResponseWriter(conn, br)
+		w := newHijackableResponseWriter(ctx, conn, br)
 		p.handleHTTP(w, req)
 		if isWebSocketRequest(req) {
 			return

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -144,7 +144,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	defer func() {
 		if rec := recover(); rec != nil {
 			logging.Errorf(ctx, "TLS proxy panic (recovered): %v", rec)
-			writeHTTPError(conn, http.StatusBadGateway, "proxy error")
+			writeHTTPError(ctx, conn, http.StatusBadGateway, "proxy error")
 		}
 	}()
 
@@ -164,7 +164,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		var err error
 		bodyBytes, err = httputil.ReadLimitedBody(r.Body, maxBodyBytes)
 		if err != nil {
-			writeHTTPError(conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("request body too large: %v", err))
+			writeHTTPError(ctx, conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("request body too large: %v", err))
 			return
 		}
 		_ = r.Body.Close()
@@ -186,13 +186,13 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	var err error
 	proxyReq, err = runPluginRequest(ctx, p.plugins, proxyReq, "tls proxy")
 	if err != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("plugin error: %v", err))
+		writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("plugin error: %v", err))
 		return
 	}
 
 	// Mocked response short-circuit.
 	if proxyReq.MockedResponse != nil {
-		writeProxyResponseToConn(conn, proxyReq.MockedResponse)
+		writeProxyResponseToConn(ctx, conn, proxyReq.MockedResponse)
 		return
 	}
 
@@ -206,13 +206,13 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		tx = modified
 		switch action {
 		case ResumeDrop:
-			writeHTTPError(conn, http.StatusBadGateway, "request dropped by breakpoint")
+			writeHTTPError(ctx, conn, http.StatusBadGateway, "request dropped by breakpoint")
 			return
 		case ResumeRespond:
 			if tx.Response != nil {
-				writeProxyResponseToConn(conn, tx.Response)
+				writeProxyResponseToConn(ctx, conn, tx.Response)
 			} else {
-				writeHTTPError(conn, http.StatusBadGateway, "no synthetic response")
+				writeHTTPError(ctx, conn, http.StatusBadGateway, "no synthetic response")
 			}
 			return
 		}
@@ -226,14 +226,14 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	// Build and send upstream request using the shared pooled transport.
 	upReq, upErr := http.NewRequestWithContext(ctx, proxyReq.Method, proxyReq.URL.String(), proxyReq.Body)
 	if upErr != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("build upstream request: %v", upErr))
+		writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("build upstream request: %v", upErr))
 		return
 	}
 	upReq.Header = proxyReq.Headers.Clone()
 
 	upResp, upErr := p.transport.RoundTrip(upReq)
 	if upErr != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("upstream error: %v", upErr))
+		writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("upstream error: %v", upErr))
 		return
 	}
 	defer func() { _ = upResp.Body.Close() }()
@@ -241,7 +241,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	// Apply the same body size limit to response bodies
 	respBody, readErr := httputil.ReadLimitedBody(upResp.Body, maxBodyBytes)
 	if readErr != nil {
-		writeHTTPError(conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("response body too large: %v", readErr))
+		writeHTTPError(ctx, conn, http.StatusRequestEntityTooLarge, fmt.Sprintf("response body too large: %v", readErr))
 		return
 	}
 	mergeTrailersIntoHeaders(upResp.Header, upResp.Trailer)
@@ -258,7 +258,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	// Run plugin OnResponse chain with panic recovery.
 	proxyResp, err = runPluginResponse(ctx, p.plugins, proxyReq, proxyResp, "tls proxy")
 	if err != nil {
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("plugin OnResponse error: %v", err))
+		writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("plugin OnResponse error: %v", err))
 		return
 	}
 
@@ -269,7 +269,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		var readErr error
 		finalRespBody, readErr = io.ReadAll(proxyResp.Body)
 		if readErr != nil {
-			writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("read response body: %v", readErr))
+			writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("read response body: %v", readErr))
 			return
 		}
 		proxyResp.Body = io.NopCloser(bytes.NewReader(finalRespBody))
@@ -286,13 +286,13 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		tx = modified
 		switch action {
 		case ResumeDrop:
-			writeHTTPError(conn, http.StatusBadGateway, "response dropped by breakpoint")
+			writeHTTPError(ctx, conn, http.StatusBadGateway, "response dropped by breakpoint")
 			return
 		case ResumeRespond:
 			if tx.Response != nil {
-				writeProxyResponseToConn(conn, tx.Response)
+				writeProxyResponseToConn(ctx, conn, tx.Response)
 			} else {
-				writeHTTPError(conn, http.StatusBadGateway, "no synthetic response")
+				writeHTTPError(ctx, conn, http.StatusBadGateway, "no synthetic response")
 			}
 			return
 		}
@@ -311,7 +311,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	observeRequest(ctx, p.cfg, proxyReq.Method, proxyReq.URL.Host, tx.Response.StatusCode, dur)
 	_ = reqID
 
-	writeProxyResponseToConn(conn, tx.Response)
+	writeProxyResponseToConn(ctx, conn, tx.Response)
 }
 
 func (p *TLSProxy) handleHTTP2Conn(ctx context.Context, conn net.Conn, br *bufio.Reader, host string) {
@@ -503,11 +503,11 @@ func (p *TLSProxy) handleWebSocket(ctx context.Context, conn net.Conn, br *bufio
 			defer func() { _ = resp.Body.Close() }()
 			msg, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
 			if readErr == nil && len(msg) > 0 {
-				writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("websocket upstream error: %v: %s", err, msg))
+				writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("websocket upstream error: %v: %s", err, msg))
 				return
 			}
 		}
-		writeHTTPError(conn, http.StatusBadGateway, fmt.Sprintf("websocket upstream error: %v", err))
+		writeHTTPError(ctx, conn, http.StatusBadGateway, fmt.Sprintf("websocket upstream error: %v", err))
 		return
 	}
 
@@ -517,7 +517,7 @@ func (p *TLSProxy) handleWebSocket(ctx context.Context, conn net.Conn, br *bufio
 	if protocol := upstreamConn.Subprotocol(); protocol != "" {
 		upgrader.Subprotocols = []string{protocol}
 	}
-	responseWriter := newHijackableResponseWriter(conn, br)
+	responseWriter := newHijackableResponseWriter(ctx, conn, br)
 	clientConn, err := upgrader.Upgrade(responseWriter, clientReq, copyHeadersExcluding(resp.Header, "Connection", "Upgrade", "Sec-WebSocket-Accept", "Sec-WebSocket-Extensions"))
 	if err != nil {
 		_ = upstreamConn.Close()
@@ -541,7 +541,7 @@ func (p *TLSProxy) handleWebSocket(ctx context.Context, conn net.Conn, br *bufio
 }
 
 // writeHTTPError writes a minimal HTTP error response to the connection.
-func writeHTTPError(conn net.Conn, code int, msg string) {
+func writeHTTPError(ctx context.Context, conn net.Conn, code int, msg string) {
 	resp := &http.Response{
 		StatusCode: code,
 		Status:     fmt.Sprintf("%d %s", code, http.StatusText(code)),
@@ -553,18 +553,18 @@ func writeHTTPError(conn net.Conn, code int, msg string) {
 	}
 	resp.ContentLength = int64(len(msg))
 	if err := resp.Write(conn); err != nil {
-		logging.Errorf(context.Background(), "tls proxy: write error response to client: %v", err)
+		logging.Errorf(ctx, "tls proxy: write error response to client: %v", err)
 	}
 }
 
 // writeProxyResponseToConn serialises a ProxyResponse to a net.Conn.
-func writeProxyResponseToConn(conn net.Conn, resp *plugins.ProxyResponse) {
+func writeProxyResponseToConn(ctx context.Context, conn net.Conn, resp *plugins.ProxyResponse) {
 	var body []byte
 	if resp.Body != nil {
 		var err error
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			logging.Errorf(context.Background(), "tls proxy: read response body for write: %v", err)
+			logging.Errorf(ctx, "tls proxy: read response body for write: %v", err)
 			return
 		}
 	}
@@ -579,7 +579,7 @@ func writeProxyResponseToConn(conn net.Conn, resp *plugins.ProxyResponse) {
 		ContentLength: int64(len(body)),
 	}
 	if err := httpResp.Write(conn); err != nil {
-		logging.Errorf(context.Background(), "tls proxy: write response to client: %v", err)
+		logging.Errorf(ctx, "tls proxy: write response to client: %v", err)
 	}
 }
 

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -213,13 +213,18 @@ type hijackableResponseWriter struct {
 	conn   net.Conn
 	reader *bufio.Reader
 	header http.Header
+	ctx    context.Context
 }
 
-func newHijackableResponseWriter(conn net.Conn, reader *bufio.Reader) *hijackableResponseWriter {
+func newHijackableResponseWriter(ctx context.Context, conn net.Conn, reader *bufio.Reader) *hijackableResponseWriter {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	return &hijackableResponseWriter{
 		conn:   conn,
 		reader: reader,
 		header: make(http.Header),
+		ctx:    ctx,
 	}
 }
 
@@ -244,7 +249,7 @@ func (w *hijackableResponseWriter) WriteHeader(statusCode int) {
 		ContentLength: int64(len(body)),
 	}
 	if err := response.Write(w.conn); err != nil {
-		logging.Errorf(context.Background(), "websocket response writer: %v", err)
+		logging.Errorf(w.ctx, "websocket response writer: %v", err)
 	}
 }
 

--- a/internal/storage/mapper.go
+++ b/internal/storage/mapper.go
@@ -32,7 +32,7 @@ func scanRequest(row *sql.Row) (*RequestRecord, error) {
 		Protocol:   protocol,
 	}
 	if err := json.Unmarshal([]byte(hdrs), &req.Headers); err != nil {
-		logging.Warnf(context.Background(), "failed to unmarshal request headers for request %s: %v", id, err)
+		logging.Warnf(logging.WithRequestID(context.Background(), id), "failed to unmarshal request headers for request %s: %v", id, err)
 		req.Headers = make(map[string]string)
 	}
 	return req, nil
@@ -60,7 +60,7 @@ func scanResponse(row *sql.Row) (*ResponseRecord, error) {
 		Body:       body,
 	}
 	if err := json.Unmarshal([]byte(hdrs), &resp.Headers); err != nil {
-		logging.Warnf(context.Background(), "failed to unmarshal response headers for request %s: %v", reqID, err)
+		logging.Warnf(logging.WithRequestID(context.Background(), reqID), "failed to unmarshal response headers for request %s: %v", reqID, err)
 		resp.Headers = make(map[string]string)
 	}
 	return resp, nil
@@ -100,7 +100,7 @@ func scanTransactionRows(rows *sql.Rows) ([]*RequestRecord, []*ResponseRecord, e
 			Protocol:   protocol,
 		}
 		if err := json.Unmarshal([]byte(reqHeaders), &req.Headers); err != nil {
-			logging.Warnf(context.Background(), "failed to unmarshal request headers for request %s: %v", reqID, err)
+			logging.Warnf(logging.WithRequestID(context.Background(), reqID), "failed to unmarshal request headers for request %s: %v", reqID, err)
 			req.Headers = make(map[string]string)
 		}
 		reqs = append(reqs, req)
@@ -119,7 +119,7 @@ func scanTransactionRows(rows *sql.Rows) ([]*RequestRecord, []*ResponseRecord, e
 			}
 			if respHeaders.Valid {
 				if err := json.Unmarshal([]byte(respHeaders.String), &resp.Headers); err != nil {
-					logging.Warnf(context.Background(), "failed to unmarshal response headers for request %s: %v", respReqID.String, err)
+					logging.Warnf(logging.WithRequestID(context.Background(), respReqID.String), "failed to unmarshal response headers for request %s: %v", respReqID.String, err)
 					resp.Headers = make(map[string]string)
 				}
 			}

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -296,11 +296,11 @@ func (d *DB) ListBreakpoints() ([]*BreakpointRecord, error) {
 			CreatedAt:   time.UnixMilli(createdAtMs),
 		}
 		if err := json.Unmarshal([]byte(methodsJSON), &bp.Methods); err != nil {
-			logging.Warnf(context.Background(), "failed to unmarshal methods for breakpoint %s: %v", id, err)
+			logging.Warnf(logging.WithRequestID(context.Background(), id), "failed to unmarshal methods for breakpoint %s: %v", id, err)
 			bp.Methods = nil
 		}
 		if err := json.Unmarshal([]byte(statusCodesJSON), &bp.StatusCodes); err != nil {
-			logging.Warnf(context.Background(), "failed to unmarshal status codes for breakpoint %s: %v", id, err)
+			logging.Warnf(logging.WithRequestID(context.Background(), id), "failed to unmarshal status codes for breakpoint %s: %v", id, err)
 			bp.StatusCodes = nil
 		}
 		bps = append(bps, bp)
@@ -353,7 +353,7 @@ func (d *DB) ListRequestTemplates() ([]*RequestTemplateRecord, error) {
 			UpdatedAt: time.UnixMilli(updatedAtMs),
 		}
 		if err := json.Unmarshal([]byte(hdrs), &tpl.Headers); err != nil {
-			logging.Warnf(context.Background(), "failed to unmarshal template headers for id %s: %v", id, err)
+			logging.Warnf(logging.WithRequestID(context.Background(), id), "failed to unmarshal template headers for id %s: %v", id, err)
 			tpl.Headers = map[string]string{}
 		}
 		templates = append(templates, tpl)


### PR DESCRIPTION
## Summary
- keep request-scoped context in engine transaction persistence logs
- propagate request context into TLS/websocket response write helpers
- avoid raw `context.Background()` in storage decode warning paths by attaching request-scoped IDs

Note: startup config logs still intentionally use background context because there is no request scope at load time.

Fixes #383