### PR TITLE
feat(logging): add Debugf helper

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -115,6 +115,11 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	getLogger().ErrorContext(ctx, fmt.Sprintf(format, args...), extraArgs(ctx)...)
 }
 
+// Debugf logs a formatted debug-level message.
+func Debugf(ctx context.Context, format string, args ...interface{}) {
+	getLogger().DebugContext(ctx, fmt.Sprintf(format, args...), extraArgs(ctx)...)
+}
+
 // Fatalf logs a formatted fatal-level message and exits the process.
 func Fatalf(ctx context.Context, format string, args ...interface{}) {
 	getLogger().ErrorContext(ctx, fmt.Sprintf(format, args...), extraArgs(ctx)...)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -42,6 +42,29 @@ func TestInitWithFormatText(t *testing.T) {
 	}
 }
 
+func TestDebugf(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithFormat(&buf, "json")
+
+	ctx := WithRequestID(context.Background(), "rid-debug")
+	Debugf(ctx, "debug value=%d", 7)
+
+	line := strings.TrimSpace(buf.String())
+	if line == "" {
+		t.Fatal("expected debug log output, got empty string")
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		t.Fatalf("expected valid JSON, got: %s — err: %v", line, err)
+	}
+	if entry["msg"] != "debug value=7" {
+		t.Errorf("unexpected msg: %v", entry["msg"])
+	}
+	if entry["request_id"] != "rid-debug" {
+		t.Errorf("unexpected request_id: %v", entry["request_id"])
+	}
+}
+
 func TestInitNilWriterDefaultsToText(t *testing.T) {
 	// Init(nil) should not panic; it falls back to os.Stdout
 	Init(nil)


### PR DESCRIPTION
Summary:
- add logging Debugf helper for debug-level structured logs
- add test for debug output and request_id propagation

Fixes #380