### PR TITLE
feat(logging): make log level configurable

### DIFF
--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -27,6 +27,7 @@ import (
 func main() {
 	configCheck := flag.Bool("config-check", false, "Validate config and exit")
 	logFormat := flag.String("log-format", "", "Log output format: 'text' or 'json' (overrides LOG_FORMAT env var; default 'text')")
+	logLevel := flag.String("log-level", "", "Log level: 'debug', 'info', 'warn', or 'error' (overrides LOG_LEVEL env var; default 'info')")
 	flag.Parse()
 
 	stop := make(chan os.Signal, 1)
@@ -43,7 +44,14 @@ func main() {
 	if format == "" {
 		format = "text"
 	}
-	logging.InitWithFormat(os.Stdout, format)
+	level := *logLevel
+	if level == "" {
+		level = os.Getenv("LOG_LEVEL")
+	}
+	if level == "" {
+		level = "info"
+	}
+	logging.InitWithFormatAndLevel(os.Stdout, format, level)
 
 	// 1. Load config from well-known search paths.
 	cfg := config.LoadConfig(config.DefaultPath())

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -24,6 +24,7 @@ const RequestIDHeader = "X-Request-ID"
 
 // global holds the active *slog.Logger with lock-free loads/stores.
 var global atomic.Pointer[slog.Logger]
+var levelVar slog.LevelVar
 
 func getLogger() *slog.Logger {
 	if l := global.Load(); l != nil {
@@ -39,17 +40,25 @@ func setLogger(l *slog.Logger) {
 // Init initializes the logger with the text handler writing to w.
 // If w is nil, os.Stdout is used. Equivalent to InitWithFormat(w, "text").
 func Init(w io.Writer) {
-	InitWithFormat(w, "text")
+	InitWithFormatAndLevel(w, "text", "info")
 }
 
 // InitWithFormat initialises the global logger.
 // format must be "json" or "text" (case-insensitive); anything else defaults to text.
 // If w is nil, os.Stdout is used.
 func InitWithFormat(w io.Writer, format string) {
+	InitWithFormatAndLevel(w, format, "info")
+}
+
+// InitWithFormatAndLevel initialises the global logger with format and level.
+// format: "json" or "text" (unknown values default to text)
+// level: "debug", "info", "warn", "error" (unknown values default to info)
+func InitWithFormatAndLevel(w io.Writer, format string, level string) {
 	if w == nil {
 		w = os.Stdout
 	}
-	opts := &slog.HandlerOptions{Level: slog.LevelDebug}
+	levelVar.Set(parseLevel(level))
+	opts := &slog.HandlerOptions{Level: &levelVar}
 	var h slog.Handler
 	if format == "json" {
 		h = slog.NewJSONHandler(w, opts)
@@ -57,6 +66,19 @@ func InitWithFormat(w io.Writer, format string) {
 		h = slog.NewTextHandler(w, opts)
 	}
 	setLogger(slog.New(h))
+}
+
+func parseLevel(level string) slog.Level {
+	switch level {
+	case "debug", "DEBUG":
+		return slog.LevelDebug
+	case "warn", "WARN", "warning", "WARNING":
+		return slog.LevelWarn
+	case "error", "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 // WithRequestID returns a new context with the provided request ID attached.

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -44,7 +44,7 @@ func TestInitWithFormatText(t *testing.T) {
 
 func TestDebugf(t *testing.T) {
 	var buf bytes.Buffer
-	InitWithFormat(&buf, "json")
+	InitWithFormatAndLevel(&buf, "json", "debug")
 
 	ctx := WithRequestID(context.Background(), "rid-debug")
 	Debugf(ctx, "debug value=%d", 7)
@@ -62,6 +62,15 @@ func TestDebugf(t *testing.T) {
 	}
 	if entry["request_id"] != "rid-debug" {
 		t.Errorf("unexpected request_id: %v", entry["request_id"])
+	}
+}
+
+func TestDebugfSuppressedAtInfoLevel(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithFormatAndLevel(&buf, "json", "info")
+	Debugf(context.Background(), "hidden debug")
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Fatalf("expected no debug output at info level, got: %s", buf.String())
 	}
 }
 


### PR DESCRIPTION
Summary:
- add log-level flag and LOG_LEVEL env support in engine startup
- add level-aware logger initialization using slog LevelVar
- default logging level changed to info

Fixes #379