### PR TITLE
feat(config): add log_format and log_level settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Validate config:
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
 | `metrics_enabled` / `metrics_port` | `false` / `9091` | Prometheus metrics endpoint |
 | `health_port` | `9092` | `/healthz` endpoint |
+| `log_format` / `log_level` | `text` / `info` | Engine log output shape and verbosity |
 | `mcp_enabled` / `mcp_port` | `false` / `9093` | MCP server |
 | `mcp_allow_replay` / `mcp_allow_compose` | `false` / `false` | Side-effect MCP tools |
 | `map_local_rules` | empty | URL regex -> local file response mapping (`file_path`, with `local_path` alias) |

--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -36,25 +36,11 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := &sync.WaitGroup{}
 
-	// Resolve log format: flag > LOG_FORMAT env var > default "text".
-	format := *logFormat
-	if format == "" {
-		format = os.Getenv("LOG_FORMAT")
-	}
-	if format == "" {
-		format = "text"
-	}
-	level := *logLevel
-	if level == "" {
-		level = os.Getenv("LOG_LEVEL")
-	}
-	if level == "" {
-		level = "info"
-	}
-	logging.InitWithFormatAndLevel(os.Stdout, format, level)
-
 	// 1. Load config from well-known search paths.
 	cfg := config.LoadConfig(config.DefaultPath())
+	format := firstNonEmpty(*logFormat, os.Getenv("LOG_FORMAT"), cfg.LogFormat, "text")
+	level := firstNonEmpty(*logLevel, os.Getenv("LOG_LEVEL"), cfg.LogLevel, "info")
+	logging.InitWithFormatAndLevel(os.Stdout, format, level)
 
 	// Initialize metrics (Prometheus endpoint + slowlog)
 	metrics.Init(cfg.MetricsEnabled)
@@ -236,4 +222,13 @@ func main() {
 	case <-time.After(15 * time.Second):
 		logging.Fatalf(ctx, "FATAL: shutdown timeout exceeded (15s), forcing exit")
 	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	HistoryMaxAgeDays int `yaml:"history_max_age_days"` // 0 = keep forever
 	HistoryMaxRows    int `yaml:"history_max_rows"`     // 0 = unlimited
 
+	// Logging
+	LogFormat string `yaml:"log_format"` // text|json
+	LogLevel  string `yaml:"log_level"`  // debug|info|warn|error
+
 	// GRPCRateLimitPerSec is the maximum number of gRPC unary calls allowed
 	// per peer address per second. Stream RPCs count as 1 call on open.
 	// 0 disables rate limiting (local desktop mode default).
@@ -162,6 +166,8 @@ func LoadConfig(path string) *Config {
 		VacuumIntervalHours: 24,
 		GRPCRateLimitPerSec: 0, // 0 = disabled (local desktop); set to e.g. 100 for remote deployments
 		SlowlogThresholdMs:  1000,
+		LogFormat:           "text",
+		LogLevel:            "info",
 		MCPEnabled:          false,
 		MCPPort:             "9093",
 		MCPBindAddress:      "127.0.0.1",

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -12,6 +12,10 @@ mcp_bind_address: "127.0.0.1"  # remote usage requires tls_enabled: true + auth 
 mcp_allow_replay: false
 mcp_allow_compose: false
 
+# Logging
+log_format: "text"  # text | json
+log_level: "info"   # debug | info | warn | error
+
 # HTTP server timeouts (prevents Slowloris attacks)
 http_read_header_timeout_sec: 10
 http_read_timeout_sec: 30

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,8 @@ max_body_size_mb: 64
 dial_timeout_sec: 5
 mcp_enabled: true
 mcp_port: "9100"
+log_format: "json"
+log_level: "debug"
 `)
 	cfg := LoadConfig(path)
 
@@ -85,6 +87,12 @@ mcp_port: "9100"
 	}
 	if cfg.MCPPort != "9100" {
 		t.Errorf("MCPPort: got %q want %q", cfg.MCPPort, "9100")
+	}
+	if cfg.LogFormat != "json" {
+		t.Errorf("LogFormat: got %q want json", cfg.LogFormat)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Errorf("LogLevel: got %q want debug", cfg.LogLevel)
 	}
 	// Unspecified fields stay at defaults.
 	if cfg.HTTPIdleTimeout != 120 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -183,6 +183,18 @@ func (c *Config) validate(allowBoundPorts bool) error {
 		}
 	}
 
+	// ── logging options ─────────────────────────────────────────────────────
+	if c.LogFormat != "" && c.LogFormat != "text" && c.LogFormat != "json" {
+		errs = append(errs, fmt.Errorf("log_format %q is invalid — use \"text\" or \"json\"", c.LogFormat))
+	}
+	if c.LogLevel != "" {
+		switch strings.ToLower(c.LogLevel) {
+		case "debug", "info", "warn", "error":
+		default:
+			errs = append(errs, fmt.Errorf("log_level %q is invalid — use debug|info|warn|error", c.LogLevel))
+		}
+	}
+
 	// ── map-local rules ────────────────────────────────────────────────────
 	for i, rule := range c.MapLocalRules {
 		if rule.URLPattern == "" {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -23,9 +23,35 @@ func TestValidate_ValidConfig(t *testing.T) {
 		DBPath:              "apix.db",
 		MaxIdleConnsPerHost: 10,
 		MaxBodySizeMB:       32,
+		LogFormat:           "text",
+		LogLevel:            "info",
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestValidate_InvalidLogSettings(t *testing.T) {
+	t.Parallel()
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:            httpPort,
+		GRPCPort:            grpcPort,
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		LogFormat:           "xml",
+		LogLevel:            "trace",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid log settings to fail validation")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "log_format") {
+		t.Fatalf("expected log_format validation error, got: %v", err)
+	}
+	if !strings.Contains(msg, "log_level") {
+		t.Fatalf("expected log_level validation error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Summary:
- add log_format and log_level fields to config struct and config.yaml
- enforce valid log_format/log_level in config validation
- apply precedence: flag > env > config.yaml > default in engine startup
- update config tests and README key reference

Fixes #386