### PR TITLE
feat(observability): expose request_id across CLI and extension

### DIFF
--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -33,6 +33,7 @@
     "onCommand:apix.replayRequest",
     "onCommand:apix.composeRequest",
     "onCommand:apix.copyAsCurl",
+    "onCommand:apix.copyRequestId",
     "onCommand:apix.exportHAR",
     "onCommand:apix.importHAR",
     "onCommand:apix.openTrafficPanel",
@@ -90,6 +91,11 @@
       {
         "command": "apix.copyAsCurl",
         "title": "APiX: Copy Request as curl",
+        "icon": "$(clippy)"
+      },
+      {
+        "command": "apix.copyRequestId",
+        "title": "APiX: Copy Request ID",
         "icon": "$(clippy)"
       },
       {
@@ -220,6 +226,11 @@
           "command": "apix.copyAsCurl",
           "when": "view == apix.trafficView && viewItem == httpTransaction",
           "group": "inline"
+        },
+        {
+          "command": "apix.copyRequestId",
+          "when": "view == apix.trafficView && viewItem == httpTransaction",
+          "group": "navigation"
         },
         {
           "command": "apix.exportHAR",

--- a/apix-vscode/src/engineClient.ts
+++ b/apix-vscode/src/engineClient.ts
@@ -282,6 +282,7 @@ export class EngineClient {
             stream.on('data', (raw: any) => {
                 const tx: HttpTransaction = {
                     id: raw.id || '',
+                    requestId: raw.requestId || raw.id || '',
                     request: raw.request || {},
                     response: raw.response || {},
                     timestamp: raw.timestamp || 0,
@@ -358,6 +359,7 @@ export class EngineClient {
             // CaptureTraffic streams HttpRequest; wrap into a partial HttpTransaction
             const tx: HttpTransaction = {
                 id: raw.id || '',
+                requestId: (raw.headers && (raw.headers['X-Request-ID'] || raw.headers['x-request-id'])) || raw.id || '',
                 request: {
                     id: raw.id || '',
                     method: raw.method || '',

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -127,6 +127,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand('apix.copyAsCurl', (itemOrTx: TrafficItem | HttpTransaction) =>
             copyAsCurl(itemOrTx)
         ),
+        vscode.commands.registerCommand('apix.copyRequestId', (itemOrTxOrID: TrafficItem | HttpTransaction | string) =>
+            copyRequestId(itemOrTxOrID)
+        ),
         vscode.commands.registerCommand('apix.exportHAR', (itemOrTx?: TrafficItem | HttpTransaction) =>
             exportHAR(engineClient!, itemOrTx)
         ),
@@ -374,6 +377,21 @@ async function copyAsCurl(itemOrTx: TrafficItem | HttpTransaction): Promise<void
 
     await vscode.env.clipboard.writeText(buildCurlCommand(tx));
     vscode.window.showInformationMessage('APiX: Copied request as curl.');
+}
+
+async function copyRequestId(itemOrTxOrID: TrafficItem | HttpTransaction | string): Promise<void> {
+    const requestID = typeof itemOrTxOrID === 'string'
+        ? itemOrTxOrID
+        : itemOrTxOrID instanceof TrafficItem
+            ? (itemOrTxOrID.transaction.requestId || itemOrTxOrID.transaction.id)
+            : (itemOrTxOrID.requestId || itemOrTxOrID.id);
+
+    if (!requestID) {
+        vscode.window.showErrorMessage('APiX: No request ID available to copy.');
+        return;
+    }
+    await vscode.env.clipboard.writeText(requestID);
+    vscode.window.showInformationMessage('APiX: Copied request ID.');
 }
 
 async function exportHAR(client: EngineClient, itemOrTx?: TrafficItem | HttpTransaction): Promise<void> {

--- a/apix-vscode/src/trafficPanel.ts
+++ b/apix-vscode/src/trafficPanel.ts
@@ -141,6 +141,11 @@ export class TrafficPanel {
                     vscode.commands.executeCommand('apix.copyAsCurl', message.data.transaction);
                 }
                 break;
+            case 'copyRequestId':
+                if (message.data?.requestId) {
+                    vscode.commands.executeCommand('apix.copyRequestId', message.data.requestId);
+                }
+                break;
             case 'addBreakpoint':
                 vscode.commands.executeCommand('apix.addBreakpoint');
                 break;
@@ -253,6 +258,7 @@ export class TrafficPanel {
     <button class="close-btn" onclick="closeDetail()">✕</button>
     <h3 id="detail-title"></h3>
     <h4>Request Headers</h4><pre id="detail-req-headers"></pre>
+    <h4>Request ID</h4><pre id="detail-request-id"></pre>
     <h4>Request Body</h4><pre id="detail-req-body"></pre>
     <h4>Response Headers</h4><pre id="detail-resp-headers"></pre>
     <h4>Response Body</h4><pre id="detail-resp-body"></pre>
@@ -264,6 +270,7 @@ export class TrafficPanel {
     <div class="detail-actions">
       <button onclick="replayRequest()">↺ Replay</button>
       <button onclick="copyAsCurl()">⎘ Copy as curl</button>
+      <button onclick="copyRequestId()">⎘ Copy Request ID</button>
       <button onclick="addBreakpoint()">⊕ Add Breakpoint</button>
     </div>
   </div>
@@ -333,6 +340,8 @@ export class TrafficPanel {
       document.getElementById('detail-title').textContent = (isWebSocket ? '[WS] ' : '') + method + ' ' + url;
       document.getElementById('detail-req-headers').textContent =
         JSON.stringify((tx.request && tx.request.headers) || {}, null, 2);
+      document.getElementById('detail-request-id').textContent =
+        tx.requestId || tx.id || '(none)';
       document.getElementById('detail-req-body').textContent =
         (tx.request && tx.request.body) ? String(tx.request.body) : '(empty)';
       document.getElementById('detail-resp-headers').textContent =
@@ -577,6 +586,15 @@ export class TrafficPanel {
     function copyAsCurl() {
       if (window._currentTx) {
         vscode.postMessage({ type: 'copyAsCurl', data: { transaction: window._currentTx } });
+      }
+    }
+
+    function copyRequestId() {
+      if (window._currentTx) {
+        vscode.postMessage({
+          type: 'copyRequestId',
+          data: { requestId: window._currentTx.requestId || window._currentTx.id || '' }
+        });
       }
     }
 

--- a/apix-vscode/src/trafficProvider.ts
+++ b/apix-vscode/src/trafficProvider.ts
@@ -66,7 +66,7 @@ export class TrafficItem extends vscode.TreeItem {
         const summary = status ? `${status} ${duration}`.trim() : duration || '—';
         this.description = isWebSocket ? `WS ${summary}`.trim() : summary;
         this.tooltip = new vscode.MarkdownString(
-            `**${isWebSocket ? 'WS ' : ''}${method}** ${url}\n\nStatus: ${status || '—'}  Duration: ${duration || '—'}`
+            `**${isWebSocket ? 'WS ' : ''}${method}** ${url}\n\nStatus: ${status || '—'}  Duration: ${duration || '—'}\n\nRequest ID: ${tx.requestId || tx.id || '—'}`
         );
         this.contextValue = 'httpTransaction';
         this.iconPath = this._iconForStatus(status);

--- a/apix-vscode/src/types.ts
+++ b/apix-vscode/src/types.ts
@@ -20,6 +20,7 @@ export interface HttpResponse {
 
 export interface HttpTransaction {
     id: string;
+    requestId: string;
     request: HttpRequest;
     response: HttpResponse;
     timestamp: number; // Unix ms

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -57,7 +57,8 @@ type historyListOptions struct {
 }
 
 type historyGetOptions struct {
-	pageSize int
+	pageSize  int
+	requestID string
 }
 
 type watchOptions struct {
@@ -609,10 +610,7 @@ func (a *app) cmdHistory(args []string) error {
 	case "list":
 		return a.cmdHistoryList(args[1:])
 	case "get":
-		if len(args) < 2 {
-			return fmt.Errorf("usage: history get <id> [--page-size N]")
-		}
-		return a.cmdHistoryGet(args[1], args[2:])
+		return a.cmdHistoryGet(args[1:])
 	case "clear":
 		return a.cmdHistoryClear(args[1:])
 	default:
@@ -674,28 +672,49 @@ func (a *app) cmdHistoryList(args []string) error {
 		return nil
 	}
 	tw := tabwriter.NewWriter(a.out, 0, 0, 2, ' ', 0)
-	writeLine(tw, "ID\tMETHOD\tURL\tSTATUS\tDURATION_MS")
+	writeLine(tw, "ID\tREQUEST_ID\tMETHOD\tURL\tSTATUS\tDURATION_MS")
 	for _, tx := range items {
 		statusCode := int32(0)
 		if tx.Response != nil {
 			statusCode = tx.Response.StatusCode
 		}
-		writef(tw, "%s\t%s\t%s\t%d\t%d\n", tx.Id, tx.Request.Method, tx.Request.Url, statusCode, tx.DurationMs)
+		writef(tw, "%s\t%s\t%s\t%s\t%d\t%d\n",
+			tx.Id,
+			historyRequestID(tx),
+			tx.Request.Method,
+			tx.Request.Url,
+			statusCode,
+			tx.DurationMs,
+		)
 	}
 	return tw.Flush()
 }
 
-func (a *app) cmdHistoryGet(id string, args []string) error {
+func (a *app) cmdHistoryGet(args []string) error {
 	fs := flag.NewFlagSet("history get", flag.ContinueOnError)
 	fs.SetOutput(a.errw)
 	opts := historyGetOptions{pageSize: 100}
 	fs.IntVar(&opts.pageSize, "page-size", 100, "page size while searching for an id")
+	fs.StringVar(&opts.requestID, "request-id", "", "lookup by logical request_id (X-Request-ID)")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	id := fs.Arg(0)
+	if id == "" && opts.requestID == "" {
+		return fmt.Errorf("usage: history get <id> [--page-size N] or history get --request-id <uuid> [--page-size N]")
+	}
+	if id != "" && opts.requestID != "" {
+		return fmt.Errorf("provide either <id> or --request-id, not both")
 	}
 	client, err := a.clientConn()
 	if err != nil {
 		return err
+	}
+	targetID := id
+	lookupByRequestID := false
+	if opts.requestID != "" {
+		targetID = opts.requestID
+		lookupByRequestID = true
 	}
 	offset := 0
 	for {
@@ -724,7 +743,7 @@ func (a *app) cmdHistoryGet(id string, args []string) error {
 			return status.Error(codes.NotFound, "history item not found")
 		}
 		for _, tx := range items {
-			if tx.Id == id {
+			if (lookupByRequestID && historyRequestID(tx) == targetID) || (!lookupByRequestID && tx.Id == targetID) {
 				if a.opts.output == "json" {
 					return emitJSON(a.out, historyItemToJSON(tx))
 				}
@@ -788,17 +807,19 @@ func historyToJSON(items []*apix.HttpTransaction) []map[string]any {
 func historyItemToJSON(tx *apix.HttpTransaction) map[string]any {
 	item := map[string]any{
 		"id":          tx.Id,
+		"request_id":  historyRequestID(tx),
 		"timestamp":   tx.Timestamp,
 		"duration_ms": tx.DurationMs,
 	}
 	if tx.Request != nil {
 		item["request"] = map[string]any{
-			"id":        tx.Request.Id,
-			"method":    tx.Request.Method,
-			"url":       tx.Request.Url,
-			"headers":   tx.Request.Headers,
-			"body":      string(tx.Request.Body),
-			"timestamp": tx.Request.Timestamp,
+			"id":         tx.Request.Id,
+			"method":     tx.Request.Method,
+			"url":        tx.Request.Url,
+			"headers":    tx.Request.Headers,
+			"body":       string(tx.Request.Body),
+			"timestamp":  tx.Request.Timestamp,
+			"request_id": historyRequestID(tx),
 		}
 	}
 	if tx.Response != nil {
@@ -817,6 +838,20 @@ func validateStreamingOutput(output string) error {
 		return status.Error(codes.InvalidArgument, "--output json is not supported for streaming commands; use --output ndjson")
 	}
 	return nil
+}
+
+func historyRequestID(tx *apix.HttpTransaction) string {
+	if tx.RequestId != "" {
+		return tx.RequestId
+	}
+	if tx.Request != nil {
+		for key, value := range tx.Request.Headers {
+			if strings.EqualFold(key, "X-Request-ID") && value != "" {
+				return value
+			}
+		}
+	}
+	return tx.Id
 }
 
 func (a *app) cmdWatch(args []string) error {
@@ -861,19 +896,34 @@ func (a *app) cmdWatch(args []string) error {
 			continue
 		}
 		if a.opts.output == "ndjson" || a.opts.output == "json" {
+			requestID := msg.Id
+			for key, value := range msg.Headers {
+				if strings.EqualFold(key, "X-Request-ID") && value != "" {
+					requestID = value
+					break
+				}
+			}
 			if err := emitNDJSON(a.out, map[string]any{
-				"event":     "request",
-				"id":        msg.Id,
-				"method":    msg.Method,
-				"url":       msg.Url,
-				"headers":   msg.Headers,
-				"body":      string(msg.Body),
-				"timestamp": msg.Timestamp,
+				"event":      "request",
+				"id":         msg.Id,
+				"request_id": requestID,
+				"method":     msg.Method,
+				"url":        msg.Url,
+				"headers":    msg.Headers,
+				"body":       string(msg.Body),
+				"timestamp":  msg.Timestamp,
 			}); err != nil {
 				return err
 			}
 		} else {
-			writef(a.out, "%s\t%s\t%s\n", msg.Id, msg.Method, msg.Url)
+			requestID := msg.Id
+			for key, value := range msg.Headers {
+				if strings.EqualFold(key, "X-Request-ID") && value != "" {
+					requestID = value
+					break
+				}
+			}
+			writef(a.out, "%s\t%s\t%s\t%s\n", msg.Id, requestID, msg.Method, msg.Url)
 		}
 		seen++
 		if opts.count > 0 && seen >= opts.count {
@@ -932,13 +982,20 @@ func (a *app) cmdFilter(args []string) error {
 		return nil
 	}
 	tw := tabwriter.NewWriter(a.out, 0, 0, 2, ' ', 0)
-	writeLine(tw, "ID\tMETHOD\tURL\tSTATUS\tDURATION_MS")
+	writeLine(tw, "ID\tREQUEST_ID\tMETHOD\tURL\tSTATUS\tDURATION_MS")
 	for _, tx := range items {
 		statusCode := int32(0)
 		if tx.Response != nil {
 			statusCode = tx.Response.StatusCode
 		}
-		writef(tw, "%s\t%s\t%s\t%d\t%d\n", tx.Id, tx.Request.Method, tx.Request.Url, statusCode, tx.DurationMs)
+		writef(tw, "%s\t%s\t%s\t%s\t%d\t%d\n",
+			tx.Id,
+			historyRequestID(tx),
+			tx.Request.Method,
+			tx.Request.Url,
+			statusCode,
+			tx.DurationMs,
+		)
 	}
 	return tw.Flush()
 }

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -106,12 +106,15 @@ func (s *cliTestStack) storeTransaction(t *testing.T, id, method, rawURL, reqBod
 	tx := &proxy.Transaction{
 		ID: id,
 		Request: &plugins.ProxyRequest{
-			ID:      id,
-			Method:  method,
-			URL:     parsed,
-			Headers: http.Header{"X-Test": []string{"1"}},
-			Body:    io.NopCloser(strings.NewReader(reqBody)),
-			Raw:     rawReq,
+			ID:     id,
+			Method: method,
+			URL:    parsed,
+			Headers: http.Header{
+				"X-Test":       []string{"1"},
+				"X-Request-ID": []string{"rid-" + id},
+			},
+			Body: io.NopCloser(strings.NewReader(reqBody)),
+			Raw:  rawReq,
 		},
 		RequestBody: reqBodyBytes(reqBody),
 		DurationMs:  12,
@@ -233,6 +236,9 @@ func TestCLIReadWorkflows_EngineBacked(t *testing.T) {
 	if len(historyList) != 1 || historyList[0]["id"] != "req-1" {
 		t.Fatalf("unexpected history list: %#v", historyList)
 	}
+	if historyList[0]["request_id"] != "rid-req-1" {
+		t.Fatalf("history list request_id=%v", historyList[0]["request_id"])
+	}
 
 	exit, out, errOut = runCLI(t, stack.args("--output", "json", "history", "get", "req-1")...)
 	if exit != 0 {
@@ -244,6 +250,21 @@ func TestCLIReadWorkflows_EngineBacked(t *testing.T) {
 	}
 	if historyItem["id"] != "req-1" {
 		t.Fatalf("history id=%v", historyItem["id"])
+	}
+	if historyItem["request_id"] != "rid-req-1" {
+		t.Fatalf("history request_id=%v", historyItem["request_id"])
+	}
+
+	exit, out, errOut = runCLI(t, stack.args("--output", "json", "history", "get", "--request-id", "rid-req-1")...)
+	if exit != 0 {
+		t.Fatalf("history get --request-id exit=%d err=%s", exit, errOut)
+	}
+	var historyByRequestID map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &historyByRequestID); err != nil {
+		t.Fatalf("history get --request-id json: %v", err)
+	}
+	if historyByRequestID["id"] != "req-1" {
+		t.Fatalf("history get --request-id id=%v", historyByRequestID["id"])
 	}
 }
 

--- a/docs/REFERENCE/cli-contract-v1.md
+++ b/docs/REFERENCE/cli-contract-v1.md
@@ -71,9 +71,9 @@ Representative stable fields:
 |---|---|
 | `status --output json` | `status`, `version`, `proxy_port`, `grpc_port`, `tls_enabled` |
 | `plugins list --output json` | array of objects with `name`, `version`, `description`, `enabled` |
-| `history list --output json` | array of objects including `id`, `timestamp`, `duration_ms`, `request`, optional `response` |
-| `history get --output json` | single object with the same field family as `history list` items |
-| `watch traffic --output ndjson` | one event object per line with `event`, `id`, `method`, `url`, `headers`, `body`, `timestamp` |
+| `history list --output json` | array of objects including `id`, `request_id`, `timestamp`, `duration_ms`, `request`, optional `response` |
+| `history get --output json` | single object with the same field family as `history list` items; supports lookup by `id` or `--request-id` |
+| `watch traffic --output ndjson` | one event object per line with `event`, `id`, `request_id`, `method`, `url`, `headers`, `body`, `timestamp` |
 
 ### Write commands
 

--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -445,6 +445,35 @@ func TestGetHistory(t *testing.T) {
 	}
 }
 
+func TestGetHistoryIncludesRequestID(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	defer f.stop()
+
+	rec := &storage.RequestRecord{
+		ID:        "req-rid",
+		Method:    "GET",
+		URL:       "https://rid.example.com/",
+		Headers:   map[string]string{"X-Request-ID": "rid-123"},
+		Timestamp: time.Now(),
+	}
+	if err := f.db.SaveRequest(rec); err != nil {
+		t.Fatalf("SaveRequest: %v", err)
+	}
+
+	stream, err := f.client.GetHistory(context.Background(), &apix.HistoryQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	tx, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if tx.RequestId != "rid-123" {
+		t.Fatalf("request_id: got %q want %q", tx.RequestId, "rid-123")
+	}
+}
+
 func TestGetWebSocketFrames(t *testing.T) {
 	t.Parallel()
 	f := newFixture(t)

--- a/internal/server/handlers_traffic.go
+++ b/internal/server/handlers_traffic.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"strings"
 
 	gql "github.com/mnafshin/apix/internal/graphql"
 	"github.com/mnafshin/apix/internal/har"
@@ -58,6 +59,7 @@ func (s *EngineServer) GetHistory(req *apix.HistoryQuery, stream grpc.ServerStre
 			Id:         r.ID,
 			Timestamp:  r.Timestamp.UnixMilli(),
 			DurationMs: r.DurationMs,
+			RequestId:  requestIDFromHeaders(r.ID, r.Headers),
 			Request: &apix.HttpRequest{
 				Id:        r.ID,
 				Method:    r.Method,
@@ -107,6 +109,15 @@ func respBody(resp *apix.HttpResponse) []byte {
 		return nil
 	}
 	return resp.Body
+}
+
+func requestIDFromHeaders(fallback string, headers map[string]string) string {
+	for key, value := range headers {
+		if strings.EqualFold(key, "X-Request-ID") && value != "" {
+			return value
+		}
+	}
+	return fallback
 }
 
 func (s *EngineServer) GetWebSocketFrames(req *apix.GetWebSocketFramesRequest, stream grpc.ServerStreamingServer[apix.WebSocketFrame]) error {

--- a/pkg/api/generated/apix.pb.go
+++ b/pkg/api/generated/apix.pb.go
@@ -601,6 +601,7 @@ type HttpTransaction struct {
 	Timestamp     int64                  `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"` // Unix ms
 	DurationMs    int64                  `protobuf:"varint,5,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
 	Graphql       *GraphQLMetadata       `protobuf:"bytes,6,opt,name=graphql,proto3" json:"graphql,omitempty"`
+	RequestId     string                 `protobuf:"bytes,7,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"` // logical request id (X-Request-ID), used for log correlation
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -675,6 +676,13 @@ func (x *HttpTransaction) GetGraphql() *GraphQLMetadata {
 		return x.Graphql
 	}
 	return nil
+}
+
+func (x *HttpTransaction) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
 }
 
 type PluginInfo struct {
@@ -2522,7 +2530,7 @@ const file_apix_proto_rawDesc = "" +
 	"\x06errors\x18\x01 \x03(\v2\x12.apix.GraphQLErrorR\x06errors\"\x84\x01\n" +
 	"\x0fGraphQLMetadata\x126\n" +
 	"\arequest\x18\x01 \x01(\v2\x1c.apix.GraphQLRequestMetadataR\arequest\x129\n" +
-	"\bresponse\x18\x02 \x01(\v2\x1d.apix.GraphQLResponseMetadataR\bresponse\"\xee\x01\n" +
+	"\bresponse\x18\x02 \x01(\v2\x1d.apix.GraphQLResponseMetadataR\bresponse\"\x8d\x02\n" +
 	"\x0fHttpTransaction\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12+\n" +
 	"\arequest\x18\x02 \x01(\v2\x11.apix.HttpRequestR\arequest\x12.\n" +
@@ -2530,7 +2538,9 @@ const file_apix_proto_rawDesc = "" +
 	"\ttimestamp\x18\x04 \x01(\x03R\ttimestamp\x12\x1f\n" +
 	"\vduration_ms\x18\x05 \x01(\x03R\n" +
 	"durationMs\x12/\n" +
-	"\agraphql\x18\x06 \x01(\v2\x15.apix.GraphQLMetadataR\agraphql\"v\n" +
+	"\agraphql\x18\x06 \x01(\v2\x15.apix.GraphQLMetadataR\agraphql\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\a \x01(\tR\trequestId\"v\n" +
 	"\n" +
 	"PluginInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +

--- a/pkg/api/proto/apix.proto
+++ b/pkg/api/proto/apix.proto
@@ -60,6 +60,7 @@ message HttpTransaction {
   int64 timestamp = 4; // Unix ms
   int64 duration_ms = 5;
   GraphQLMetadata graphql = 6;
+  string request_id = 7; // logical request id (X-Request-ID), used for log correlation
 }
 
 // ========== Plugin messages ==========


### PR DESCRIPTION
Summary:\n- add request_id to HttpTransaction in apix.proto and generated Go bindings\n- populate request_id from X-Request-ID with fallback to transaction id in GetHistory\n- expose request_id in CLI watch/history/filter output and add history get --request-id lookup\n- show request ID in VS Code traffic details/tooltips and add Copy Request ID command/context menu\n- update CLI contract docs for stable request_id fields\n\nTesting:\n- go test ./cmd/apix-cli ./internal/server\n- make lint\n- make test\n- cd apix-vscode && npm run compile\n\nFixes #385