### PR TITLE
feat(engine): wire built-in OTel tracing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Validate config:
 | `max_body_size_mb` | `32` | Request/response body limit per body |
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
 | `metrics_enabled` / `metrics_port` | `false` / `9091` | Prometheus metrics endpoint |
+| `otel_enabled` / `otel_endpoint` / `otel_service_name` / `otel_insecure` / `otel_sample_rate` | `false` / `localhost:4317` / `apix-proxy` / `true` / `1.0` | Built-in OTLP tracing exporter plugin |
 | `health_port` | `9092` | `/healthz` endpoint |
 | `log_format` / `log_level` | `text` / `info` | Engine log output shape and verbosity |
 | `mcp_enabled` / `mcp_port` | `false` / `9093` | MCP server |

--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -137,6 +137,7 @@ func main() {
 
 	// 5. Create plugin runtime and register built-ins.
 	pluginRT := pluginrt.NewRuntime()
+	var otelTracingPlugin *builtins.OTelTracing
 	if err := pluginRT.Register(&builtins.HeaderEditor{}); err != nil {
 		logging.Warnf(ctx, "register header-editor: %v", err)
 	}
@@ -145,6 +146,22 @@ func main() {
 	}
 	if err := pluginRT.Register(&builtins.EnvSubst{}); err != nil {
 		logging.Warnf(ctx, "register env-subst: %v", err)
+	}
+	if cfg.OTelEnabled {
+		otelTracingPlugin, err = builtins.NewOTelTracing(ctx, builtins.OTelTracingConfig{
+			Endpoint:    cfg.OTelEndpoint,
+			ServiceName: cfg.OTelServiceName,
+			Insecure:    cfg.OTelInsecure,
+			SampleRate:  cfg.OTelSampleRate,
+		})
+		if err != nil {
+			logging.Fatalf(ctx, "initialize otel-tracing plugin: %v", err)
+		}
+		if err := pluginRT.Register(otelTracingPlugin); err != nil {
+			logging.Fatalf(ctx, "register otel-tracing plugin: %v", err)
+		}
+		logging.Infof(ctx, "otel tracing enabled (endpoint=%s service=%s sample_rate=%.2f)",
+			cfg.OTelEndpoint, cfg.OTelServiceName, cfg.OTelSampleRate)
 	}
 
 	// 6. Create Engine.
@@ -204,6 +221,13 @@ func main() {
 	<-stop
 	logging.Infof(ctx, "Shutting down…")
 	cancel()
+	if otelTracingPlugin != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := otelTracingPlugin.Shutdown(shutdownCtx); err != nil {
+			logging.Warnf(ctx, "otel-tracing shutdown: %v", err)
+		}
+		shutdownCancel()
+	}
 
 	// 13. Close proxies to release file descriptors.
 	httpProxy.Close()

--- a/docs/REFERENCE/OTEL.md
+++ b/docs/REFERENCE/OTEL.md
@@ -1,14 +1,24 @@
 # OpenTelemetry Collector (OTel) integration
 
-APiX exposes Prometheus-format metrics at `/metrics` when `metrics_enabled` is set in `config.yaml`. The recommended integration path is to run the OpenTelemetry Collector to scrape APiX's Prometheus endpoint and forward metrics via OTLP to your observability backend.
+APiX supports both:
 
-Quick start
+- Prometheus metrics at `/metrics` (when `metrics_enabled: true`)
+- built-in OTLP trace export via the `otel-tracing` plugin (when `otel_enabled: true`)
 
-1. Enable metrics in `config.yaml`:
+The recommended integration path is to run the OpenTelemetry Collector and forward to your observability backend.
+
+Quick start (metrics + traces)
+
+1. Enable OTel settings in `config.yaml`:
 
 ```yaml
 metrics_enabled: true
 metrics_port: "9091"
+otel_enabled: true
+otel_endpoint: "localhost:4317"
+otel_service_name: "apix-proxy"
+otel_insecure: true
+otel_sample_rate: 1.0
 ```
 
 2. Start APiX:
@@ -30,7 +40,12 @@ docker run --rm \
 Notes
 
 - If the Collector runs in Docker and APiX runs on the host, use `host.docker.internal:9091` (macOS/Windows) as the scrape target or use host networking on Linux.
-- Adjust the OTLP exporter endpoint and TLS/insecure settings to match your backend.
+- Adjust `otel_endpoint` and `otel_insecure` for your backend.
 - The sample config is intentionally minimal — production deployments should tune receivers/exporters and add security.
+
+Common targets:
+
+- Jaeger all-in-one OTLP gRPC endpoint: `localhost:4317`
+- Grafana Tempo OTLP gRPC endpoint: `<tempo-host>:4317`
 
 See `docs/otel-collector-config.yaml` for an example collector configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,8 +52,13 @@ type Config struct {
 	// VacuumIntervalHours is how often (in hours) to run SQLite VACUUM to
 	// reclaim free pages and defragment the database. 0 disables periodic
 	// VACUUM. Default: 24 (once per day).
-	VacuumIntervalHours int `yaml:"vacuum_interval_hours"`
-	SlowlogThresholdMs  int `yaml:"slowlog_threshold_ms"`
+	VacuumIntervalHours int     `yaml:"vacuum_interval_hours"`
+	SlowlogThresholdMs  int     `yaml:"slowlog_threshold_ms"`
+	OTelEnabled         bool    `yaml:"otel_enabled"`
+	OTelEndpoint        string  `yaml:"otel_endpoint"`
+	OTelServiceName     string  `yaml:"otel_service_name"`
+	OTelInsecure        bool    `yaml:"otel_insecure"`
+	OTelSampleRate      float64 `yaml:"otel_sample_rate"`
 
 	// History retention
 	HistoryMaxAgeDays int `yaml:"history_max_age_days"` // 0 = keep forever
@@ -88,8 +93,8 @@ type Config struct {
 
 // MapLocalRule maps a URL regex pattern to a local file response.
 type MapLocalRule struct {
-	URLPattern  string `yaml:"url_pattern"`
-	FilePath    string `yaml:"file_path"`
+	URLPattern string `yaml:"url_pattern"`
+	FilePath   string `yaml:"file_path"`
 	// LocalPath is a backwards-compatible alias for file_path.
 	LocalPath   string `yaml:"local_path"`
 	ContentType string `yaml:"content_type"`
@@ -166,6 +171,11 @@ func LoadConfig(path string) *Config {
 		VacuumIntervalHours: 24,
 		GRPCRateLimitPerSec: 0, // 0 = disabled (local desktop); set to e.g. 100 for remote deployments
 		SlowlogThresholdMs:  1000,
+		OTelEnabled:         false,
+		OTelEndpoint:        "localhost:4317",
+		OTelServiceName:     "apix-proxy",
+		OTelInsecure:        true,
+		OTelSampleRate:      1.0,
 		LogFormat:           "text",
 		LogLevel:            "info",
 		MCPEnabled:          false,

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -16,6 +16,13 @@ mcp_allow_compose: false
 log_format: "text"  # text | json
 log_level: "info"   # debug | info | warn | error
 
+# OpenTelemetry tracing plugin
+otel_enabled: false
+otel_endpoint: "localhost:4317"
+otel_service_name: "apix-proxy"
+otel_insecure: true
+otel_sample_rate: 1.0
+
 # HTTP server timeouts (prevents Slowloris attacks)
 http_read_header_timeout_sec: 10
 http_read_timeout_sec: 30

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,21 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.MCPBindAddress != "127.0.0.1" {
 		t.Errorf("MCPBindAddress: got %q want 127.0.0.1", cfg.MCPBindAddress)
 	}
+	if cfg.OTelEnabled {
+		t.Error("OTelEnabled: expected false by default")
+	}
+	if cfg.OTelEndpoint != "localhost:4317" {
+		t.Errorf("OTelEndpoint: got %q want localhost:4317", cfg.OTelEndpoint)
+	}
+	if cfg.OTelServiceName != "apix-proxy" {
+		t.Errorf("OTelServiceName: got %q want apix-proxy", cfg.OTelServiceName)
+	}
+	if !cfg.OTelInsecure {
+		t.Error("OTelInsecure: expected true by default")
+	}
+	if cfg.OTelSampleRate != 1.0 {
+		t.Errorf("OTelSampleRate: got %v want 1.0", cfg.OTelSampleRate)
+	}
 }
 
 func TestLoadConfig_YAMLOverride(t *testing.T) {
@@ -67,6 +82,11 @@ mcp_enabled: true
 mcp_port: "9100"
 log_format: "json"
 log_level: "debug"
+otel_enabled: true
+otel_endpoint: "otel-collector:4317"
+otel_service_name: "apix-dev"
+otel_insecure: false
+otel_sample_rate: 0.25
 `)
 	cfg := LoadConfig(path)
 
@@ -93,6 +113,21 @@ log_level: "debug"
 	}
 	if cfg.LogLevel != "debug" {
 		t.Errorf("LogLevel: got %q want debug", cfg.LogLevel)
+	}
+	if !cfg.OTelEnabled {
+		t.Error("OTelEnabled should be true from YAML override")
+	}
+	if cfg.OTelEndpoint != "otel-collector:4317" {
+		t.Errorf("OTelEndpoint: got %q want otel-collector:4317", cfg.OTelEndpoint)
+	}
+	if cfg.OTelServiceName != "apix-dev" {
+		t.Errorf("OTelServiceName: got %q want apix-dev", cfg.OTelServiceName)
+	}
+	if cfg.OTelInsecure {
+		t.Error("OTelInsecure should be false from YAML override")
+	}
+	if cfg.OTelSampleRate != 0.25 {
+		t.Errorf("OTelSampleRate: got %v want 0.25", cfg.OTelSampleRate)
 	}
 	// Unspecified fields stay at defaults.
 	if cfg.HTTPIdleTimeout != 120 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -194,6 +194,17 @@ func (c *Config) validate(allowBoundPorts bool) error {
 			errs = append(errs, fmt.Errorf("log_level %q is invalid — use debug|info|warn|error", c.LogLevel))
 		}
 	}
+	if c.OTelEnabled {
+		if strings.TrimSpace(c.OTelEndpoint) == "" {
+			errs = append(errs, fmt.Errorf("otel_endpoint must be set when otel_enabled is true"))
+		}
+		if strings.TrimSpace(c.OTelServiceName) == "" {
+			errs = append(errs, fmt.Errorf("otel_service_name must be set when otel_enabled is true"))
+		}
+		if c.OTelSampleRate <= 0 || c.OTelSampleRate > 1 {
+			errs = append(errs, fmt.Errorf("otel_sample_rate must be > 0 and <= 1 when otel_enabled is true (got %v)", c.OTelSampleRate))
+		}
+	}
 
 	// ── map-local rules ────────────────────────────────────────────────────
 	for i, rule := range c.MapLocalRules {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -55,6 +55,53 @@ func TestValidate_InvalidLogSettings(t *testing.T) {
 	}
 }
 
+func TestValidate_InvalidOTelSettings(t *testing.T) {
+	t.Parallel()
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:            httpPort,
+		GRPCPort:            grpcPort,
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		OTelEnabled:         true,
+		OTelEndpoint:        "",
+		OTelServiceName:     "",
+		OTelSampleRate:      1.5,
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid otel settings to fail validation")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "otel_endpoint") {
+		t.Fatalf("expected otel_endpoint validation error, got: %v", err)
+	}
+	if !strings.Contains(msg, "otel_service_name") {
+		t.Fatalf("expected otel_service_name validation error, got: %v", err)
+	}
+	if !strings.Contains(msg, "otel_sample_rate") {
+		t.Fatalf("expected otel_sample_rate validation error, got: %v", err)
+	}
+}
+
+func TestValidate_ValidOTelSettings(t *testing.T) {
+	t.Parallel()
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:            httpPort,
+		GRPCPort:            grpcPort,
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		OTelEnabled:         true,
+		OTelEndpoint:        "localhost:4317",
+		OTelServiceName:     "apix-proxy",
+		OTelSampleRate:      1.0,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid otel settings, got: %v", err)
+	}
+}
+
 func TestValidate_MCPRemoteRequiresTLSAndToken(t *testing.T) {
 	t.Parallel()
 	httpPort, grpcPort := mustFreePorts(t)


### PR DESCRIPTION
Summary:\n- add engine config keys for otel tracing (enabled/endpoint/service/insecure/sample rate) with defaults\n- validate otel config fields when tracing is enabled\n- conditionally initialize/register the otel-tracing built-in plugin from engine startup\n- flush tracing provider on shutdown for span delivery\n- document OTel tracing config and quick setup for Jaeger/Tempo\n\nTesting:\n- go test ./internal/config ./internal/pluginrt/builtins ./cmd/apix-engine\n- make lint\n- make test\n\nFixes #381