### PR TITLE
feat(observability): propagate W3C traceparent in OTel plugin

### DIFF
--- a/internal/pluginrt/builtins/otel_tracing.go
+++ b/internal/pluginrt/builtins/otel_tracing.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -91,6 +92,9 @@ func NewOTelTracing(ctx context.Context, cfg OTelTracingConfig) (*OTelTracing, e
 		sdktrace.WithSampler(sdktrace.TraceIDRatioBased(cfg.sampleRate())),
 	)
 	otel.SetTracerProvider(provider)
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}),
+	)
 
 	return &OTelTracing{
 		cfg:      cfg,
@@ -106,10 +110,18 @@ func (p *OTelTracing) Shutdown(ctx context.Context) error {
 
 // OnRequest starts a span for the incoming request and stores it keyed by ID.
 func (p *OTelTracing) OnRequest(ctx context.Context, req *plugins.ProxyRequest) (*plugins.ProxyRequest, error) {
+	if req.Headers == nil {
+		req.Headers = make(http.Header)
+	}
+	carrier := propagation.HeaderCarrier(req.Headers)
+	ctx = otel.GetTextMapPropagator().Extract(ctx, carrier)
+
 	spanName := req.Method + " " + req.URL.Path
-	_, span := p.tracer.Start(ctx, spanName,
+	spanCtx, span := p.tracer.Start(ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindClient),
 	)
+	otel.GetTextMapPropagator().Inject(spanCtx, carrier)
+
 	span.SetAttributes(
 		semconv.HTTPRequestMethodKey.String(req.Method),
 		semconv.URLFullKey.String(req.URL.String()),

--- a/internal/pluginrt/builtins/otel_tracing_test.go
+++ b/internal/pluginrt/builtins/otel_tracing_test.go
@@ -2,9 +2,12 @@ package builtins
 
 import (
 	"context"
+	"strings"
 	"testing"
 
-	"go.opentelemetry.io/otel/trace/noop"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/mnafshin/apix/pkg/plugins"
 )
@@ -12,9 +15,13 @@ import (
 // newNoopOTelTracing builds an OTelTracing that uses a no-op tracer so no
 // real OTLP connection is required during unit tests.
 func newNoopOTelTracing() *OTelTracing {
+	provider := sdktrace.NewTracerProvider(
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
 	return &OTelTracing{
 		cfg:    OTelTracingConfig{},
-		tracer: noop.NewTracerProvider().Tracer("apix-test"),
+		tracer: provider.Tracer("apix-test"),
 	}
 }
 
@@ -52,6 +59,30 @@ func TestOTelTracing_OnRequest_StoresSpan(t *testing.T) {
 	}
 	if _, ok := p.spans.Load("req-store-test"); !ok {
 		t.Error("expected span to be stored in sync.Map after OnRequest")
+	}
+	if req.Headers.Get("traceparent") == "" {
+		t.Fatal("expected traceparent header to be injected on request")
+	}
+}
+
+func TestOTelTracing_OnRequest_ExtractsParentTraceContext(t *testing.T) {
+	t.Parallel()
+	p := newNoopOTelTracing()
+	req := makeReq("GET", "https://example.com/trace", "")
+	req.ID = "req-parent-trace"
+	req.Headers.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+	if _, err := p.OnRequest(context.Background(), req); err != nil {
+		t.Fatalf("OnRequest: %v", err)
+	}
+	val, ok := p.spans.Load("req-parent-trace")
+	if !ok {
+		t.Fatal("expected span to be stored")
+	}
+	_ = val
+	traceparent := req.Headers.Get("traceparent")
+	if !strings.Contains(traceparent, "4bf92f3577b34da6a3ce929d0e0e4736") {
+		t.Fatalf("expected injected traceparent to keep parent trace ID, got: %s", traceparent)
 	}
 }
 


### PR DESCRIPTION
Summary:\n- extract incoming W3C trace context from request headers before starting proxy spans\n- inject updated traceparent/tracestate headers back onto forwarded requests\n- set global W3C+baggage propagator when OTel tracing plugin is initialized\n- add tests for traceparent injection and parent trace continuity\n\nTesting:\n- go test ./internal/pluginrt/builtins\n- make lint\n- make test\n\nFixes #382