### PR TITLE
feat(observability): add configurable engine access log

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Validate config:
 | `max_body_size_mb` | `32` | Request/response body limit per body |
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
 | `metrics_enabled` / `metrics_port` | `false` / `9091` | Prometheus metrics endpoint |
+| `access_log_enabled` / `access_log_format` / `access_log_path` | `false` / `json` / `stdout` | Per-request access logging |
 | `otel_enabled` / `otel_endpoint` / `otel_service_name` / `otel_insecure` / `otel_sample_rate` | `false` / `localhost:4317` / `apix-proxy` / `true` / `1.0` | Built-in OTLP tracing exporter plugin |
 | `health_port` | `9092` | `/healthz` endpoint |
 | `log_format` / `log_level` | `text` / `info` | Engine log output shape and verbosity |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,9 @@ type Config struct {
 	// VACUUM. Default: 24 (once per day).
 	VacuumIntervalHours int     `yaml:"vacuum_interval_hours"`
 	SlowlogThresholdMs  int     `yaml:"slowlog_threshold_ms"`
+	AccessLogEnabled    bool    `yaml:"access_log_enabled"`
+	AccessLogFormat     string  `yaml:"access_log_format"`
+	AccessLogPath       string  `yaml:"access_log_path"`
 	OTelEnabled         bool    `yaml:"otel_enabled"`
 	OTelEndpoint        string  `yaml:"otel_endpoint"`
 	OTelServiceName     string  `yaml:"otel_service_name"`
@@ -171,6 +174,9 @@ func LoadConfig(path string) *Config {
 		VacuumIntervalHours: 24,
 		GRPCRateLimitPerSec: 0, // 0 = disabled (local desktop); set to e.g. 100 for remote deployments
 		SlowlogThresholdMs:  1000,
+		AccessLogEnabled:    false,
+		AccessLogFormat:     "json",
+		AccessLogPath:       "stdout",
 		OTelEnabled:         false,
 		OTelEndpoint:        "localhost:4317",
 		OTelServiceName:     "apix-proxy",

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -15,6 +15,9 @@ mcp_allow_compose: false
 # Logging
 log_format: "text"  # text | json
 log_level: "info"   # debug | info | warn | error
+access_log_enabled: false
+access_log_format: "json"  # json | common | combined
+access_log_path: "stdout"  # stdout | stderr | /path/to/file.log
 
 # OpenTelemetry tracing plugin
 otel_enabled: false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,15 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.OTelSampleRate != 1.0 {
 		t.Errorf("OTelSampleRate: got %v want 1.0", cfg.OTelSampleRate)
 	}
+	if cfg.AccessLogEnabled {
+		t.Error("AccessLogEnabled: expected false by default")
+	}
+	if cfg.AccessLogFormat != "json" {
+		t.Errorf("AccessLogFormat: got %q want json", cfg.AccessLogFormat)
+	}
+	if cfg.AccessLogPath != "stdout" {
+		t.Errorf("AccessLogPath: got %q want stdout", cfg.AccessLogPath)
+	}
 }
 
 func TestLoadConfig_YAMLOverride(t *testing.T) {
@@ -87,6 +96,9 @@ otel_endpoint: "otel-collector:4317"
 otel_service_name: "apix-dev"
 otel_insecure: false
 otel_sample_rate: 0.25
+access_log_enabled: true
+access_log_format: "combined"
+access_log_path: "/tmp/apix-access.log"
 `)
 	cfg := LoadConfig(path)
 
@@ -128,6 +140,15 @@ otel_sample_rate: 0.25
 	}
 	if cfg.OTelSampleRate != 0.25 {
 		t.Errorf("OTelSampleRate: got %v want 0.25", cfg.OTelSampleRate)
+	}
+	if !cfg.AccessLogEnabled {
+		t.Error("AccessLogEnabled should be true from YAML override")
+	}
+	if cfg.AccessLogFormat != "combined" {
+		t.Errorf("AccessLogFormat: got %q want combined", cfg.AccessLogFormat)
+	}
+	if cfg.AccessLogPath != "/tmp/apix-access.log" {
+		t.Errorf("AccessLogPath: got %q want /tmp/apix-access.log", cfg.AccessLogPath)
 	}
 	// Unspecified fields stay at defaults.
 	if cfg.HTTPIdleTimeout != 120 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -194,6 +194,16 @@ func (c *Config) validate(allowBoundPorts bool) error {
 			errs = append(errs, fmt.Errorf("log_level %q is invalid — use debug|info|warn|error", c.LogLevel))
 		}
 	}
+	if c.AccessLogFormat != "" {
+		switch strings.ToLower(c.AccessLogFormat) {
+		case "json", "common", "combined":
+		default:
+			errs = append(errs, fmt.Errorf("access_log_format %q is invalid — use json|common|combined", c.AccessLogFormat))
+		}
+	}
+	if c.AccessLogEnabled && strings.TrimSpace(c.AccessLogPath) == "" {
+		errs = append(errs, fmt.Errorf("access_log_path must be set when access_log_enabled is true"))
+	}
 	if c.OTelEnabled {
 		if strings.TrimSpace(c.OTelEndpoint) == "" {
 			errs = append(errs, fmt.Errorf("otel_endpoint must be set when otel_enabled is true"))

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -41,6 +41,7 @@ func TestValidate_InvalidLogSettings(t *testing.T) {
 		MaxIdleConnsPerHost: 10,
 		LogFormat:           "xml",
 		LogLevel:            "trace",
+		AccessLogFormat:     "plain",
 	}
 	err := cfg.Validate()
 	if err == nil {
@@ -52,6 +53,9 @@ func TestValidate_InvalidLogSettings(t *testing.T) {
 	}
 	if !strings.Contains(msg, "log_level") {
 		t.Fatalf("expected log_level validation error, got: %v", err)
+	}
+	if !strings.Contains(msg, "access_log_format") {
+		t.Fatalf("expected access_log_format validation error, got: %v", err)
 	}
 }
 

--- a/internal/logging/access_log.go
+++ b/internal/logging/access_log.go
@@ -1,0 +1,115 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+type AccessLogConfig struct {
+	Enabled bool
+	Format  string
+	Path    string
+}
+
+type AccessLogEntry struct {
+	Timestamp    time.Time
+	Method       string
+	URL          string
+	Status       int
+	DurationMs   int64
+	RequestID    string
+	ClientIP     string
+	RequestSize  int
+	ResponseSize int
+}
+
+func EmitAccessLog(_ context.Context, cfg AccessLogConfig, entry AccessLogEntry) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+
+	w, closeFn, err := accessLogWriter(cfg.Path)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+
+	switch strings.ToLower(cfg.Format) {
+	case "common":
+		_, err = fmt.Fprintf(w, "%s - - [%s] \"%s %s HTTP/1.1\" %d %d request_id=%s duration_ms=%d request_size=%d\n",
+			emptyDash(entry.ClientIP),
+			entry.Timestamp.Format("02/Jan/2006:15:04:05 -0700"),
+			entry.Method,
+			entry.URL,
+			entry.Status,
+			entry.ResponseSize,
+			emptyDash(entry.RequestID),
+			entry.DurationMs,
+			entry.RequestSize,
+		)
+		return err
+	case "combined":
+		_, err = fmt.Fprintf(w, "%s - - [%s] \"%s %s HTTP/1.1\" %d %d \"-\" \"-\" request_id=%s duration_ms=%d request_size=%d\n",
+			emptyDash(entry.ClientIP),
+			entry.Timestamp.Format("02/Jan/2006:15:04:05 -0700"),
+			entry.Method,
+			entry.URL,
+			entry.Status,
+			entry.ResponseSize,
+			emptyDash(entry.RequestID),
+			entry.DurationMs,
+			entry.RequestSize,
+		)
+		return err
+	default:
+		payload := map[string]any{
+			"ts":            entry.Timestamp.UTC().Format(time.RFC3339Nano),
+			"method":        entry.Method,
+			"url":           entry.URL,
+			"status":        entry.Status,
+			"duration_ms":   entry.DurationMs,
+			"request_id":    entry.RequestID,
+			"client_ip":     entry.ClientIP,
+			"request_size":  entry.RequestSize,
+			"response_size": entry.ResponseSize,
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(w, "%s\n", b)
+		return err
+	}
+}
+
+func accessLogWriter(path string) (io.Writer, func(), error) {
+	switch strings.ToLower(strings.TrimSpace(path)) {
+	case "", "stdout":
+		return os.Stdout, nil, nil
+	case "stderr":
+		return os.Stderr, nil, nil
+	default:
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return nil, nil, err
+		}
+		return f, func() { _ = f.Close() }, nil
+	}
+}
+
+func emptyDash(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "-"
+	}
+	return v
+}

--- a/internal/logging/access_log.go
+++ b/internal/logging/access_log.go
@@ -99,6 +99,7 @@ func accessLogWriter(path string) (io.Writer, func(), error) {
 	case "stderr":
 		return os.Stderr, nil, nil
 	default:
+		// #nosec G304 -- access_log_path is an explicit operator-configured destination.
 		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, nil, err

--- a/internal/logging/access_log.go
+++ b/internal/logging/access_log.go
@@ -99,7 +99,7 @@ func accessLogWriter(path string) (io.Writer, func(), error) {
 	case "stderr":
 		return os.Stderr, nil, nil
 	default:
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/logging/access_log_test.go
+++ b/internal/logging/access_log_test.go
@@ -1,0 +1,75 @@
+package logging
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmitAccessLogJSONToFile(t *testing.T) {
+	t.Parallel()
+	file := filepath.Join(t.TempDir(), "access.log")
+	err := EmitAccessLog(context.Background(), AccessLogConfig{
+		Enabled: true,
+		Format:  "json",
+		Path:    file,
+	}, AccessLogEntry{
+		Timestamp:    time.Unix(1700000000, 0).UTC(),
+		Method:       "GET",
+		URL:          "https://api.example.com/users",
+		Status:       200,
+		DurationMs:   45,
+		RequestID:    "rid-1",
+		ClientIP:     "127.0.0.1",
+		RequestSize:  12,
+		ResponseSize: 128,
+	})
+	if err != nil {
+		t.Fatalf("EmitAccessLog: %v", err)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, `"method":"GET"`) || !strings.Contains(out, `"request_id":"rid-1"`) {
+		t.Fatalf("unexpected access log output: %s", out)
+	}
+}
+
+func TestEmitAccessLogCommonToFile(t *testing.T) {
+	t.Parallel()
+	file := filepath.Join(t.TempDir(), "access-common.log")
+	err := EmitAccessLog(context.Background(), AccessLogConfig{
+		Enabled: true,
+		Format:  "common",
+		Path:    file,
+	}, AccessLogEntry{
+		Timestamp:    time.Unix(1700000000, 0).UTC(),
+		Method:       "POST",
+		URL:          "https://api.example.com/orders",
+		Status:       201,
+		DurationMs:   32,
+		RequestID:    "rid-2",
+		ClientIP:     "10.0.0.1",
+		RequestSize:  64,
+		ResponseSize: 256,
+	})
+	if err != nil {
+		t.Fatalf("EmitAccessLog: %v", err)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, `"POST https://api.example.com/orders HTTP/1.1"`) {
+		t.Fatalf("missing request line in common log: %s", out)
+	}
+	if !strings.Contains(out, "request_id=rid-2") {
+		t.Fatalf("missing request_id in common log: %s", out)
+	}
+}

--- a/internal/proxy/accesslog_test.go
+++ b/internal/proxy/accesslog_test.go
@@ -1,0 +1,51 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mnafshin/apix/internal/config"
+)
+
+func TestHTTPProxyAccessLogWritesJSON(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	cfg := &config.Config{
+		MaxBodySizeMB:      1,
+		AccessLogEnabled:   true,
+		AccessLogFormat:    "json",
+		AccessLogPath:      logPath,
+		SlowlogThresholdMs: 0,
+	}
+	p := NewHTTPProxy("127.0.0.1:0", nil, nil, TransportOptions{}, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, upstream.URL, nil)
+	rr := httptest.NewRecorder()
+	p.handleHTTP(rr, req)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, `"method":"GET"`) {
+		t.Fatalf("expected method in access log, got: %s", out)
+	}
+	if !strings.Contains(out, `"status":200`) {
+		t.Fatalf("expected status in access log, got: %s", out)
+	}
+	if !strings.Contains(out, `"request_id":"`) {
+		t.Fatalf("expected request_id in access log, got: %s", out)
+	}
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -584,7 +584,18 @@ func (p *HTTPProxy) storeAndWriteResponse(ctx context.Context, w http.ResponseWr
 			logging.Errorf(ctx, "store transaction: %v", err)
 		}
 	}
-	observeRequest(ctx, p.cfg, tx.Request.Method, tx.Request.URL.String(), tx.Response.StatusCode, time.Since(start))
+	observeRequest(
+		ctx,
+		p.cfg,
+		tx.Request.Method,
+		tx.Request.URL.String(),
+		tx.Response.StatusCode,
+		time.Since(start),
+		tx.ID,
+		tx.Request.Raw.RemoteAddr,
+		len(tx.RequestBody),
+		len(tx.ResponseBody),
+	)
 	writeProxyResponse(w, tx.Response, tx.ResponseBody)
 }
 

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -308,7 +308,18 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 
 	// Observe metrics + slowlog.
 	dur := time.Since(start)
-	observeRequest(ctx, p.cfg, proxyReq.Method, proxyReq.URL.Host, tx.Response.StatusCode, dur)
+	observeRequest(
+		ctx,
+		p.cfg,
+		proxyReq.Method,
+		proxyReq.URL.String(),
+		tx.Response.StatusCode,
+		dur,
+		tx.ID,
+		proxyReq.Raw.RemoteAddr,
+		len(tx.RequestBody),
+		len(tx.ResponseBody),
+	)
 	_ = reqID
 
 	writeProxyResponseToConn(ctx, conn, tx.Response)
@@ -490,7 +501,18 @@ func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter
 			logging.Errorf(ctx, "tls proxy h2: store transaction: %v", err)
 		}
 	}
-	observeRequest(ctx, p.cfg, proxyReq.Method, proxyReq.URL.Host, tx.Response.StatusCode, time.Since(start))
+	observeRequest(
+		ctx,
+		p.cfg,
+		proxyReq.Method,
+		proxyReq.URL.String(),
+		tx.Response.StatusCode,
+		time.Since(start),
+		tx.ID,
+		proxyReq.Raw.RemoteAddr,
+		len(tx.RequestBody),
+		len(tx.ResponseBody),
+	)
 	writeProxyResponse(w, tx.Response, tx.ResponseBody)
 }
 

--- a/internal/proxy/observe.go
+++ b/internal/proxy/observe.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"github.com/mnafshin/apix/internal/config"
@@ -11,10 +12,45 @@ import (
 
 // observeRequest records Prometheus metrics and emits a slowlog warning when the
 // request duration exceeds the configured threshold.
-func observeRequest(ctx context.Context, cfg *config.Config, method, displayURL string, status int, dur time.Duration) {
+func observeRequest(
+	ctx context.Context,
+	cfg *config.Config,
+	method, displayURL string,
+	status int,
+	dur time.Duration,
+	requestID, clientAddr string,
+	requestSize, responseSize int,
+) {
 	metrics.ObserveRequest(method, status, dur.Seconds())
 	if cfg != nil && cfg.SlowlogThresholdMs > 0 && dur.Milliseconds() > int64(cfg.SlowlogThresholdMs) {
 		logging.Warnf(ctx, "slow request: method=%s url=%s status=%d duration_ms=%d",
 			method, displayURL, status, dur.Milliseconds())
 	}
+	if cfg != nil {
+		if err := logging.EmitAccessLog(ctx, logging.AccessLogConfig{
+			Enabled: cfg.AccessLogEnabled,
+			Format:  cfg.AccessLogFormat,
+			Path:    cfg.AccessLogPath,
+		}, logging.AccessLogEntry{
+			Timestamp:    time.Now().UTC(),
+			Method:       method,
+			URL:          displayURL,
+			Status:       status,
+			DurationMs:   dur.Milliseconds(),
+			RequestID:    requestID,
+			ClientIP:     clientIP(clientAddr),
+			RequestSize:  requestSize,
+			ResponseSize: responseSize,
+		}); err != nil {
+			logging.Warnf(ctx, "access log write failed: %v", err)
+		}
+	}
+}
+
+func clientIP(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err == nil {
+		return host
+	}
+	return addr
 }


### PR DESCRIPTION
Summary:\n- add access log config keys: access_log_enabled, access_log_format, access_log_path\n- validate access log format/path in config validation\n- emit per-request access logs with method/url/status/duration/request_id/client_ip/request_size/response_size\n- support json/common/combined formats and stdout/stderr/file destinations\n- add logging/proxy/config coverage for access log behavior\n\nTesting:\n- go test ./internal/logging ./internal/proxy ./internal/config\n- make lint\n- make test\n\nFixes #390