### PR TITLE
fix: enforce inbound URL/header bounds (closes #307)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,10 @@ type Config struct {
 	HTTPReadTimeout                  int    `yaml:"http_read_timeout_sec"`
 	HTTPWriteTimeout                 int    `yaml:"http_write_timeout_sec"`
 	HTTPIdleTimeout                  int    `yaml:"http_idle_timeout_sec"`
+	MaxHeadersPerRequest             int    `yaml:"max_headers_per_request"`
+	MaxHeaderValueBytes              int    `yaml:"max_header_value_bytes"`
+	MaxTotalHeaderBytes              int    `yaml:"max_total_header_bytes"`
+	MaxURLLength                     int    `yaml:"max_url_length"`
 	MaxBodySizeMB                    int    `yaml:"max_body_size_mb"`
 	ReplaySkipTLSVerify              bool   `yaml:"replay_skip_tls_verify"`
 	// BreakpointPauseTimeoutSec is the maximum number of seconds a request will
@@ -165,6 +169,10 @@ func LoadConfig(path string) *Config {
 		HTTPReadTimeout:                  30,
 		HTTPWriteTimeout:                 120,
 		HTTPIdleTimeout:                  120,
+		MaxHeadersPerRequest:             200,
+		MaxHeaderValueBytes:              8 * 1024,
+		MaxTotalHeaderBytes:              1 * 1024 * 1024,
+		MaxURLLength:                     8 * 1024,
 		MaxBodySizeMB:                    32,
 		BreakpointPauseTimeoutSec:        120,
 		// Observability defaults

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -39,6 +39,10 @@ dial_timeout_sec: 10         # seconds allowed for TCP dial to upstream
 
 # Body size limits (prevents OOM from unbounded buffering)
 max_body_size_mb: 32         # maximum request/response body size in MB (413 if exceeded)
+max_headers_per_request: 200
+max_header_value_bytes: 8192
+max_total_header_bytes: 1048576
+max_url_length: 8192
 
 # History retention policy (0 = disabled / keep forever)
 history_max_age_days: 0      # delete transactions older than N days

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,18 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.MaxIdleConnsPerHost != 10 {
 		t.Errorf("MaxIdleConnsPerHost: got %d want 10", cfg.MaxIdleConnsPerHost)
 	}
+	if cfg.MaxHeadersPerRequest != 200 {
+		t.Errorf("MaxHeadersPerRequest: got %d want 200", cfg.MaxHeadersPerRequest)
+	}
+	if cfg.MaxHeaderValueBytes != 8192 {
+		t.Errorf("MaxHeaderValueBytes: got %d want 8192", cfg.MaxHeaderValueBytes)
+	}
+	if cfg.MaxTotalHeaderBytes != 1048576 {
+		t.Errorf("MaxTotalHeaderBytes: got %d want 1048576", cfg.MaxTotalHeaderBytes)
+	}
+	if cfg.MaxURLLength != 8192 {
+		t.Errorf("MaxURLLength: got %d want 8192", cfg.MaxURLLength)
+	}
 	if cfg.TLSEnabled {
 		t.Error("TLSEnabled: expected false by default")
 	}
@@ -87,6 +99,10 @@ http_port: "9999"
 grpc_port: "8888"
 max_body_size_mb: 64
 dial_timeout_sec: 5
+max_headers_per_request: 150
+max_header_value_bytes: 4096
+max_total_header_bytes: 262144
+max_url_length: 4096
 mcp_enabled: true
 mcp_port: "9100"
 log_format: "json"
@@ -113,6 +129,18 @@ access_log_path: "/tmp/apix-access.log"
 	}
 	if cfg.DialTimeoutSec != 5 {
 		t.Errorf("DialTimeoutSec: got %d want 5", cfg.DialTimeoutSec)
+	}
+	if cfg.MaxHeadersPerRequest != 150 {
+		t.Errorf("MaxHeadersPerRequest: got %d want 150", cfg.MaxHeadersPerRequest)
+	}
+	if cfg.MaxHeaderValueBytes != 4096 {
+		t.Errorf("MaxHeaderValueBytes: got %d want 4096", cfg.MaxHeaderValueBytes)
+	}
+	if cfg.MaxTotalHeaderBytes != 262144 {
+		t.Errorf("MaxTotalHeaderBytes: got %d want 262144", cfg.MaxTotalHeaderBytes)
+	}
+	if cfg.MaxURLLength != 4096 {
+		t.Errorf("MaxURLLength: got %d want 4096", cfg.MaxURLLength)
 	}
 	if !cfg.MCPEnabled {
 		t.Error("MCPEnabled should be true from YAML override")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -46,6 +46,21 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	var errs []error
 	var httpPort, grpcPort int
 
+	// Keep zero values on direct Config literals safe by restoring secure
+	// defaults; explicit negative values remain invalid and are rejected below.
+	if c.MaxHeadersPerRequest == 0 {
+		c.MaxHeadersPerRequest = 200
+	}
+	if c.MaxHeaderValueBytes == 0 {
+		c.MaxHeaderValueBytes = 8 * 1024
+	}
+	if c.MaxTotalHeaderBytes == 0 {
+		c.MaxTotalHeaderBytes = 1 * 1024 * 1024
+	}
+	if c.MaxURLLength == 0 {
+		c.MaxURLLength = 8 * 1024
+	}
+
 	// ── Port validation ────────────────────────────────────────────────────
 	if c.HTTPPort == "" {
 		errs = append(errs, fmt.Errorf("http_port must be set"))
@@ -111,6 +126,18 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	// ── Connection pool ────────────────────────────────────────────────────
 	if c.MaxIdleConnsPerHost <= 0 {
 		errs = append(errs, fmt.Errorf("max_idle_conns_per_host must be > 0 (got %d) — recommended value: 10", c.MaxIdleConnsPerHost))
+	}
+	if c.MaxHeadersPerRequest <= 0 {
+		errs = append(errs, fmt.Errorf("max_headers_per_request must be > 0 (got %d)", c.MaxHeadersPerRequest))
+	}
+	if c.MaxHeaderValueBytes <= 0 {
+		errs = append(errs, fmt.Errorf("max_header_value_bytes must be > 0 (got %d)", c.MaxHeaderValueBytes))
+	}
+	if c.MaxTotalHeaderBytes <= 0 {
+		errs = append(errs, fmt.Errorf("max_total_header_bytes must be > 0 (got %d)", c.MaxTotalHeaderBytes))
+	}
+	if c.MaxURLLength <= 0 {
+		errs = append(errs, fmt.Errorf("max_url_length must be > 0 (got %d)", c.MaxURLLength))
 	}
 	if c.MaxBodySizeMB < 0 {
 		errs = append(errs, fmt.Errorf("max_body_size_mb must be >= 0 (got %d) — use 0 to disable the limit", c.MaxBodySizeMB))

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -315,6 +315,32 @@ func TestValidate_NegativeBodySize(t *testing.T) {
 	}
 }
 
+func TestValidate_InvalidInputBounds(t *testing.T) {
+	t.Parallel()
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:             httpPort,
+		GRPCPort:             grpcPort,
+		DBPath:               "apix.db",
+		MaxIdleConnsPerHost:  10,
+		MaxHeadersPerRequest: -1,
+		MaxHeaderValueBytes:  -1,
+		MaxTotalHeaderBytes:  -1,
+		MaxURLLength:         -1,
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation failure for invalid input bounds")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "max_headers_per_request") ||
+		!strings.Contains(msg, "max_header_value_bytes") ||
+		!strings.Contains(msg, "max_total_header_bytes") ||
+		!strings.Contains(msg, "max_url_length") {
+		t.Fatalf("expected all input-bound errors, got: %v", err)
+	}
+}
+
 // TestValidate_AggregatesAllErrors ensures that multiple config problems are
 // reported at once rather than stopping at the first error.
 func TestValidate_AggregatesAllErrors(t *testing.T) {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -57,6 +57,7 @@ func (p *HTTPProxy) Start(ctx context.Context) error {
 		ReadTimeout:       time.Duration(p.cfg.HTTPReadTimeout) * time.Second,
 		WriteTimeout:      time.Duration(p.cfg.HTTPWriteTimeout) * time.Second,
 		IdleTimeout:       time.Duration(p.cfg.HTTPIdleTimeout) * time.Second,
+		MaxHeaderBytes:    p.cfg.MaxTotalHeaderBytes,
 	}
 	go func() {
 		<-ctx.Done()
@@ -149,6 +150,10 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	reqID := logging.EnsureRequestID(r.Header)
 	ctx = logging.WithRequestID(ctx, reqID)
+	if err := validateInboundRequest(p.cfg, r); err != nil {
+		http.Error(w, err.Error(), http.StatusRequestHeaderFieldsTooLarge)
+		return
+	}
 
 	// Instrument active connections
 	metrics.IncActive()

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -151,6 +151,10 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	reqID := uuid.NewString()
 	start := time.Now()
 	origHeaders := r.Header.Clone()
+	if err := validateInboundRequest(p.cfg, r); err != nil {
+		writeHTTPError(ctx, conn, http.StatusRequestHeaderFieldsTooLarge, err.Error())
+		return
+	}
 
 	// Instrument active connections
 	metrics.IncActive()
@@ -350,6 +354,10 @@ func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter
 	}
 	if r.URL.Scheme == "" {
 		r.URL.Scheme = "https"
+	}
+	if err := validateInboundRequest(p.cfg, r); err != nil {
+		http.Error(w, err.Error(), http.StatusRequestHeaderFieldsTooLarge)
+		return
 	}
 
 	origHeaders := r.Header.Clone()

--- a/internal/proxy/request_limits.go
+++ b/internal/proxy/request_limits.go
@@ -1,0 +1,39 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mnafshin/apix/internal/config"
+)
+
+func validateInboundRequest(cfg *config.Config, req *http.Request) error {
+	if cfg == nil || req == nil {
+		return nil
+	}
+
+	urlLen := len(req.URL.String())
+	if cfg.MaxURLLength > 0 && urlLen > cfg.MaxURLLength {
+		return fmt.Errorf("url too long: %d bytes (max %d)", urlLen, cfg.MaxURLLength)
+	}
+
+	headerFields := 0
+	totalHeaderBytes := 0
+	for key, values := range req.Header {
+		headerFields += len(values)
+		for _, value := range values {
+			if cfg.MaxHeaderValueBytes > 0 && len(value) > cfg.MaxHeaderValueBytes {
+				return fmt.Errorf("header %q value too large: %d bytes (max %d)", key, len(value), cfg.MaxHeaderValueBytes)
+			}
+			totalHeaderBytes += len(key) + len(value)
+			if cfg.MaxTotalHeaderBytes > 0 && totalHeaderBytes > cfg.MaxTotalHeaderBytes {
+				return fmt.Errorf("total headers too large: %d bytes (max %d)", totalHeaderBytes, cfg.MaxTotalHeaderBytes)
+			}
+		}
+	}
+	if cfg.MaxHeadersPerRequest > 0 && headerFields > cfg.MaxHeadersPerRequest {
+		return fmt.Errorf("too many header fields: %d (max %d)", headerFields, cfg.MaxHeadersPerRequest)
+	}
+
+	return nil
+}

--- a/internal/proxy/request_limits_test.go
+++ b/internal/proxy/request_limits_test.go
@@ -1,0 +1,115 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/mnafshin/apix/internal/config"
+)
+
+func TestValidateInboundRequest(t *testing.T) {
+	t.Parallel()
+
+	baseURL, err := url.Parse("http://example.com/path")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		req       *http.Request
+		wantError string
+	}{
+		{
+			name: "valid request",
+			cfg: &config.Config{
+				MaxHeadersPerRequest: 5,
+				MaxHeaderValueBytes:  64,
+				MaxTotalHeaderBytes:  256,
+				MaxURLLength:         64,
+			},
+			req: &http.Request{
+				URL: baseURL,
+				Header: http.Header{
+					"X-Test": []string{"ok"},
+				},
+			},
+		},
+		{
+			name: "url too long",
+			cfg: &config.Config{
+				MaxURLLength: 8,
+			},
+			req: &http.Request{
+				URL: baseURL,
+				Header: http.Header{
+					"X-Test": []string{"ok"},
+				},
+			},
+			wantError: "url too long",
+		},
+		{
+			name: "too many header fields",
+			cfg: &config.Config{
+				MaxHeadersPerRequest: 1,
+			},
+			req: &http.Request{
+				URL: baseURL,
+				Header: http.Header{
+					"X-One": []string{"1"},
+					"X-Two": []string{"2"},
+				},
+			},
+			wantError: "too many header fields",
+		},
+		{
+			name: "header value too large",
+			cfg: &config.Config{
+				MaxHeaderValueBytes: 3,
+			},
+			req: &http.Request{
+				URL: baseURL,
+				Header: http.Header{
+					"X-One": []string{"toolong"},
+				},
+			},
+			wantError: "value too large",
+		},
+		{
+			name: "total headers too large",
+			cfg: &config.Config{
+				MaxTotalHeaderBytes: 10,
+			},
+			req: &http.Request{
+				URL: baseURL,
+				Header: http.Header{
+					"X-One": []string{"1234567890"},
+				},
+			},
+			wantError: "total headers too large",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateInboundRequest(tc.cfg, tc.req)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantError, err.Error())
+			}
+		})
+	}
+}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -118,6 +118,9 @@ func NewGRPCServer(cfg *config.Config, extraOpts ...grpc.ServerOption) *grpc.Ser
 			authStreamInterceptor(cfg.AuthToken),
 		),
 	}
+	if cfg.MaxTotalHeaderBytes > 0 {
+		opts = append(opts, grpc.MaxHeaderListSize(uint32(cfg.MaxTotalHeaderBytes)))
+	}
 	opts = append(opts, extraOpts...)
 	return grpc.NewServer(opts...)
 }

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"math"
 	"net"
 	"time"
 
@@ -119,7 +120,11 @@ func NewGRPCServer(cfg *config.Config, extraOpts ...grpc.ServerOption) *grpc.Ser
 		),
 	}
 	if cfg.MaxTotalHeaderBytes > 0 {
-		opts = append(opts, grpc.MaxHeaderListSize(uint32(cfg.MaxTotalHeaderBytes)))
+		maxHeaderListSize := cfg.MaxTotalHeaderBytes
+		if maxHeaderListSize > math.MaxUint32 {
+			maxHeaderListSize = math.MaxUint32
+		}
+		opts = append(opts, grpc.MaxHeaderListSize(uint32(maxHeaderListSize)))
 	}
 	opts = append(opts, extraOpts...)
 	return grpc.NewServer(opts...)


### PR DESCRIPTION
## Summary\n- add bounded input controls for URL/header sizes in config with secure defaults\n- enforce limits on HTTP and HTTPS inbound requests with 431 responses\n- cap gRPC metadata header list size using the same total-header budget\n- add unit tests for request-bound enforcement and config validation/default behavior\n\n## Validation\n- make lint\n- make test\n\nCloses #307