### PR TITLE
docs: expand architecture deep-dives (closes #421)

### DIFF
--- a/docs/ARCHITECTURE/extension_arch.md
+++ b/docs/ARCHITECTURE/extension_arch.md
@@ -1,20 +1,155 @@
 # VS Code Extension Architecture
 
-Summary
+The extension is the primary desktop UX for APiX. It manages engine process lifecycle, renders traffic/breakpoint/mocks views, and bridges gRPC streams into tree views and webviews.
 
-The VS Code extension provides the user-facing UI for APiX by connecting to the engine gRPC API. It includes tree views for traffic/breakpoints, webview panels for request editing, and an engine process manager that can start the apix-engine binary for development.
+## Activation and startup flow
 
-Key files
-- apix-vscode/src/extension.ts — activation, command registration
-- apix-vscode/src/engineProcessManager.ts — spawns/monitors engine binary
-- apix-vscode/src/trafficProvider.ts — traffic tree view
-- apix-vscode/src/trafficPanel.ts — webview for inspecting requests
+Entry point: `apix-vscode/src/extension.ts` (`activate`).
 
-End-to-end flow
-1. Extension activates and attempts to locate or spawn apix-engine
-2. Engine publishes traffic via gRPC CaptureTraffic stream
-3. trafficProvider presents events in the tree; pause/resume uses WatchPausedRequests and ResumeRequest
+Startup sequence:
 
-Acceptance criteria
-- New contributor can trace a proxied request from engine capture to webview representation
-- Links to the TypeScript files are present
+1. Read workspace settings (`apix.engine.*`).
+2. Create status bar and output channels.
+3. Initialize:
+   - `EngineProcessManager`
+   - `EngineClient`
+   - tree providers (`TrafficProvider`, `BreakpointsProvider`, `MocksProvider`)
+4. Register commands (`apix.*`).
+5. Auto-start engine if configured (`engine.autoStart`).
+
+`startEngine(...)` orchestrates process startup, health check, provider refresh, and paused-request stream initialization.
+
+## Component map
+
+```text
+extension.ts
+  ├─ EngineProcessManager (spawn/restart/stop apix-engine)
+  ├─ EngineClient (typed gRPC wrapper)
+  ├─ TrafficProvider (tree view)
+  ├─ BreakpointsProvider (tree view)
+  ├─ MocksProvider (tree view)
+  ├─ TrafficPanel (live webview stream)
+  ├─ RequestEditor (paused request webview editor)
+  └─ ReplayPanel (replay/compose webview)
+```
+
+## Engine process lifecycle
+
+`apix-vscode/src/engineProcessManager.ts`:
+
+- resolves binary path (workspace root override or bundled binary)
+- spawns child process and watches stdout/stderr
+- detects readiness (`gRPC server listening` log markers)
+- handles unexpected exits
+- performs bounded exponential backoff restarts
+- exposes callbacks:
+  - `onUnexpectedExit`
+  - `onRestarting`
+  - `onRestart`
+
+On restart, `extension.ts` reinitializes providers and streams.
+
+## gRPC client integration
+
+`apix-vscode/src/engineClient.ts` wraps RPCs in Promise/callback-friendly methods:
+
+- unary calls for status/history/breakpoints/replay/rules
+- stream adapters for:
+  - `captureTraffic(...)`
+  - `watchPausedRequests(...)`
+
+It also maps proto field names to TS interfaces (camelCase via proto-loader settings).
+
+## Data flows
+
+### Traffic tree (`TrafficProvider`)
+
+`TrafficProvider.getChildren()` calls `getHistory()` and maps transactions to `TrafficItem`.
+
+`TrafficItem` adds:
+- method/url summary
+- status/duration info
+- request ID tooltip
+- context value for command menus
+
+### Live traffic panel (`TrafficPanel`)
+
+Flow:
+
+1. Webview panel opens via command `apix.openTrafficPanel`.
+2. Panel starts `captureTraffic` stream.
+3. Each event is posted to webview via `postMessage({ type: 'transaction', ... })`.
+4. UI renders rows and detail pane in webview script.
+5. Panel retries stream on errors with backoff.
+
+### Breakpoint pause flow (`RequestEditor`)
+
+Flow:
+
+1. Extension subscribes to `watchPausedRequests`.
+2. On paused event, `RequestEditor.showEditor(...)` opens editor webview.
+3. User chooses forward/drop/respond action.
+4. Editor sends action payload to extension host.
+5. Host calls `ResumeRequest` through `EngineClient`.
+
+## Webview messaging model
+
+Webview panels use a simple message protocol:
+
+- host -> webview:
+  - `transaction`
+  - `streamError`
+  - `streamRecovered`
+  - `websocketFrames`
+- webview -> host:
+  - `replay`
+  - `addBreakpoint`
+  - `copyAsCurl`
+  - `copyRequestId`
+  - `loadWebSocketFrames`
+
+Message handling is centralized in `TrafficPanel._handleWebviewMessage(...)`.
+
+## Command surface (selected)
+
+Registered in `extension.ts`:
+
+- Engine lifecycle: `apix.startEngine`, `apix.stopEngine`
+- Traffic actions: `apix.openTrafficPanel`, `apix.refreshTraffic`, `apix.copyAsCurl`, `apix.copyRequestId`
+- Breakpoints: add/delete/toggle + refresh
+- Replay: `apix.replayRequest`, `apix.composeRequest`
+- HAR import/export
+- Mock/rewrite rule actions
+
+Commands are intentionally thin wrappers around provider/client helpers.
+
+## Reliability patterns
+
+1. **Stream retries with backoff**
+   - `watchPausedRequests` and `captureTraffic` both auto-retry.
+2. **Provider refresh on reconnect**
+   - process manager restart callback triggers re-sync.
+3. **UI state signaling**
+   - status bar switches between stopped/starting/running/disconnected.
+4. **Defensive error surfacing**
+   - failures shown via output channel and VS Code notifications.
+
+## File responsibility map
+
+- `src/extension.ts` — composition root: activation, commands, stream setup, status bar updates.
+- `src/engineProcessManager.ts` — child-process lifecycle and restart strategy.
+- `src/engineClient.ts` — gRPC transport wrappers and type mapping.
+- `src/trafficProvider.ts` — tree-view model for historical transactions.
+- `src/breakpointsProvider.ts` — tree-view model for breakpoint rules.
+- `src/mocksProvider.ts` — tree-view model for rewrite/mock rules.
+- `src/trafficPanel.ts` — live capture webview, postMessage routing.
+- `src/requestEditor.ts` — paused request edit-and-resume webview.
+- `src/replayPanel.ts` — replay/compose UI and template management.
+
+## Adding a new UI feature safely
+
+1. Add/extend RPC in proto + engine server.
+2. Implement client method in `engineClient.ts`.
+3. Add provider/panel wiring in `extension.ts`.
+4. Add command + menu contribution in `package.json` if user-triggered.
+5. Ensure reconnect/stream retry behavior still works.

--- a/docs/ARCHITECTURE/grpc_protobuf.md
+++ b/docs/ARCHITECTURE/grpc_protobuf.md
@@ -1,21 +1,135 @@
-# gRPC and Protobuf (APiX engine contract)
+# gRPC and Protobuf Contract
 
-Why gRPC/protobuf
-- gRPC provides typed RPCs including streaming; APiX uses it to stream captured traffic and paused requests to clients.
-- The protobuf definitions (pkg/api/proto/apix.proto) are the source of truth. Clients (CLI, VS Code extension) rely on stable fields and enum semantics.
+The APiX engine exposes one gRPC service (`Engine`) as the control plane for:
+- live capture streams
+- breakpoint workflows
+- replay/compose workflows
+- history export/import
+- rewrite-rule and plugin management
 
-What contributors should know
-- Unary vs streaming RPCs — CaptureTraffic uses a server stream to continuously push HttpRequest records.
-- Do not edit pkg/api/generated/* directly. Run protoc to regenerate after editing pkg/api/proto/apix.proto.
+## Source of truth and generated artifacts
 
-Where to look
-- pkg/api/proto/apix.proto — API definitions
-- internal/server/grpc.go — gRPC server wiring and interceptors
-- apix-vscode/src/engineClient.ts — typed client usage in the extension
+- **Proto source:** `pkg/api/proto/apix.proto`
+- **Generated Go:** `pkg/api/generated/apix.pb.go`, `pkg/api/generated/apix_grpc.pb.go`
+- **Server implementation:** `internal/server/*.go`
+- **Extension proto copy:** `apix-vscode/proto/apix.proto`
 
-Best practices
-- Keep backwards-compatible changes in protos where possible (additive fields with defaults).
-- Update apix-vscode/proto/apix.proto after regenerating the Go bindings.
+Never hand-edit files under `pkg/api/generated/`; regenerate instead.
 
-Acceptance criteria
-- Doc links proto and generated code and demonstrates a quick edit->regenerate workflow.
+## Service surface (high-level)
+
+`service Engine` contains both unary and server-streaming methods.
+
+Examples:
+
+- Unary:
+  - `GetStatus`
+  - `ReplayRequest`
+  - `ComposeRequest`
+  - `ListPlugins`
+  - `ClearHistory`
+- Streaming:
+  - `CaptureTraffic` → `stream HttpRequest`
+  - `WatchPausedRequests` → `stream PausedRequest`
+  - `GetHistory` → `stream HttpTransaction`
+  - `GetWebSocketFrames` → `stream WebSocketFrame`
+
+## Key message types
+
+### `HttpRequest`
+
+Represents captured or synthesized request payload:
+- method/url
+- headers map
+- raw body bytes
+- capture timestamp
+- request id + protocol
+
+### `HttpResponse`
+
+Status code/text + headers + body payload.
+
+### `HttpTransaction`
+
+Request + optional response + timing metadata + GraphQL metadata + logical `request_id` correlation field.
+
+### `PausedRequest` + `ResumeAction`
+
+Breakpoint control plane:
+- engine streams paused requests
+- client responds with action (`FORWARD`, `DROP`, `RESPOND`) and optional modifications
+
+### `ReplaySpec`
+
+Supports replay by stored `request_id` or inline `raw_request`, with header/body override controls.
+
+## Streaming patterns and lifecycle
+
+### `CaptureTraffic`
+
+Server side (`internal/server/handlers_traffic.go`) subscribes to engine pub/sub (`engine.Subscribe()`), then forwards each event to stream consumers until cancellation.
+
+Typical clients:
+- CLI `watch`
+- VS Code traffic panel live stream
+
+### `WatchPausedRequests`
+
+Server streams breakpoint hits from the breakpoint manager. VS Code extension opens `RequestEditor` when events arrive, then calls `ResumeRequest`.
+
+### `GetHistory`
+
+Server executes DB query with filters/pagination and streams historical transactions to avoid huge unary payloads.
+
+## Server wiring and cross-cutting concerns
+
+`internal/server/grpc.go` centralizes server options:
+
+- unary + stream logging interceptors
+- optional auth-token interceptors
+- optional per-peer rate limiting
+- optional TLS credentials
+- max metadata header-list size bounds
+
+Reflection is enabled only in unauthenticated local mode.
+
+## Proto evolution rules in APiX
+
+1. Prefer additive fields over breaking changes.
+2. Keep field numbers stable.
+3. Avoid reusing removed field numbers.
+4. Preserve enum semantics once shipped.
+5. Update consumers (CLI + extension) for new fields.
+
+## Regeneration workflow
+
+After editing `pkg/api/proto/apix.proto`:
+
+```bash
+protoc --go_out=pkg/api/generated --go-grpc_out=pkg/api/generated \
+  --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative \
+  pkg/api/proto/apix.proto
+cp pkg/api/proto/apix.proto apix-vscode/proto/apix.proto
+```
+
+Then run project checks (`make lint`, `make test`, extension compile path when applicable).
+
+## TypeScript proto-loader behavior
+
+The VS Code extension uses dynamic loading (`@grpc/proto-loader`) rather than generated TS stubs.
+
+Important option behavior:
+- `keepCase: false` means `snake_case` proto fields become `camelCase` in TS.
+  - Example: `request_id` -> `requestId`
+
+This is why extension types and mapping code in `apix-vscode/src/engineClient.ts` must explicitly map camel-cased fields.
+
+## Where to modify when adding an RPC
+
+1. Add message + method in `pkg/api/proto/apix.proto`.
+2. Regenerate Go code.
+3. Implement handler in `internal/server/handlers_*.go`.
+4. Wire client methods:
+   - CLI (`cmd/apix-cli/main.go`)
+   - VS Code client (`apix-vscode/src/engineClient.ts`)
+5. Update docs/contracts as needed (`docs/REFERENCE/*`).

--- a/docs/ARCHITECTURE/proxy_mitm.md
+++ b/docs/ARCHITECTURE/proxy_mitm.md
@@ -1,23 +1,141 @@
-# HTTP Proxying & TLS MITM (APiX)
+# HTTP Proxying & TLS MITM
 
-Overview
+APiX uses a two-layer proxy:
+1. `internal/proxy/http.go` accepts plain HTTP traffic and `CONNECT` tunnels.
+2. `internal/proxy/https.go` performs HTTPS MITM inside hijacked `CONNECT` sockets.
 
-APiX acts as an intercepting proxy. For HTTPS, it performs a MITM TLS handshake (using an in-repo CA) to capture and modify traffic. This page explains the high-level flow and where to find the implementation.
+This split keeps HTTP forwarding and TLS interception isolated while sharing the same engine, plugin chain, breakpoints, and observability pipeline.
 
-Key concepts
-- CONNECT: browser/agent requests a TCP tunnel to the destination.
-- MITM: APiX generates per-host certificates using an on-disk CA and performs a TLS handshake with the client.
-- Request capture: once the TLS session is established, APiX reads HTTP requests from the tunnel and forwards them upstream.
+## End-to-end traffic flow
 
-Where to look in code
-- internal/proxy/http.go — HTTP proxy and CONNECT handling
-- internal/proxy/https.go — MITM TLS handling and request loop
-- internal/proxy/certauthority.go — CA management (cert generation)
+```text
+Client (browser/curl)
+   |
+   | HTTP request OR CONNECT host:443
+   v
+HTTPProxy (internal/proxy/http.go)
+   |-- plain HTTP  ---> handleHTTP() ---------------------------+
+   |-- CONNECT      ---> handleConnect()                        |
+                           |                                    |
+                           | if TLS handshake bytes             |
+                           v                                    |
+                       TLSProxy.handleBufferedConn()            |
+                           | TLS server handshake (MITM cert)   |
+                           | ALPN: h2 or http/1.1              |
+                           v                                    |
+                 handleRequest() / handleHTTP2Request()         |
+                           |                                    |
+                           +--> plugin OnRequest                |
+                           +--> breakpoint pause request        |
+                           +--> upstream RoundTrip              |
+                           +--> plugin OnResponse               |
+                           +--> breakpoint pause response       |
+                           +--> engine.StoreTransaction() ------+--> storage + gRPC subscribers
+                           +--> observeRequest() (metrics/logs)
+```
 
-Security notes
-- Users must install the CA certificate to trust intercepted TLS traffic.
-- The repo limits MITM scope: generated certs are per-host with SNI.
+## CONNECT tunnel handling
 
-Acceptance criteria
-- Document explains CONNECT vs MITM clearly for new contributors
-- Links to the exact files to edit for changes
+`HTTPProxy.handleConnect()` (`internal/proxy/http.go`) does the protocol switch:
+
+1. Hijacks the HTTP connection (`http.Hijacker`).
+2. Replies `HTTP/1.1 200 Connection established`.
+3. Peeks first bytes to classify payload:
+   - TLS ClientHello (`0x16`) → hand off to TLS MITM.
+   - HTTP/2 cleartext preface (`PRI * HTTP/2.0...`) → h2c tunnel path.
+   - otherwise → raw TCP tunnel path.
+
+This lets APiX intercept HTTPS while still supporting non-TLS tunnel use cases.
+
+## TLS MITM handshake details
+
+TLS interception starts in `TLSProxy.handleBufferedConn()` (`internal/proxy/https.go`):
+
+1. Extract destination hostname from `host:port`.
+2. Generate/reuse leaf certificate via `p.ca.CertForHost(hostname)`.
+3. Build `tls.Config` with `NextProtos: ["h2", "http/1.1"]`.
+4. Perform server-side TLS handshake against the client.
+5. Branch by ALPN:
+   - `h2` → `handleHTTP2Conn()` / `handleHTTP2Request()`
+   - default → HTTP/1.1 loop with `http.ReadRequest()`
+
+CA and cert lifecycle lives in:
+- `internal/proxy/certauthority.go`
+- `internal/proxy/cert.go`
+
+Operators must trust APiX CA cert on client machines for HTTPS interception to work.
+
+## HTTP/1.1 vs HTTP/2 handling
+
+Both paths enforce the same core policy and business logic:
+
+- input bounds (`validateInboundRequest`, 431 on violation)
+- body size limits (`MaxBodySizeMB`)
+- plugin request/response hooks
+- request and response breakpoint pauses
+- transaction persistence and metrics/access logging
+
+Main differences:
+
+- **HTTP/1.1 path** (`handleRequest`) writes raw HTTP responses back to `net.Conn`.
+- **HTTP/2 path** (`handleHTTP2Request`) writes via `http.ResponseWriter`.
+- HTTP/1.1 path supports pipelined request loop on the same TLS connection.
+
+## Plugin hook points
+
+Plugin execution is explicit and ordered:
+
+1. Build `plugins.ProxyRequest`
+2. `runPluginRequest(...)`
+3. Optional short-circuit via `MockedResponse`
+4. Upstream request/response round trip
+5. `runPluginResponse(...)`
+
+Relevant files:
+- `internal/proxy/http.go` (plain HTTP path)
+- `internal/proxy/https.go` (TLS paths)
+- `internal/proxy/plugins.go` (shared hook wrappers)
+
+## Breakpoint orchestration in proxy path
+
+Before forwarding upstream, proxy calls engine pause APIs:
+
+- `PauseRequest(tx)` may return:
+  - forward unchanged/modified
+  - drop (`502`)
+  - synthetic response
+
+After upstream response and plugin response hooks:
+
+- `PauseResponse(tx, statusCode, body)` supports the same decisions.
+
+Breakpoint control-plane comes from gRPC:
+- `WatchPausedRequests`
+- `ResumeRequest`
+
+## Persistence + observability handoff
+
+Once finalized, proxy writes one `Transaction` to engine:
+
+- `engine.StoreTransaction(tx)` persists request/response.
+- `observeRequest(...)` emits metrics, slowlog, and access-log fields.
+
+This guarantees history and telemetry reflect post-plugin/post-breakpoint outcomes.
+
+## Files to modify by concern
+
+- Protocol entry/tunnel behavior: `internal/proxy/http.go`
+- TLS interception / ALPN handling: `internal/proxy/https.go`
+- CA and certificate generation: `internal/proxy/certauthority.go`, `internal/proxy/cert.go`
+- Shared plugin execution helpers: `internal/proxy/plugins.go`
+- Input/body guardrails: `internal/proxy/request_limits.go`, `internal/http/limit.go`
+
+## Contributor checklist
+
+When changing proxy behavior:
+
+1. Verify both HTTP and HTTPS paths.
+2. Verify HTTP/1.1 and HTTP/2 TLS branches.
+3. Confirm plugin and breakpoint hooks still run in order.
+4. Confirm transaction persistence fields remain correct.
+5. Confirm metrics/access logs still receive request/response metadata.

--- a/docs/ARCHITECTURE/storage_replay.md
+++ b/docs/ARCHITECTURE/storage_replay.md
@@ -1,19 +1,125 @@
 # Storage, Replay, and Breakpoint Orchestration
 
-Why storage exists
-- APiX persists captured transactions so users can inspect, replay, and debug historical traffic.
-- SQLite is used for simplicity, portability, and transactional guarantees.
+APiX persists captured traffic to SQLite, serves it over gRPC history APIs, and can replay stored or synthetic requests through the same HTTP stack.
 
-Where to look
-- internal/storage — SQL schema and queries
-- internal/engine — in-memory store, pub/sub to gRPC streams
-- internal/replay — replay engine that re-sends recorded requests
-- internal/breakpoints — matching, pause/resume orchestration
+## Core packages
 
-Important notes
-- SQLite PRAGMAs are tuned for performance in production; tests use an ephemeral DB.
-- Replay respects original request headers and supports modifications via the extension's RequestEditor.
+- `internal/storage/` — SQLite schema and query layer
+- `internal/engine/` — write orchestration + pub/sub fanout to live subscribers
+- `internal/replay/` — replay request builders and upstream execution
+- `internal/breakpoints/` — pause/resume decisions injected into proxy flow
 
-Acceptance criteria
-- Doc explains the flow between storage, engine, and replay
-- Links to the relevant files are included
+## Data model (SQLite)
+
+Schema source: `internal/storage/schema.go`.
+
+Primary tables:
+
+- `requests` — canonical request record (`id`, method/url/headers/body, timestamp, duration, protocol)
+- `responses` — response by `request_id` (1:1 with requests when available)
+- `breakpoints` — persistent breakpoint rules
+- `plugins` — plugin config and enabled state
+- `ws_frames` — WebSocket frame history keyed by `transaction_id`
+- `rewrite_rules` — response/request rewrite and mock rules
+- `request_templates` — saved replay/compose templates
+
+Indexes include timestamp/method/url and websocket transaction lookups to keep list/history views responsive under load.
+
+## DB initialization and runtime behavior
+
+`storage.Open()` (`internal/storage/sqlite.go`) configures:
+
+- WAL mode (`PRAGMA journal_mode=WAL`)
+- `synchronous=NORMAL`
+- `busy_timeout=5000`
+- `foreign_keys=ON`
+- schema bootstrap + lightweight migrations
+
+In-memory mode (`:memory:`) pins connection count to 1 so tests share one database.
+
+## Write path (capture -> persistence)
+
+```text
+HTTP/TLS proxy handler
+   -> builds proxy.Transaction
+   -> engine.StoreTransaction(tx)
+       -> map headers/body into storage.RequestRecord + ResponseRecord
+       -> SaveTransaction(req, resp) when available (single SQL tx)
+          or SaveRequest/SaveResponse fallback
+       -> publish HttpRequest to capture subscribers
+```
+
+Key files:
+- `internal/proxy/http.go`
+- `internal/proxy/https.go`
+- `internal/engine/engine.go` (`StoreTransaction`)
+- `internal/storage/queries.go` (`SaveTransaction`, `SaveRequest`, `SaveResponse`)
+
+## Read path (history APIs)
+
+```text
+CLI/VS Code
+   -> gRPC GetHistory
+   -> internal/server/handlers_traffic.go
+   -> storage.ListTransactions(...)
+   -> stream HttpTransaction records to client
+```
+
+`ListTransactions` supports:
+- pagination (`limit`, `offset`)
+- URL and method filters
+- status-code filter
+- request/response body substring filter
+
+WebSocket inspection is similar via `GetWebSocketFrames` + `ListWebSocketFrames`.
+
+## Replay lifecycle
+
+Replay entrypoint: `internal/replay/engine.go` (`ReplayRequest`).
+
+`ReplaySpec` supports two sources:
+1. `request_id` (load stored request from DB)
+2. `raw_request` (ad-hoc composed request)
+
+Flow:
+
+1. Select source builder (`storedRequestBuilder` or `rawRequestBuilder`).
+2. Build `http.Request`.
+3. Apply override headers/method/body.
+4. Execute with replay HTTP client (timeouts + TLS policy).
+5. Return `HttpResponse` over gRPC.
+
+Related server handler: `internal/server/handlers_replay.go`.
+
+## Breakpoint integration
+
+Breakpoints are applied in proxy handlers before and after upstream round trip:
+
+- request phase: `engine.PauseRequest(tx)`
+- response phase: `engine.PauseResponse(tx, statusCode, body)`
+
+Decisions originate from `internal/breakpoints/manager.go` and are controlled by gRPC `WatchPausedRequests` + `ResumeRequest`.
+
+Because pause decisions happen before `StoreTransaction`, persisted history reflects the final forwarded/synthetic response behavior.
+
+## Body storage behavior and limits
+
+- Request/response bodies are stored inline as BLOBs in `requests.body` and `responses.body`.
+- Proxy enforces max body size (`MaxBodySizeMB`) before persistence.
+- Oversized bodies are rejected in proxy path (413), preventing unbounded DB growth per transaction.
+
+There is no out-of-band blob store today; all persisted payloads live in SQLite.
+
+## Operational considerations
+
+1. **Pruning:** retention/prune helpers live in `internal/storage/prune.go`.
+2. **VACUUM:** periodic vacuum support exists in `sqlite.go` (`StartPeriodicVacuum`).
+3. **Atomicity:** `SaveTransaction` avoids split writes when both sides exist.
+4. **Backpressure:** live subscribers are non-blocking; overflow drops only stream events, not persistence.
+
+## Change map for contributors
+
+- Add/modify columns: `internal/storage/schema.go` + mapper/query scans.
+- Change persistence semantics: `internal/engine/engine.go` and `internal/storage/queries.go`.
+- Change replay behavior/timeouts: `internal/replay/engine.go` and builders.
+- Change history shape to clients: `internal/server/handlers_traffic.go` + `pkg/api/proto/apix.proto`.


### PR DESCRIPTION
Summary:\n- expand proxy_mitm.md with CONNECT/TLS MITM/ALPN flow, plugin and breakpoint hook points\n- expand storage_replay.md with schema details, write/read paths, replay lifecycle, and limits\n- expand grpc_protobuf.md with RPC/message coverage, streaming patterns, and proto workflow\n- expand extension_arch.md with activation flow, component responsibilities, and webview message protocol\n\nCloses #421