### PR TITLE
feat(security): add audit log for state-changing RPCs (closes #292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Validate config:
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
 | `metrics_enabled` / `metrics_port` | `false` / `9091` | Prometheus metrics endpoint |
 | `access_log_enabled` / `access_log_format` / `access_log_path` | `false` / `json` / `stdout` | Per-request access logging |
+| `audit_log_enabled` / `audit_log_path` | `false` / `stdout` | Structured audit trail for state-changing gRPC operations |
 | `otel_enabled` / `otel_endpoint` / `otel_service_name` / `otel_insecure` / `otel_sample_rate` | `false` / `localhost:4317` / `apix-proxy` / `true` / `1.0` | Built-in OTLP tracing exporter plugin |
 | `health_port` | `9092` | `/healthz` endpoint |
 | `log_format` / `log_level` | `text` / `info` | Engine log output shape and verbosity |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,8 @@ type Config struct {
 	AccessLogEnabled    bool    `yaml:"access_log_enabled"`
 	AccessLogFormat     string  `yaml:"access_log_format"`
 	AccessLogPath       string  `yaml:"access_log_path"`
+	AuditLogEnabled     bool    `yaml:"audit_log_enabled"`
+	AuditLogPath        string  `yaml:"audit_log_path"`
 	OTelEnabled         bool    `yaml:"otel_enabled"`
 	OTelEndpoint        string  `yaml:"otel_endpoint"`
 	OTelServiceName     string  `yaml:"otel_service_name"`
@@ -185,6 +187,8 @@ func LoadConfig(path string) *Config {
 		AccessLogEnabled:    false,
 		AccessLogFormat:     "json",
 		AccessLogPath:       "stdout",
+		AuditLogEnabled:     false,
+		AuditLogPath:        "stdout",
 		OTelEnabled:         false,
 		OTelEndpoint:        "localhost:4317",
 		OTelServiceName:     "apix-proxy",

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -18,6 +18,8 @@ log_level: "info"   # debug | info | warn | error
 access_log_enabled: false
 access_log_format: "json"  # json | common | combined
 access_log_path: "stdout"  # stdout | stderr | /path/to/file.log
+audit_log_enabled: false
+audit_log_path: "stdout"   # stdout | stderr | /path/to/file.log
 
 # OpenTelemetry tracing plugin
 otel_enabled: false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,12 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.AccessLogPath != "stdout" {
 		t.Errorf("AccessLogPath: got %q want stdout", cfg.AccessLogPath)
 	}
+	if cfg.AuditLogEnabled {
+		t.Error("AuditLogEnabled: expected false by default")
+	}
+	if cfg.AuditLogPath != "stdout" {
+		t.Errorf("AuditLogPath: got %q want stdout", cfg.AuditLogPath)
+	}
 }
 
 func TestLoadConfig_YAMLOverride(t *testing.T) {
@@ -115,6 +121,8 @@ otel_sample_rate: 0.25
 access_log_enabled: true
 access_log_format: "combined"
 access_log_path: "/tmp/apix-access.log"
+audit_log_enabled: true
+audit_log_path: "/tmp/apix-audit.log"
 `)
 	cfg := LoadConfig(path)
 
@@ -177,6 +185,12 @@ access_log_path: "/tmp/apix-access.log"
 	}
 	if cfg.AccessLogPath != "/tmp/apix-access.log" {
 		t.Errorf("AccessLogPath: got %q want /tmp/apix-access.log", cfg.AccessLogPath)
+	}
+	if !cfg.AuditLogEnabled {
+		t.Error("AuditLogEnabled should be true from YAML override")
+	}
+	if cfg.AuditLogPath != "/tmp/apix-audit.log" {
+		t.Errorf("AuditLogPath: got %q want /tmp/apix-audit.log", cfg.AuditLogPath)
 	}
 	// Unspecified fields stay at defaults.
 	if cfg.HTTPIdleTimeout != 120 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -231,6 +231,9 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	if c.AccessLogEnabled && strings.TrimSpace(c.AccessLogPath) == "" {
 		errs = append(errs, fmt.Errorf("access_log_path must be set when access_log_enabled is true"))
 	}
+	if c.AuditLogEnabled && strings.TrimSpace(c.AuditLogPath) == "" {
+		errs = append(errs, fmt.Errorf("audit_log_path must be set when audit_log_enabled is true"))
+	}
 	if c.OTelEnabled {
 		if strings.TrimSpace(c.OTelEndpoint) == "" {
 			errs = append(errs, fmt.Errorf("otel_endpoint must be set when otel_enabled is true"))

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -42,6 +42,7 @@ func TestValidate_InvalidLogSettings(t *testing.T) {
 		LogFormat:           "xml",
 		LogLevel:            "trace",
 		AccessLogFormat:     "plain",
+		AuditLogEnabled:     true,
 	}
 	err := cfg.Validate()
 	if err == nil {
@@ -56,6 +57,9 @@ func TestValidate_InvalidLogSettings(t *testing.T) {
 	}
 	if !strings.Contains(msg, "access_log_format") {
 		t.Fatalf("expected access_log_format validation error, got: %v", err)
+	}
+	if !strings.Contains(msg, "audit_log_path") {
+		t.Fatalf("expected audit_log_path validation error, got: %v", err)
 	}
 }
 

--- a/internal/logging/audit.go
+++ b/internal/logging/audit.go
@@ -1,0 +1,54 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type AuditLogConfig struct {
+	Enabled bool
+	Path    string
+}
+
+type AuditLogEntry struct {
+	Timestamp time.Time
+	Action    string
+	Actor     string
+	TargetID  string
+	Details   map[string]any
+}
+
+func EmitAuditLog(_ context.Context, cfg AuditLogConfig, entry AuditLogEntry) error {
+	if !cfg.Enabled {
+		return nil
+	}
+	if entry.Timestamp.IsZero() {
+		entry.Timestamp = time.Now().UTC()
+	}
+
+	w, closeFn, err := accessLogWriter(cfg.Path)
+	if err != nil {
+		return err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+
+	payload := map[string]any{
+		"timestamp": entry.Timestamp.UTC().Format(time.RFC3339Nano),
+		"action":    entry.Action,
+		"actor":     entry.Actor,
+		"target_id": entry.TargetID,
+	}
+	if len(entry.Details) > 0 {
+		payload["details"] = entry.Details
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s\n", b)
+	return err
+}

--- a/internal/logging/audit_test.go
+++ b/internal/logging/audit_test.go
@@ -1,0 +1,50 @@
+package logging
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmitAuditLog(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "audit.log")
+	err := EmitAuditLog(context.Background(), AuditLogConfig{
+		Enabled: true,
+		Path:    path,
+	}, AuditLogEntry{
+		Timestamp: time.Unix(0, 0).UTC(),
+		Action:    "replay_request",
+		Actor:     "peer:127.0.0.1:1234",
+		TargetID:  "req-1",
+		Details: map[string]any{
+			"method": "GET",
+			"url":    "https://example.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("emit audit log: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	line := string(b)
+	if !strings.Contains(line, `"action":"replay_request"`) {
+		t.Fatalf("missing action field: %s", line)
+	}
+	if !strings.Contains(line, `"actor":"peer:127.0.0.1:1234"`) {
+		t.Fatalf("missing actor field: %s", line)
+	}
+	if !strings.Contains(line, `"target_id":"req-1"`) {
+		t.Fatalf("missing target_id field: %s", line)
+	}
+	if !strings.Contains(line, `"details":{"method":"GET","url":"https://example.com"}`) {
+		t.Fatalf("missing details field: %s", line)
+	}
+}

--- a/internal/server/audit.go
+++ b/internal/server/audit.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net"
+	"strings"
+	"time"
+
+	logging "github.com/mnafshin/apix/internal/logging"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func (s *EngineServer) auditLog(ctx context.Context, action, targetID string, details map[string]any) {
+	if s == nil || s.cfg == nil || !s.cfg.AuditLogEnabled {
+		return
+	}
+	err := logging.EmitAuditLog(ctx, logging.AuditLogConfig{
+		Enabled: s.cfg.AuditLogEnabled,
+		Path:    s.cfg.AuditLogPath,
+	}, logging.AuditLogEntry{
+		Timestamp: time.Now().UTC(),
+		Action:    action,
+		Actor:     auditActorFromContext(ctx),
+		TargetID:  targetID,
+		Details:   details,
+	})
+	if err != nil {
+		logging.Errorf(ctx, "audit log emit: %v", err)
+	}
+}
+
+func auditActorFromContext(ctx context.Context) string {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if authVals := md.Get("authorization"); len(authVals) > 0 {
+			raw := strings.TrimSpace(authVals[0])
+			if raw != "" {
+				sum := sha256.Sum256([]byte(raw))
+				return "bearer_sha256:" + hex.EncodeToString(sum[:8])
+			}
+		}
+	}
+	if p, ok := peer.FromContext(ctx); ok && p != nil && p.Addr != nil {
+		if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+			return "peer:" + host
+		}
+		return "peer:" + p.Addr.String()
+	}
+	return "unknown"
+}

--- a/internal/server/handlers_breakpoints.go
+++ b/internal/server/handlers_breakpoints.go
@@ -39,6 +39,11 @@ func (s *EngineServer) SetBreakpoint(ctx context.Context, req *apix.BreakpointRu
 	if err := s.db.SaveBreakpoint(added.ID, added.URLPattern, added.Methods, added.Enabled, added.Label, added.HeaderName, added.HeaderValue, added.BodyPattern, added.StatusCodes); err != nil {
 		logging.Errorf(ctx, "grpc: save breakpoint: %v", err)
 	}
+	s.auditLog(ctx, "set_breakpoint", added.ID, map[string]any{
+		"url_pattern": added.URLPattern,
+		"methods":     added.Methods,
+		"enabled":     added.Enabled,
+	})
 	return &apix.BreakpointResponse{
 		Breakpoint: &apix.BreakpointRule{
 			Id:          added.ID,
@@ -61,6 +66,7 @@ func (s *EngineServer) DeleteBreakpoint(ctx context.Context, req *apix.Breakpoin
 	if err := s.db.DeleteBreakpoint(req.Id); err != nil {
 		logging.Errorf(ctx, "grpc: delete breakpoint from storage: %v", err)
 	}
+	s.auditLog(ctx, "delete_breakpoint", req.Id, nil)
 	return &apix.Empty{}, nil
 }
 
@@ -159,5 +165,8 @@ func (s *EngineServer) ResumeRequest(ctx context.Context, req *apix.ResumeAction
 	if err := s.breakpointMgr.Resume(req.RequestId, decision); err != nil {
 		return nil, status.Errorf(codes.NotFound, "resume request: %v", err)
 	}
+	s.auditLog(ctx, "resume_request", req.RequestId, map[string]any{
+		"action": req.Action.String(),
+	})
 	return &apix.Empty{}, nil
 }

--- a/internal/server/handlers_replay.go
+++ b/internal/server/handlers_replay.go
@@ -40,6 +40,18 @@ func (s *EngineServer) ReplayRequest(ctx context.Context, req *apix.ReplaySpec) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "replay: %v", err)
 	}
+	details := map[string]any{
+		"follow_redirects": rr.FollowRedirects,
+	}
+	if rr.RequestID != "" {
+		details["source"] = "request_id"
+		details["request_id"] = rr.RequestID
+	} else if rr.RawRequest != nil {
+		details["source"] = "raw_request"
+		details["method"] = rr.RawRequest.Method
+		details["url"] = rr.RawRequest.URL.String()
+	}
+	s.auditLog(ctx, "replay_request", rr.RequestID, details)
 	return httpResponseToProto(resp)
 }
 
@@ -55,10 +67,15 @@ func (s *EngineServer) ComposeRequest(ctx context.Context, req *apix.ComposeSpec
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "compose request: %v", err)
 	}
+	s.auditLog(ctx, "compose_request", "", map[string]any{
+		"method":           httpReq.Method,
+		"url":              httpReq.URL.String(),
+		"follow_redirects": req.FollowRedirects,
+	})
 	return httpResponseToProto(resp)
 }
 
-func (s *EngineServer) SaveRequestTemplate(_ context.Context, req *apix.RequestTemplate) (*apix.RequestTemplate, error) {
+func (s *EngineServer) SaveRequestTemplate(ctx context.Context, req *apix.RequestTemplate) (*apix.RequestTemplate, error) {
 	if req.GetRequest() == nil {
 		return nil, status.Error(codes.InvalidArgument, "request is required")
 	}
@@ -84,6 +101,11 @@ func (s *EngineServer) SaveRequestTemplate(_ context.Context, req *apix.RequestT
 	if err := s.db.SaveRequestTemplate(record); err != nil {
 		return nil, status.Errorf(codes.Internal, "save request template: %v", err)
 	}
+	s.auditLog(ctx, "save_request_template", id, map[string]any{
+		"name":   record.Name,
+		"method": record.Method,
+		"url":    record.URL,
+	})
 	return requestTemplateRecordToProto(record), nil
 }
 
@@ -99,13 +121,14 @@ func (s *EngineServer) ListRequestTemplates(_ context.Context, _ *apix.Empty) (*
 	return &apix.RequestTemplateList{Templates: templates}, nil
 }
 
-func (s *EngineServer) DeleteRequestTemplate(_ context.Context, req *apix.RequestTemplateID) (*apix.Empty, error) {
+func (s *EngineServer) DeleteRequestTemplate(ctx context.Context, req *apix.RequestTemplateID) (*apix.Empty, error) {
 	if req.GetId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
 	if err := s.db.DeleteRequestTemplate(req.GetId()); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete request template: %v", err)
 	}
+	s.auditLog(ctx, "delete_request_template", req.GetId(), nil)
 	return &apix.Empty{}, nil
 }
 

--- a/internal/server/handlers_rewrite.go
+++ b/internal/server/handlers_rewrite.go
@@ -16,6 +16,12 @@ func (s *EngineServer) AddRewriteRule(ctx context.Context, rule *apix.RewriteRul
 	if err := s.db.AddRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "add rewrite rule: %v", err)
 	}
+	s.auditLog(ctx, "add_rewrite_rule", rule.Id, map[string]any{
+		"name":     rule.Name,
+		"action":   rule.Action.String(),
+		"enabled":  rule.Enabled,
+		"priority": rule.Priority,
+	})
 	return rule, nil
 }
 
@@ -26,6 +32,12 @@ func (s *EngineServer) UpdateRewriteRule(ctx context.Context, rule *apix.Rewrite
 	if err := s.db.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "update rewrite rule: %v", err)
 	}
+	s.auditLog(ctx, "update_rewrite_rule", rule.Id, map[string]any{
+		"name":     rule.Name,
+		"action":   rule.Action.String(),
+		"enabled":  rule.Enabled,
+		"priority": rule.Priority,
+	})
 	return rule, nil
 }
 
@@ -36,6 +48,7 @@ func (s *EngineServer) DeleteRewriteRule(ctx context.Context, req *apix.RewriteR
 	if err := s.db.DeleteRewriteRule(req.RuleId); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete rewrite rule: %v", err)
 	}
+	s.auditLog(ctx, "delete_rewrite_rule", req.RuleId, nil)
 	return &apix.Empty{}, nil
 }
 
@@ -62,5 +75,6 @@ func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteR
 	if err := s.db.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "toggle rewrite rule: %v", err)
 	}
+	s.auditLog(ctx, "toggle_rewrite_rule", rule.Id, map[string]any{"enabled": rule.Enabled})
 	return rule, nil
 }

--- a/internal/server/handlers_traffic.go
+++ b/internal/server/handlers_traffic.go
@@ -165,6 +165,7 @@ func (s *EngineServer) ClearHistory(ctx context.Context, _ *apix.Empty) (*apix.E
 	if err := s.db.DeleteAllTransactions(); err != nil {
 		return nil, status.Errorf(codes.Internal, "clear history: %v", err)
 	}
+	s.auditLog(ctx, "clear_history", "", nil)
 	return &apix.Empty{}, nil
 }
 


### PR DESCRIPTION
Summary:\n- add configurable JSON audit logger (audit_log_enabled, audit_log_path)\n- emit audit events for breakpoint changes, replay/compose, history clear, template save/delete, rewrite rule mutations, and resume actions\n- include actor attribution from auth metadata hash or peer address\n- add config defaults/validation/tests and audit logger unit tests\n- document audit log config keys in README\n\nCloses #292