### PR TITLE
feat(security): add proxy-layer rate limiting (closes #291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Validate config:
 | `tls_enabled` | `false` | Enable TLS for gRPC |
 | `grpc_cert_path` / `grpc_key_path` | empty | Required when TLS is enabled |
 | `auth_token` | empty | Bearer token for gRPC/MCP auth |
+| `proxy_rate_limit_per_sec` / `proxy_max_concurrent_connections` | `1000` / `200` | Per-client proxy throttling and concurrent tunnel/request cap |
 | `max_body_size_mb` | `32` | Request/response body limit per body |
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
 | `metrics_enabled` / `metrics_port` | `false` / `9091` | Prometheus metrics endpoint |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	HTTPReadTimeout                  int    `yaml:"http_read_timeout_sec"`
 	HTTPWriteTimeout                 int    `yaml:"http_write_timeout_sec"`
 	HTTPIdleTimeout                  int    `yaml:"http_idle_timeout_sec"`
+	ProxyRateLimitPerSec             int    `yaml:"proxy_rate_limit_per_sec"`
+	ProxyMaxConcurrentConnections    int    `yaml:"proxy_max_concurrent_connections"`
 	MaxHeadersPerRequest             int    `yaml:"max_headers_per_request"`
 	MaxHeaderValueBytes              int    `yaml:"max_header_value_bytes"`
 	MaxTotalHeaderBytes              int    `yaml:"max_total_header_bytes"`
@@ -171,6 +173,8 @@ func LoadConfig(path string) *Config {
 		HTTPReadTimeout:                  30,
 		HTTPWriteTimeout:                 120,
 		HTTPIdleTimeout:                  120,
+		ProxyRateLimitPerSec:             1000,
+		ProxyMaxConcurrentConnections:    200,
 		MaxHeadersPerRequest:             200,
 		MaxHeaderValueBytes:              8 * 1024,
 		MaxTotalHeaderBytes:              1 * 1024 * 1024,

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -33,6 +33,8 @@ http_read_header_timeout_sec: 10
 http_read_timeout_sec: 30
 http_write_timeout_sec: 120
 http_idle_timeout_sec: 120
+proxy_rate_limit_per_sec: 1000
+proxy_max_concurrent_connections: 200
 
 # Connection pool settings
 max_idle_conns_per_host: 10  # max idle connections kept per upstream host

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,12 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.MaxIdleConnsPerHost != 10 {
 		t.Errorf("MaxIdleConnsPerHost: got %d want 10", cfg.MaxIdleConnsPerHost)
 	}
+	if cfg.ProxyRateLimitPerSec != 1000 {
+		t.Errorf("ProxyRateLimitPerSec: got %d want 1000", cfg.ProxyRateLimitPerSec)
+	}
+	if cfg.ProxyMaxConcurrentConnections != 200 {
+		t.Errorf("ProxyMaxConcurrentConnections: got %d want 200", cfg.ProxyMaxConcurrentConnections)
+	}
 	if cfg.MaxHeadersPerRequest != 200 {
 		t.Errorf("MaxHeadersPerRequest: got %d want 200", cfg.MaxHeadersPerRequest)
 	}
@@ -105,6 +111,8 @@ http_port: "9999"
 grpc_port: "8888"
 max_body_size_mb: 64
 dial_timeout_sec: 5
+proxy_rate_limit_per_sec: 300
+proxy_max_concurrent_connections: 50
 max_headers_per_request: 150
 max_header_value_bytes: 4096
 max_total_header_bytes: 262144
@@ -137,6 +145,12 @@ audit_log_path: "/tmp/apix-audit.log"
 	}
 	if cfg.DialTimeoutSec != 5 {
 		t.Errorf("DialTimeoutSec: got %d want 5", cfg.DialTimeoutSec)
+	}
+	if cfg.ProxyRateLimitPerSec != 300 {
+		t.Errorf("ProxyRateLimitPerSec: got %d want 300", cfg.ProxyRateLimitPerSec)
+	}
+	if cfg.ProxyMaxConcurrentConnections != 50 {
+		t.Errorf("ProxyMaxConcurrentConnections: got %d want 50", cfg.ProxyMaxConcurrentConnections)
 	}
 	if cfg.MaxHeadersPerRequest != 150 {
 		t.Errorf("MaxHeadersPerRequest: got %d want 150", cfg.MaxHeadersPerRequest)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -51,6 +51,12 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	if c.MaxHeadersPerRequest == 0 {
 		c.MaxHeadersPerRequest = 200
 	}
+	if c.ProxyRateLimitPerSec == 0 {
+		c.ProxyRateLimitPerSec = 1000
+	}
+	if c.ProxyMaxConcurrentConnections == 0 {
+		c.ProxyMaxConcurrentConnections = 200
+	}
 	if c.MaxHeaderValueBytes == 0 {
 		c.MaxHeaderValueBytes = 8 * 1024
 	}
@@ -126,6 +132,12 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	// ── Connection pool ────────────────────────────────────────────────────
 	if c.MaxIdleConnsPerHost <= 0 {
 		errs = append(errs, fmt.Errorf("max_idle_conns_per_host must be > 0 (got %d) — recommended value: 10", c.MaxIdleConnsPerHost))
+	}
+	if c.ProxyRateLimitPerSec <= 0 {
+		errs = append(errs, fmt.Errorf("proxy_rate_limit_per_sec must be > 0 (got %d)", c.ProxyRateLimitPerSec))
+	}
+	if c.ProxyMaxConcurrentConnections <= 0 {
+		errs = append(errs, fmt.Errorf("proxy_max_concurrent_connections must be > 0 (got %d)", c.ProxyMaxConcurrentConnections))
 	}
 	if c.MaxHeadersPerRequest <= 0 {
 		errs = append(errs, fmt.Errorf("max_headers_per_request must be > 0 (got %d)", c.MaxHeadersPerRequest))

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -323,21 +323,25 @@ func TestValidate_InvalidInputBounds(t *testing.T) {
 	t.Parallel()
 	httpPort, grpcPort := mustFreePorts(t)
 	cfg := &Config{
-		HTTPPort:             httpPort,
-		GRPCPort:             grpcPort,
-		DBPath:               "apix.db",
-		MaxIdleConnsPerHost:  10,
-		MaxHeadersPerRequest: -1,
-		MaxHeaderValueBytes:  -1,
-		MaxTotalHeaderBytes:  -1,
-		MaxURLLength:         -1,
+		HTTPPort:                      httpPort,
+		GRPCPort:                      grpcPort,
+		DBPath:                        "apix.db",
+		MaxIdleConnsPerHost:           10,
+		ProxyRateLimitPerSec:          -1,
+		ProxyMaxConcurrentConnections: -1,
+		MaxHeadersPerRequest:          -1,
+		MaxHeaderValueBytes:           -1,
+		MaxTotalHeaderBytes:           -1,
+		MaxURLLength:                  -1,
 	}
 	err := cfg.Validate()
 	if err == nil {
 		t.Fatal("expected validation failure for invalid input bounds")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "max_headers_per_request") ||
+	if !strings.Contains(msg, "proxy_rate_limit_per_sec") ||
+		!strings.Contains(msg, "proxy_max_concurrent_connections") ||
+		!strings.Contains(msg, "max_headers_per_request") ||
 		!strings.Contains(msg, "max_header_value_bytes") ||
 		!strings.Contains(msg, "max_total_header_bytes") ||
 		!strings.Contains(msg, "max_url_length") {

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -35,17 +35,23 @@ type HTTPProxy struct {
 	engine    TrafficEngine
 	transport *http.Transport
 	cfg       *config.Config
+	limiter   *proxyRateLimiter
 }
 
 // NewHTTPProxy creates a new HTTP proxy listening on addr.
 func NewHTTPProxy(addr string, tlsProxy *TLSProxy, engine TrafficEngine, opts TransportOptions, cfg *config.Config) *HTTPProxy {
-	return &HTTPProxy{
+	p := &HTTPProxy{
 		addr:      addr,
 		tlsProxy:  tlsProxy,
 		engine:    engine,
 		transport: newTransport(nil, opts),
 		cfg:       cfg,
+		limiter:   newProxyRateLimiter(cfg),
 	}
+	if tlsProxy != nil {
+		tlsProxy.SetRateLimiter(p.limiter)
+	}
+	return p
 }
 
 // Start begins accepting connections. Blocks until ctx is cancelled.
@@ -78,6 +84,16 @@ func (p *HTTPProxy) Start(ctx context.Context) error {
 // ServeHTTP handles both plain HTTP and CONNECT (tunnel) requests.
 func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	clientIP := normalizeClientIP(r.RemoteAddr)
+	if !p.limiter.allow(clientIP) {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+	if !p.limiter.acquire(clientIP) {
+		http.Error(w, "too many concurrent connections", http.StatusTooManyRequests)
+		return
+	}
+	defer p.limiter.release(clientIP)
 	defer func() {
 		if rec := recover(); rec != nil {
 			logging.Errorf(ctx, "HTTP proxy panic in ServeHTTP (recovered): %v", rec)

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -29,6 +29,7 @@ type TLSProxy struct {
 	transport     *http.Transport
 	transportOpts TransportOptions // retained so SetUpstreamTLSConfig can rebuild
 	cfg           *config.Config
+	limiter       *proxyRateLimiter
 }
 
 // NewTLSProxy creates a MITM TLS proxy using the provided CA.
@@ -39,6 +40,7 @@ func NewTLSProxy(ca *CertAuthority, engine TrafficEngine, opts TransportOptions,
 		transportOpts: opts,
 		transport:     newTransport(nil, opts),
 		cfg:           cfg,
+		limiter:       newProxyRateLimiter(cfg),
 	}
 }
 
@@ -47,6 +49,10 @@ func NewTLSProxy(ca *CertAuthority, engine TrafficEngine, opts TransportOptions,
 // plugin execution.
 func (p *TLSProxy) SetPlugins(chain any) {
 	p.plugins = chain
+}
+
+func (p *TLSProxy) SetRateLimiter(limiter *proxyRateLimiter) {
+	p.limiter = limiter
 }
 
 // SetUpstreamTLSConfig sets a custom TLS configuration used when dialling the
@@ -151,6 +157,11 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 	reqID := uuid.NewString()
 	start := time.Now()
 	origHeaders := r.Header.Clone()
+	clientIP := normalizeClientIP(conn.RemoteAddr().String())
+	if !p.limiter.allow(clientIP) {
+		writeHTTPError(ctx, conn, http.StatusTooManyRequests, "rate limit exceeded")
+		return
+	}
 	if err := validateInboundRequest(p.cfg, r); err != nil {
 		writeHTTPError(ctx, conn, http.StatusRequestHeaderFieldsTooLarge, err.Error())
 		return
@@ -349,6 +360,11 @@ func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter
 
 	reqID := uuid.NewString()
 	start := time.Now()
+	clientIP := normalizeClientIP(r.RemoteAddr)
+	if !p.limiter.allow(clientIP) {
+		http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
 	if r.URL.Host == "" {
 		r.URL.Host = host
 	}

--- a/internal/proxy/ratelimit.go
+++ b/internal/proxy/ratelimit.go
@@ -1,0 +1,123 @@
+package proxy
+
+import (
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mnafshin/apix/internal/config"
+)
+
+type tokenBucket struct {
+	mu        sync.Mutex
+	tokens    float64
+	maxTokens float64
+	rate      float64
+	lastTime  time.Time
+}
+
+func newTokenBucket(ratePerSec int) *tokenBucket {
+	return &tokenBucket{
+		tokens:    float64(ratePerSec),
+		maxTokens: float64(ratePerSec),
+		rate:      float64(ratePerSec) / float64(time.Second),
+		lastTime:  time.Now(),
+	}
+}
+
+func (tb *tokenBucket) allow() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(tb.lastTime)
+	tb.lastTime = now
+	tb.tokens += float64(elapsed) * tb.rate
+	if tb.tokens > tb.maxTokens {
+		tb.tokens = tb.maxTokens
+	}
+	if tb.tokens < 1 {
+		return false
+	}
+	tb.tokens--
+	return true
+}
+
+type proxyRateLimiter struct {
+	ratePerSec    int
+	maxConcurrent int
+
+	mu      sync.Mutex
+	buckets map[string]*tokenBucket
+	active  map[string]int
+}
+
+func newProxyRateLimiter(cfg *config.Config) *proxyRateLimiter {
+	if cfg == nil {
+		return nil
+	}
+	return &proxyRateLimiter{
+		ratePerSec:    cfg.ProxyRateLimitPerSec,
+		maxConcurrent: cfg.ProxyMaxConcurrentConnections,
+		buckets:       make(map[string]*tokenBucket),
+		active:        make(map[string]int),
+	}
+}
+
+func (l *proxyRateLimiter) allow(clientIP string) bool {
+	if l == nil || l.ratePerSec <= 0 {
+		return true
+	}
+
+	clientIP = normalizeClientIP(clientIP)
+	l.mu.Lock()
+	bucket, ok := l.buckets[clientIP]
+	if !ok {
+		bucket = newTokenBucket(l.ratePerSec)
+		l.buckets[clientIP] = bucket
+	}
+	l.mu.Unlock()
+
+	return bucket.allow()
+}
+
+func (l *proxyRateLimiter) acquire(clientIP string) bool {
+	if l == nil || l.maxConcurrent <= 0 {
+		return true
+	}
+
+	clientIP = normalizeClientIP(clientIP)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.active[clientIP] >= l.maxConcurrent {
+		return false
+	}
+	l.active[clientIP]++
+	return true
+}
+
+func (l *proxyRateLimiter) release(clientIP string) {
+	if l == nil || l.maxConcurrent <= 0 {
+		return
+	}
+	clientIP = normalizeClientIP(clientIP)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if current := l.active[clientIP]; current <= 1 {
+		delete(l.active, clientIP)
+	} else {
+		l.active[clientIP] = current - 1
+	}
+}
+
+func normalizeClientIP(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return "unknown"
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
+}

--- a/internal/proxy/ratelimit_test.go
+++ b/internal/proxy/ratelimit_test.go
@@ -1,0 +1,58 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mnafshin/apix/internal/config"
+)
+
+func TestProxyRateLimiterAcquireRelease(t *testing.T) {
+	t.Parallel()
+	limiter := &proxyRateLimiter{
+		maxConcurrent: 1,
+		active:        make(map[string]int),
+	}
+	ip := "10.0.0.1"
+	if !limiter.acquire(ip) {
+		t.Fatal("expected first acquire to succeed")
+	}
+	if limiter.acquire(ip) {
+		t.Fatal("expected second acquire to fail at max concurrent limit")
+	}
+	limiter.release(ip)
+	if !limiter.acquire(ip) {
+		t.Fatal("expected acquire to succeed after release")
+	}
+}
+
+func TestHTTPProxyServeHTTPRateLimit(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := config.LoadConfig("/nonexistent/path/config.yaml")
+	cfg.ProxyRateLimitPerSec = 1
+	cfg.ProxyMaxConcurrentConnections = 50
+	p := NewHTTPProxy("", nil, nil, TransportOptions{}, cfg)
+
+	req1 := httptest.NewRequest(http.MethodGet, upstream.URL, nil)
+	req1.RemoteAddr = "10.0.0.1:1234"
+	rr1 := httptest.NewRecorder()
+	p.ServeHTTP(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, want %d", rr1.Code, http.StatusOK)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, upstream.URL, nil)
+	req2.RemoteAddr = "10.0.0.1:5678"
+	rr2 := httptest.NewRecorder()
+	p.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request status = %d, want %d", rr2.Code, http.StatusTooManyRequests)
+	}
+}


### PR DESCRIPTION
Summary:\n- add proxy_rate_limit_per_sec and proxy_max_concurrent_connections config with defaults and validation\n- implement per-client token-bucket limiting and concurrent caps in proxy layer\n- return 429 for rate/concurrency violations in HTTP and TLS request paths\n- add proxy rate limiter tests and config/readme updates\n\nCloses #291