### PR TITLE
feat(security): harden auth token config handling (closes #290)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Validate config:
 | `grpc_bind_address` | `127.0.0.1` | gRPC bind address |
 | `tls_enabled` | `false` | Enable TLS for gRPC |
 | `grpc_cert_path` / `grpc_key_path` | empty | Required when TLS is enabled |
-| `auth_token` | empty | Bearer token for gRPC/MCP auth |
+| `auth_token` / `auth_token_file` / `auth_token_require_strict_perms` | empty / empty / `true` | Bearer token auth, secret-file support, and strict config permission enforcement |
 | `proxy_rate_limit_per_sec` / `proxy_max_concurrent_connections` | `1000` / `200` | Per-client proxy throttling and concurrent tunnel/request cap |
 | `max_body_size_mb` | `32` | Request/response body limit per body |
 | `history_max_age_days` / `history_max_rows` | `0` / `0` | Retention pruning controls |
@@ -123,6 +123,7 @@ Validate config:
 - Local defaults bind gRPC/MCP to loopback.
 - Remote gRPC and remote MCP are validated to require **TLS + auth token**.
 - Prefer `APIX_AUTH_TOKEN` environment variable over storing `auth_token` in plaintext.
+- If `auth_token` is stored in `config.yaml`, APiX enforces strict file permissions (0600 or stricter) by default.
 
 ## Development commands
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -115,6 +115,9 @@ db_path: "~/.apix/apix.db"
 # Optional: Auth token for remote deployments
 # IMPORTANT: Use env var APIX_AUTH_TOKEN instead to avoid plaintext secrets!
 # auth_token: "your-secret-token-here"
+# Optional: read token from a mounted secret file
+# auth_token_file: "/run/secrets/apix-token"
+auth_token_require_strict_perms: true  # rejects plaintext auth_token if config file is wider than 0600
 
 # Optional: TLS for remote engines (for vscode.dev support)
 tls_enabled: false
@@ -341,8 +344,11 @@ APiX engine supports remote gRPC access over TLS for vscode.dev/browser clients.
    tls_enabled: true
    grpc_cert_path: "/etc/apix/grpc-server.pem"
    grpc_key_path: "/etc/apix/grpc-server-key.pem"
-   # Prefer APIX_AUTH_TOKEN env var in production:
-   auth_token: "your-secret-token"
+   # Prefer APIX_AUTH_TOKEN env var in production.
+   # If using auth_token in config, keep file mode at 0600 or stricter.
+   # auth_token: "your-secret-token"
+   # or:
+   # auth_token_file: "/run/secrets/apix-token"
    ```
 
 2. Set token via environment variable (recommended):

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	logging "github.com/mnafshin/apix/internal/logging"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,6 +24,8 @@ type Config struct {
 	GRPCCertPath                     string `yaml:"grpc_cert_path"`
 	GRPCKeyPath                      string `yaml:"grpc_key_path"`
 	AuthToken                        string `yaml:"auth_token"`
+	AuthTokenFile                    string `yaml:"auth_token_file"`
+	AuthTokenRequireStrictPerms      bool   `yaml:"auth_token_require_strict_perms"`
 	MaxIdleConnsPerHost              int    `yaml:"max_idle_conns_per_host"`
 	IdleConnTimeoutSec               int    `yaml:"idle_conn_timeout_sec"`
 	DialTimeoutSec                   int    `yaml:"dial_timeout_sec"`
@@ -100,6 +103,12 @@ type Config struct {
 	URLPatterns []string `yaml:"url_patterns"`
 	// MapLocalRules serves local files for matching request URLs.
 	MapLocalRules []MapLocalRule `yaml:"map_local_rules"`
+
+	// Internal metadata populated during LoadConfig for security validation.
+	configPath               string
+	configPermsTooOpen       bool
+	configFileMode           os.FileMode
+	authTokenSetInConfigFile bool
 }
 
 // MapLocalRule maps a URL regex pattern to a local file response.
@@ -163,6 +172,7 @@ func LoadConfig(path string) *Config {
 		CACertPath:                       filepath.Join(home, ".apix", "ca.pem"),
 		CAKeyPath:                        filepath.Join(home, ".apix", "ca-key.pem"),
 		TLSEnabled:                       false,
+		AuthTokenRequireStrictPerms:      true,
 		MaxIdleConnsPerHost:              10,
 		IdleConnTimeoutSec:               90,
 		DialTimeoutSec:                   10,
@@ -223,6 +233,25 @@ func LoadConfig(path string) *Config {
 	}
 
 	tokenFromFile := cfg.AuthToken != ""
+	cfg.authTokenSetInConfigFile = tokenFromFile
+	cfg.configPath = path
+	if info, statErr := os.Stat(path); statErr == nil {
+		cfg.configFileMode = info.Mode().Perm()
+		if cfg.configFileMode&0o077 != 0 {
+			cfg.configPermsTooOpen = true
+			logging.Warnf(context.Background(), "config file %s has overly permissive mode %04o; expected 0600 or stricter", path, cfg.configFileMode)
+		}
+	}
+
+	if strings.TrimSpace(cfg.AuthTokenFile) != "" {
+		// #nosec G304 -- auth_token_file is an explicit operator-configured path.
+		b, readErr := os.ReadFile(cfg.AuthTokenFile)
+		if readErr != nil {
+			logging.Errorf(context.Background(), "Failed to read auth_token_file %s: %v", cfg.AuthTokenFile, readErr)
+		} else {
+			cfg.AuthToken = strings.TrimSpace(string(b))
+		}
+	}
 
 	// APIX_AUTH_TOKEN env var takes precedence over the config file value.
 	if envToken := os.Getenv("APIX_AUTH_TOKEN"); envToken != "" {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -5,6 +5,8 @@ tls_enabled: false
 # grpc_cert_path: "/etc/apix/grpc-server.pem"      # required when tls_enabled is true
 # grpc_key_path: "/etc/apix/grpc-server-key.pem"   # required when tls_enabled is true
 # auth_token: "replace-me"                         # prefer APIX_AUTH_TOKEN env var
+# auth_token_file: "/run/secrets/apix-token"       # optional; loaded when set (env still takes precedence)
+auth_token_require_strict_perms: true             # fail validation if auth_token is in config and file perms are wider than 0600
 
 mcp_enabled: false
 mcp_port: "9093"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -63,6 +64,9 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.AuthToken != "" {
 		t.Errorf("AuthToken: expected empty by default, got %q", cfg.AuthToken)
 	}
+	if !cfg.AuthTokenRequireStrictPerms {
+		t.Error("AuthTokenRequireStrictPerms: expected true by default")
+	}
 	if cfg.MCPEnabled {
 		t.Error("MCPEnabled: expected false by default")
 	}
@@ -111,6 +115,7 @@ http_port: "9999"
 grpc_port: "8888"
 max_body_size_mb: 64
 dial_timeout_sec: 5
+auth_token_require_strict_perms: false
 proxy_rate_limit_per_sec: 300
 proxy_max_concurrent_connections: 50
 max_headers_per_request: 150
@@ -145,6 +150,9 @@ audit_log_path: "/tmp/apix-audit.log"
 	}
 	if cfg.DialTimeoutSec != 5 {
 		t.Errorf("DialTimeoutSec: got %d want 5", cfg.DialTimeoutSec)
+	}
+	if cfg.AuthTokenRequireStrictPerms {
+		t.Error("AuthTokenRequireStrictPerms should be false from YAML override")
 	}
 	if cfg.ProxyRateLimitPerSec != 300 {
 		t.Errorf("ProxyRateLimitPerSec: got %d want 300", cfg.ProxyRateLimitPerSec)
@@ -279,6 +287,36 @@ func TestLoadConfig_GRPCBindAddress_ExplicitValueKept(t *testing.T) {
 
 	if cfg.GRPCBindAddress != "192.168.1.10" {
 		t.Errorf("GRPCBindAddress: explicit value not preserved, got %q", cfg.GRPCBindAddress)
+	}
+}
+
+func TestLoadConfig_AuthTokenFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token.txt")
+	if err := os.WriteFile(tokenPath, []byte("file-token\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	path := writeTemp(t, "auth_token_file: "+tokenPath+"\n")
+	cfg := LoadConfig(path)
+	if cfg.AuthToken != "file-token" {
+		t.Fatalf("expected auth token from file, got %q", cfg.AuthToken)
+	}
+}
+
+func TestLoadConfig_AuthTokenStrictPermsValidation(t *testing.T) {
+	t.Parallel()
+	path := writeTemp(t, "auth_token: insecure\n")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod config: %v", err)
+	}
+	cfg := LoadConfig(path)
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for permissive config file mode")
+	}
+	if !strings.Contains(err.Error(), "file mode") {
+		t.Fatalf("expected file mode validation error, got: %v", err)
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -156,6 +156,14 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	}
 
 	// ── TLS / auth ─────────────────────────────────────────────────────────
+	if strings.TrimSpace(c.AuthTokenFile) != "" {
+		if _, err := os.Stat(c.AuthTokenFile); os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("auth_token_file %q does not exist", c.AuthTokenFile))
+		}
+	}
+	if c.AuthTokenRequireStrictPerms && c.authTokenSetInConfigFile && c.configPermsTooOpen {
+		errs = append(errs, fmt.Errorf("auth_token is set in %s but file mode is %04o (must be 0600 or stricter)", c.configPath, c.configFileMode))
+	}
 	if c.TLSEnabled && c.AuthToken == "" {
 		errs = append(errs, fmt.Errorf("tls_enabled is true but auth_token is empty — set APIX_AUTH_TOKEN or auth_token in config for secure operation"))
 	}


### PR DESCRIPTION
Summary:\n- add auth_token_file support for secret mounts\n- enforce strict config file permission checks when plaintext auth_token is present\n- keep APIX_AUTH_TOKEN env var as highest-priority token source\n- document strict-permission behavior and secret-file usage in README and deployment docs\n\nCloses #290