### PR TITLE
refactor: deduplicate maxBodyBytes calc (closes #321)

### DIFF
--- a/internal/proxy/body_limits.go
+++ b/internal/proxy/body_limits.go
@@ -1,0 +1,7 @@
+package proxy
+
+import "github.com/mnafshin/apix/internal/config"
+
+func maxBodyBytes(cfg *config.Config) int64 {
+	return int64(cfg.MaxBodySizeMB) * 1024 * 1024
+}

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -183,7 +183,7 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	start := time.Now()
-	maxBodyBytes := int64(p.cfg.MaxBodySizeMB) * 1024 * 1024
+	maxBodyBytes := maxBodyBytes(p.cfg)
 
 	// 1. Buffer request body.
 	bodyBytes, err := p.readRequestBody(r, maxBodyBytes)

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -173,7 +173,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 
 	// Buffer the entire request body so it can be stored and forwarded.
 	// Limit body size to prevent OOM denial of service.
-	maxBodyBytes := int64(p.cfg.MaxBodySizeMB) * 1024 * 1024
+	maxBodyBytes := maxBodyBytes(p.cfg)
 	var bodyBytes []byte
 	if r.Body != nil {
 		var err error
@@ -380,7 +380,7 @@ func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter
 	metrics.IncActive()
 	defer metrics.DecActive()
 
-	maxBodyBytes := int64(p.cfg.MaxBodySizeMB) * 1024 * 1024
+	maxBodyBytes := maxBodyBytes(p.cfg)
 	var bodyBytes []byte
 	if r.Body != nil {
 		var err error


### PR DESCRIPTION
Summary:\n- add shared proxy helper for maxBodyBytes from config\n- replace duplicated body-size math in HTTP and HTTPS handlers\n\nCloses #321