### PR TITLE
refactor: centralize proxy panic recovery (closes #318)

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -95,10 +95,9 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer p.limiter.release(clientIP)
 	defer func() {
-		if rec := recover(); rec != nil {
-			logging.Errorf(ctx, "HTTP proxy panic in ServeHTTP (recovered): %v", rec)
+		recoverProxyPanic(ctx, "HTTP proxy panic in ServeHTTP", func() {
 			http.Error(w, "proxy error", http.StatusBadGateway)
-		}
+		})
 	}()
 
 	if r.Method == http.MethodConnect {
@@ -112,10 +111,9 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (p *HTTPProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	defer func() {
-		if rec := recover(); rec != nil {
-			logging.Errorf(ctx, "HTTP proxy panic in handleConnect (recovered): %v", rec)
+		recoverProxyPanic(ctx, "HTTP proxy panic in handleConnect", func() {
 			http.Error(w, "proxy error", http.StatusInternalServerError)
-		}
+		})
 	}()
 
 	hj, ok := w.(http.Hijacker)
@@ -176,10 +174,9 @@ func (p *HTTPProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
 	defer metrics.DecActive()
 
 	defer func() {
-		if rec := recover(); rec != nil {
-			logging.Errorf(ctx, "HTTP proxy panic (recovered): %v", rec)
+		recoverProxyPanic(ctx, "HTTP proxy panic", func() {
 			http.Error(w, "proxy error", http.StatusBadGateway)
-		}
+		})
 	}()
 
 	start := time.Now()

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -148,10 +148,9 @@ func (c *bufferedConn) Read(p []byte) (int, error) {
 
 func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.Reader, r *http.Request, host string, protocol string) {
 	defer func() {
-		if rec := recover(); rec != nil {
-			logging.Errorf(ctx, "TLS proxy panic (recovered): %v", rec)
+		recoverProxyPanic(ctx, "TLS proxy panic", func() {
 			writeHTTPError(ctx, conn, http.StatusBadGateway, "proxy error")
-		}
+		})
 	}()
 
 	reqID := uuid.NewString()
@@ -352,10 +351,9 @@ func (p *TLSProxy) handleHTTP2Conn(ctx context.Context, conn net.Conn, br *bufio
 
 func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter, r *http.Request, host string) {
 	defer func() {
-		if rec := recover(); rec != nil {
-			logging.Errorf(ctx, "TLS proxy HTTP/2 panic (recovered): %v", rec)
+		recoverProxyPanic(ctx, "TLS proxy HTTP/2 panic", func() {
 			http.Error(w, "proxy error", http.StatusBadGateway)
-		}
+		})
 	}()
 
 	reqID := uuid.NewString()

--- a/internal/proxy/panic_recovery.go
+++ b/internal/proxy/panic_recovery.go
@@ -1,0 +1,16 @@
+package proxy
+
+import (
+	"context"
+
+	logging "github.com/mnafshin/apix/internal/logging"
+)
+
+func recoverProxyPanic(ctx context.Context, logTag string, onPanic func()) {
+	if rec := recover(); rec != nil {
+		logging.Errorf(ctx, "%s (recovered): %v", logTag, rec)
+		if onPanic != nil {
+			onPanic()
+		}
+	}
+}

--- a/internal/proxy/plugin_runner.go
+++ b/internal/proxy/plugin_runner.go
@@ -21,10 +21,9 @@ func runPluginRequest(ctx context.Context, chain any, req *plugins.ProxyRequest,
 	var runErr error
 	func() {
 		defer func() {
-			if rec := recover(); rec != nil {
-				logging.Errorf(ctx, "%s: panic in plugin OnRequest (recovered): %v", logTag, rec)
+			recoverProxyPanic(ctx, fmt.Sprintf("%s: panic in plugin OnRequest", logTag), func() {
 				runErr = fmt.Errorf("plugin panic")
-			}
+			})
 		}()
 		modified, err := rp.RunRequest(ctx, req)
 		if err != nil {
@@ -52,10 +51,9 @@ func runPluginResponse(ctx context.Context, chain any, req *plugins.ProxyRequest
 	var runErr error
 	func() {
 		defer func() {
-			if rec := recover(); rec != nil {
-				logging.Errorf(ctx, "%s: panic in plugin OnResponse (recovered): %v", logTag, rec)
+			recoverProxyPanic(ctx, fmt.Sprintf("%s: panic in plugin OnResponse", logTag), func() {
 				runErr = fmt.Errorf("plugin panic")
-			}
+			})
 		}()
 		modResp, err := rp.RunResponse(ctx, req, resp)
 		if err != nil {


### PR DESCRIPTION
Summary:\n- add shared recoverProxyPanic helper in proxy package\n- replace duplicated recover/log blocks in HTTP and TLS handlers\n- reuse helper in plugin runner request/response hook wrappers\n\nCloses #318