### PR TITLE
refactor: extract shared store+observe helper (closes #323)

### DIFF
--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -596,24 +596,7 @@ func (p *HTTPProxy) storeAndWriteResponse(ctx context.Context, w http.ResponseWr
 		http.Error(w, "proxy transaction incomplete", http.StatusBadGateway)
 		return
 	}
-	if p.engine != nil {
-		tx.DurationMs = time.Since(start).Milliseconds()
-		if err := p.engine.StoreTransaction(tx); err != nil {
-			logging.Errorf(ctx, "store transaction: %v", err)
-		}
-	}
-	observeRequest(
-		ctx,
-		p.cfg,
-		tx.Request.Method,
-		tx.Request.URL.String(),
-		tx.Response.StatusCode,
-		time.Since(start),
-		tx.ID,
-		tx.Request.Raw.RemoteAddr,
-		len(tx.RequestBody),
-		len(tx.ResponseBody),
-	)
+	storeAndObserve(ctx, p.cfg, p.engine, tx, start, "store transaction")
 	writeProxyResponse(w, tx.Response, tx.ResponseBody)
 }
 

--- a/internal/proxy/https.go
+++ b/internal/proxy/https.go
@@ -312,28 +312,7 @@ func (p *TLSProxy) handleRequest(ctx context.Context, conn net.Conn, br *bufio.R
 		}
 	}
 
-	// Store transaction.
-	if p.engine != nil {
-		tx.DurationMs = time.Since(start).Milliseconds()
-		if err := p.engine.StoreTransaction(tx); err != nil {
-			logging.Errorf(ctx, "tls proxy: store transaction: %v", err)
-		}
-	}
-
-	// Observe metrics + slowlog.
-	dur := time.Since(start)
-	observeRequest(
-		ctx,
-		p.cfg,
-		proxyReq.Method,
-		proxyReq.URL.String(),
-		tx.Response.StatusCode,
-		dur,
-		tx.ID,
-		proxyReq.Raw.RemoteAddr,
-		len(tx.RequestBody),
-		len(tx.ResponseBody),
-	)
+	storeAndObserve(ctx, p.cfg, p.engine, tx, start, "tls proxy: store transaction")
 	_ = reqID
 
 	writeProxyResponseToConn(ctx, conn, tx.Response)
@@ -517,24 +496,7 @@ func (p *TLSProxy) handleHTTP2Request(ctx context.Context, w http.ResponseWriter
 		}
 	}
 
-	if p.engine != nil {
-		tx.DurationMs = time.Since(start).Milliseconds()
-		if err := p.engine.StoreTransaction(tx); err != nil {
-			logging.Errorf(ctx, "tls proxy h2: store transaction: %v", err)
-		}
-	}
-	observeRequest(
-		ctx,
-		p.cfg,
-		proxyReq.Method,
-		proxyReq.URL.String(),
-		tx.Response.StatusCode,
-		time.Since(start),
-		tx.ID,
-		proxyReq.Raw.RemoteAddr,
-		len(tx.RequestBody),
-		len(tx.ResponseBody),
-	)
+	storeAndObserve(ctx, p.cfg, p.engine, tx, start, "tls proxy h2: store transaction")
 	writeProxyResponse(w, tx.Response, tx.ResponseBody)
 }
 

--- a/internal/proxy/transaction_finalize.go
+++ b/internal/proxy/transaction_finalize.go
@@ -1,0 +1,35 @@
+package proxy
+
+import (
+	"context"
+	"time"
+
+	"github.com/mnafshin/apix/internal/config"
+	logging "github.com/mnafshin/apix/internal/logging"
+)
+
+func storeAndObserve(ctx context.Context, cfg *config.Config, engine TrafficEngine, tx *Transaction, start time.Time, storeLogTag string) {
+	if tx == nil || tx.Request == nil || tx.Response == nil {
+		return
+	}
+
+	if engine != nil {
+		tx.DurationMs = time.Since(start).Milliseconds()
+		if err := engine.StoreTransaction(tx); err != nil {
+			logging.Errorf(ctx, "%s: %v", storeLogTag, err)
+		}
+	}
+
+	observeRequest(
+		ctx,
+		cfg,
+		tx.Request.Method,
+		tx.Request.URL.String(),
+		tx.Response.StatusCode,
+		time.Since(start),
+		tx.ID,
+		tx.Request.Raw.RemoteAddr,
+		len(tx.RequestBody),
+		len(tx.ResponseBody),
+	)
+}


### PR DESCRIPTION
Summary:\n- add shared storeAndObserve helper for transaction finalization\n- replace duplicated store/observe blocks in HTTP and TLS handlers\n\nCloses #323