### PR TITLE
refactor: align plugin interface with optional hooks (closes #326)

### DIFF
--- a/pkg/plugins/sdk.go
+++ b/pkg/plugins/sdk.go
@@ -38,8 +38,6 @@ type Plugin interface {
 	Version() string
 	// Description returns a short human-readable description.
 	Description() string
-	RequestPlugin
-	ResponsePlugin
 }
 
 // ProxyRequest is the richer internal request type passed through the plugin chain.


### PR DESCRIPTION
Summary:\n- remove RequestPlugin/ResponsePlugin embedding from plugins.Plugin\n- preserve optional hook execution via existing runtime type assertions\n\nCloses #326