### PR TITLE
docs/release: add changelog, upgrade guide, and compatibility matrix (closes #444)

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -12,31 +12,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install buf
-        uses: bufbuild/buf-action@v1
+      - uses: actions/setup-go@v5
         with:
-          version: '1.35.0'
-          setup_only: true
+          go-version: '1.25'
+      - name: Install buf
+        run: go install github.com/bufbuild/buf/cmd/buf@v1.35.0
       - name: Run buf lint
         run: |
-          buf lint --path pkg/api/proto
+          "$(go env GOPATH)/bin/buf" lint --path pkg/api/proto
 
   buf-breaking:
     runs-on: ubuntu-latest
     needs: buf-lint
     steps:
       - uses: actions/checkout@v4
-      - name: Install buf
-        uses: bufbuild/buf-action@v1
+      - uses: actions/setup-go@v5
         with:
-          version: '1.35.0'
-          setup_only: true
+          go-version: '1.25'
+      - name: Install buf
+        run: go install github.com/bufbuild/buf/cmd/buf@v1.35.0
       - name: Run buf breaking check
         run: |
           # Compare against main branch for breaking changes
           git fetch origin main:refs/remotes/origin/main || true
           if git rev-parse --verify origin/main >/dev/null 2>&1; then
-            buf breaking --against=ref://origin/main --path pkg/api/proto || true
+            "$(go env GOPATH)/bin/buf" breaking --against=ref://origin/main --path pkg/api/proto || true
           else
             echo "No origin/main to compare against; skipping breaking check"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,11 +91,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-binaries, build-extension, smoke]
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/
           merge-multiple: true
+      - name: Generate curated release notes
+        run: scripts/release/generate_release_notes.sh "${{ github.ref_name }}" release-notes.md
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
-          generate_release_notes: true
+          body_path: release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to APiX are documented in this file.
+
+The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Docs contract snapshots for CLI help, config keys, and proto RPC surface.
+- CI enforcement that user-facing docs contracts stay in sync with code changes.
+
+## [v2.1.0] - 2026-04-20
+
+### Added
+- Proxy request hardening for URL/header bounds and gRPC header-list size limits.
+- Proxy-layer rate limiting and concurrent-connection controls.
+- Structured audit logging for state-changing gRPC operations.
+- Secure auth token loading with `auth_token_file` and strict config permission checks.
+- VS Code extension token handling via `SecretStorage`.
+
+### Changed
+- Expanded architecture and deployment documentation.
+- Improved traffic refresh behavior in the VS Code extension.
+
+## [v2.0.0] - 2026-04-18
+
+### Added
+- Foundation release with HTTP/HTTPS interception, breakpoints, replay, storage, CLI, and VS Code integration.
+

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,52 @@
+# Upgrade Guide
+
+This guide covers safe upgrades for APiX engine, CLI, and VS Code extension.
+
+## Supported upgrade path
+
+- **Recommended:** upgrade within the same minor line first (for example `2.0.x -> 2.1.x`).
+- Upgrade engine + CLI together for predictable behavior.
+- Update the VS Code extension after the engine upgrade.
+
+Check version compatibility in [`docs/REFERENCE/compatibility-matrix.md`](docs/REFERENCE/compatibility-matrix.md).
+
+## Pre-upgrade checklist
+
+1. Back up your config (`~/.apix/config.yaml` or deployment-managed equivalent).
+2. Back up your storage DB if you keep long-lived history.
+3. Confirm whether you use plaintext `auth_token`; prefer `APIX_AUTH_TOKEN` or `auth_token_file`.
+4. Read the release section in [`CHANGELOG.md`](CHANGELOG.md) for your target version.
+
+## Upgrade steps
+
+1. Install new engine and CLI binaries.
+2. Update the VS Code extension to the matching release line.
+3. Run config validation:
+   ```bash
+   ./apix-engine --config-check
+   ```
+4. Start the engine and verify:
+   ```bash
+   ./apix-engine
+   ./apix-cli status
+   ./apix-cli doctor
+   ```
+
+## v2.0.x -> v2.1.x notes
+
+- If you currently store `auth_token` in config, APiX now enforces strict file permissions by default.
+- You can migrate secrets to `auth_token_file` for cleaner secret management in deployments.
+- New proxy safety knobs are available:
+  - `proxy_rate_limit_per_sec`
+  - `proxy_max_concurrent_connections`
+  - request/header bound controls
+
+## Rollback
+
+1. Stop the upgraded engine.
+2. Reinstall previous engine/CLI binaries.
+3. Restore previous config if it was changed.
+4. Start old version and run `./apix-cli status`.
+
+If rollback is required because of compatibility, keep your previous version pinned and open an issue with the failing workflow and versions.
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,8 @@ Welcome to APiX documentation. Start here to find what you're looking for.
 - [`CONFIG_VALIDATION.md`](CONFIG_VALIDATION.md) — configuration schema and validation
 - [`getting-started.md`](getting-started.md) — first steps with APiX
 - [`FEATURES.md`](FEATURES.md) — complete feature reference (v2.0.0)
+- [`../CHANGELOG.md`](../CHANGELOG.md) — release-by-release change history
+- [`../UPGRADE.md`](../UPGRADE.md) — upgrade and rollback guidance
 
 **For developers & contributors:**
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — how to contribute code and issues
@@ -60,9 +62,11 @@ Stable contracts and schemas:
 
 - [`REFERENCE/cli-contract-v1.md`](REFERENCE/cli-contract-v1.md) — CLI flags, output formats, exit codes
 - [`REFERENCE/cli_mcp.md`](REFERENCE/cli_mcp.md) — MCP server integration and tools
+- [`REFERENCE/compatibility-matrix.md`](REFERENCE/compatibility-matrix.md) — engine/CLI/extension/API compatibility
 - [`REFERENCE/glossary.md`](REFERENCE/glossary.md) — terminology and concepts
 - [`REFERENCE/OTEL.md`](REFERENCE/OTEL.md) — OpenTelemetry and Prometheus metrics
 - [`REFERENCE/plugin-sdk.md`](REFERENCE/plugin-sdk.md) — plugin interfaces and lifecycle
+- [`REFERENCE/stability-policy.md`](REFERENCE/stability-policy.md) — stable/experimental/deprecated policy
 
 ---
 

--- a/docs/REFERENCE/compatibility-matrix.md
+++ b/docs/REFERENCE/compatibility-matrix.md
@@ -22,4 +22,3 @@ Use the CLI:
 ```
 
 For API contract values, call `GetVersion` via gRPC tooling or client code.
-

--- a/docs/REFERENCE/compatibility-matrix.md
+++ b/docs/REFERENCE/compatibility-matrix.md
@@ -1,0 +1,25 @@
+# Compatibility Matrix
+
+Use this matrix to match engine, CLI, extension, and API contract versions.
+
+| Engine line | CLI line | VS Code extension line | gRPC API version (`GetVersion.api_version`) | Minimum client version (`GetVersion.min_client_version`) |
+|---|---|---|---|---|
+| 2.1.x | 2.1.x | 2.1.x | 1.0.0 | 1.0.0 |
+| 2.0.x | 2.0.x | 2.0.x | 1.0.0 | 1.0.0 |
+
+## Rules
+
+1. Keep engine and CLI on the same minor line.
+2. Extension should match the engine minor line.
+3. Clients older than `min_client_version` are unsupported.
+
+## How to check runtime versions
+
+Use the CLI:
+
+```bash
+./apix-cli status
+```
+
+For API contract values, call `GetVersion` via gRPC tooling or client code.
+

--- a/docs/REFERENCE/stability-policy.md
+++ b/docs/REFERENCE/stability-policy.md
@@ -24,4 +24,3 @@ APiX uses explicit stability labels for user-facing surfaces.
 1. Add explicit deprecation note in docs and release notes.
 2. Keep behavior available for at least one minor release when practical.
 3. Provide migration steps in [`UPGRADE.md`](../../UPGRADE.md).
-

--- a/docs/REFERENCE/stability-policy.md
+++ b/docs/REFERENCE/stability-policy.md
@@ -1,0 +1,27 @@
+# Feature Stability Policy
+
+APiX uses explicit stability labels for user-facing surfaces.
+
+## Labels
+
+| Label | Meaning | Upgrade expectation |
+|---|---|---|
+| `stable` | Supported behavior with compatibility intent across patch/minor upgrades. | No breaking changes without clear migration guidance. |
+| `experimental` | Available for feedback; behavior may change quickly. | Breaking changes may happen between minor releases. |
+| `deprecated` | Supported temporarily but scheduled for removal. | Migrate before the documented removal release. |
+
+## Current defaults
+
+| Surface | Stability |
+|---|---|
+| Engine and proxy core workflow | `stable` |
+| gRPC API (`pkg/api/proto/apix.proto`, API v1.0.0) | `stable` |
+| CLI contract v1 (`docs/REFERENCE/cli-contract-v1.md`) | `stable` |
+| MCP side-effect tools (`mcp_allow_replay`, `mcp_allow_compose`) | `experimental` |
+
+## Deprecation process
+
+1. Add explicit deprecation note in docs and release notes.
+2. Keep behavior available for at least one minor release when practical.
+3. Provide migration steps in [`UPGRADE.md`](../../UPGRADE.md).
+

--- a/scripts/release/generate_release_notes.sh
+++ b/scripts/release/generate_release_notes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TAG="${1:-${GITHUB_REF_NAME:-}}"
+OUT="${2:-$ROOT_DIR/release-notes.md}"
+
+if [[ -z "$TAG" ]]; then
+  echo "usage: $0 <tag> [output-file]" >&2
+  exit 1
+fi
+
+{
+  echo "## APiX ${TAG}"
+  echo
+  echo "### Upgrade and compatibility"
+  echo "- [Changelog](CHANGELOG.md)"
+  echo "- [Upgrade Guide](UPGRADE.md)"
+  echo "- [Compatibility Matrix](docs/REFERENCE/compatibility-matrix.md)"
+  echo "- [Stability Policy](docs/REFERENCE/stability-policy.md)"
+  echo
+  echo "### Changelog section"
+  if ! awk -v tag="$TAG" '
+    $0 ~ "^## \\[" tag "\\]" {print; found=1; next}
+    found && /^## \[/ {exit}
+    found {print}
+    END { if (!found) exit 1 }
+  ' "$ROOT_DIR/CHANGELOG.md"; then
+    echo "- No dedicated changelog section found for ${TAG}. See [CHANGELOG.md](CHANGELOG.md)."
+  fi
+} >"$OUT"


### PR DESCRIPTION
Summary:\n- add CHANGELOG.md and UPGRADE.md at repo root\n- add compatibility matrix and feature stability policy docs\n- index the new release docs from docs/INDEX.md\n- generate curated GitHub release notes from changelog/upgrade/compatibility docs\n\nCloses #444