### PR TITLE
product: unify APiX command identity around apix (closes #443)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
-        run: go build -o apix-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/apix-cli/
+        run: |
+          go build -o apix-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/apix-cli/
+          go build -o apix-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/apix-cli/
       - uses: actions/upload-artifact@v4
         with:
           name: engine-${{ matrix.goos }}-${{ matrix.goarch }}
@@ -49,7 +51,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: apix-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+          path: |
+            apix-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+            apix-cli-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
   build-extension:
     name: Package VS Code Extension

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 # Default Go binary output
 ENGINE_BIN := apix-engine
-CLI_BIN := apix-cli
+CLI_BIN := apix
+CLI_LEGACY_BIN := apix-cli
 
 # Go build
 build:
@@ -11,6 +12,7 @@ build:
 # CLI build
 build-cli:
 	go build -o $(CLI_BIN) ./cmd/apix-cli/
+	cp $(CLI_BIN) $(CLI_LEGACY_BIN)
 
 # Go tests
 test:
@@ -51,21 +53,26 @@ ext-install:
 
 # Clean build artifacts
 clean:
-	rm -f $(ENGINE_BIN) $(CLI_BIN) coverage.out
+	rm -f $(ENGINE_BIN) $(CLI_BIN) $(CLI_LEGACY_BIN) coverage.out
 	rm -rf apix-vscode/out apix-vscode/*.vsix
 
 # Cross-compile engine for all platforms
 build-all:
 	mkdir -p dist
 	GOOS=darwin GOARCH=arm64 go build -o dist/apix-engine-darwin-arm64 ./cmd/apix-engine/
+	GOOS=darwin GOARCH=arm64 go build -o dist/apix-darwin-arm64 ./cmd/apix-cli/
 	GOOS=darwin GOARCH=arm64 go build -o dist/apix-cli-darwin-arm64 ./cmd/apix-cli/
 	GOOS=darwin GOARCH=amd64 go build -o dist/apix-engine-darwin-amd64 ./cmd/apix-engine/
+	GOOS=darwin GOARCH=amd64 go build -o dist/apix-darwin-amd64 ./cmd/apix-cli/
 	GOOS=darwin GOARCH=amd64 go build -o dist/apix-cli-darwin-amd64 ./cmd/apix-cli/
 	GOOS=linux GOARCH=amd64 go build -o dist/apix-engine-linux-amd64 ./cmd/apix-engine/
+	GOOS=linux GOARCH=amd64 go build -o dist/apix-linux-amd64 ./cmd/apix-cli/
 	GOOS=linux GOARCH=amd64 go build -o dist/apix-cli-linux-amd64 ./cmd/apix-cli/
 	GOOS=linux GOARCH=arm64 go build -o dist/apix-engine-linux-arm64 ./cmd/apix-engine/
+	GOOS=linux GOARCH=arm64 go build -o dist/apix-linux-arm64 ./cmd/apix-cli/
 	GOOS=linux GOARCH=arm64 go build -o dist/apix-cli-linux-arm64 ./cmd/apix-cli/
 	GOOS=windows GOARCH=amd64 go build -o dist/apix-engine-windows-amd64.exe ./cmd/apix-engine/
+	GOOS=windows GOARCH=amd64 go build -o dist/apix-windows-amd64.exe ./cmd/apix-cli/
 	GOOS=windows GOARCH=amd64 go build -o dist/apix-cli-windows-amd64.exe ./cmd/apix-cli/
 
 # Dev: build engine + extension together
@@ -77,7 +84,7 @@ smoke:
 help:
 	@echo "Available targets:"
 	@echo "  build          - Build engine binary"
-	@echo "  build-cli      - Build CLI binary"
+	@echo "  build-cli      - Build apix (and apix-cli compatibility alias)"
 	@echo "  test           - Run Go tests"
 	@echo "  test-coverage  - Run Go tests with coverage report"
 	@echo "  test-one       - Run single test (TEST=name PKG=path)"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make build-cli
 In another terminal:
 
 ```bash
-./apix-cli status
+./apix status
 curl -x http://localhost:8080 https://example.com
 ```
 
@@ -65,7 +65,7 @@ Then run the extension from VS Code (`Run Extension`), or package/install from `
 
 ## CLI surface
 
-`apix-cli` currently includes:
+`apix` currently includes:
 
 - `status`, `plugins`
 - `history list|get|clear`
@@ -77,7 +77,9 @@ Then run the extension from VS Code (`Run Extension`), or package/install from `
 - `replay`
 - `cert`, `config`, `doctor`, `completion`
 
-Use `apix-cli help` for details.
+Use `apix help` for details.
+
+> Compatibility note: `apix-cli` remains available as a compatibility alias.
 
 ## Configuration
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,6 +34,8 @@ Check version compatibility in [`docs/REFERENCE/compatibility-matrix.md`](docs/R
 
 ## v2.0.x -> v2.1.x notes
 
+- `apix` is now the canonical command identity for the CLI surface.
+- `apix-cli` remains available as a compatibility alias for existing scripts.
 - If you currently store `auth_token` in config, APiX now enforces strict file permissions by default.
 - You can migrate secrets to `auth_token_file` for cleaner secret management in deployments.
 - New proxy safety knobs are available:
@@ -49,4 +51,3 @@ Check version compatibility in [`docs/REFERENCE/compatibility-matrix.md`](docs/R
 4. Start old version and run `./apix-cli status`.
 
 If rollback is required because of compatibility, keep your previous version pinned and open an issue with the failing workflow and versions.
-

--- a/docs/REFERENCE/cli-contract-v1.md
+++ b/docs/REFERENCE/cli-contract-v1.md
@@ -1,8 +1,10 @@
 # APiX CLI Contract v1
 
-This document defines the **user-facing compatibility contract** for the first contract-first APiX CLI shipped from `cmd/apix-cli`.
+This document defines the **user-facing compatibility contract** for the first contract-first APiX CLI shipped from `cmd/apix-cli`, exposed as the `apix` command.
 
 It is the reference for scripts, CI jobs, and future MCP/agent integrations that depend on stable CLI behavior. Implementation details may evolve internally, but the behavior described here should be treated as the compatibility surface for the v1 CLI.
+
+`apix-cli` remains available as a compatibility alias; new docs and examples use `apix`.
 
 ## Contract scope
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,8 @@
 
    ```sh
    go build -o apix-engine ./cmd/apix-engine/
-   go build -o apix-cli   ./cmd/apix-cli/
+   go build -o apix       ./cmd/apix-cli/
+   cp apix apix-cli
    ```
 
 2. **Start the engine** (HTTP proxy on `:8080`, gRPC on `:9090`):
@@ -20,8 +21,10 @@
    Verify it is running:
 
    ```sh
-   ./apix-cli status
+   ./apix status
    ```
+
+   `apix-cli` is kept as a compatibility alias for existing scripts.
 
 ---
 
@@ -36,7 +39,7 @@ Quick-start:
 curl -x http://localhost:8080 https://httpbin.org/get
 
 # List captured traffic
-./apix-cli history list
+./apix history list
 ```
 
 You should see the captured request and its response in the output.
@@ -51,14 +54,14 @@ Quick-start:
 
 ```sh
 # Add a breakpoint matching any URL containing "httpbin"
-./apix-cli breakpoints add --pattern "httpbin"
+./apix breakpoints add --pattern "httpbin"
 
 # In another terminal, send a matching request
 curl -x http://localhost:8080 https://httpbin.org/get
 
 # Watch the paused request, then forward it
-./apix-cli paused watch         # shows the paused request ID
-./apix-cli paused forward <id>  # forward with original request
+./apix paused watch         # shows the paused request ID
+./apix paused forward <id>  # forward with original request
 ```
 
 ---
@@ -71,10 +74,10 @@ Quick-start:
 
 ```sh
 # List captured requests to find an ID
-./apix-cli history list
+./apix history list
 
 # Replay a specific request
-./apix-cli replay --id <request-id>
+./apix replay --id <request-id>
 ```
 
 ---
@@ -82,7 +85,7 @@ Quick-start:
 ## 4 — Validate your configuration
 
 ```sh
-./apix-cli --config-check
+./apix --config-check
 ```
 
 This runs all config checks (port availability, plugin paths, regex patterns) and exits 0 on success or 1 with a full error list on failure.


### PR DESCRIPTION
Promote apix as the primary user-facing CLI command, keep apix-cli as a compatibility alias, and align docs/build/release artifacts with the migration strategy.

Closes #443

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
