### PR TITLE
security: add SECURITY.md and disclosure workflow (closes #461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ See [`docs/INDEX.md`](docs/INDEX.md) for the complete documentation index.
 - **CLI & MCP:** [`docs/REFERENCE/cli_mcp.md`](docs/REFERENCE/cli_mcp.md)
 - **Testing:** [`docs/TESTING.md`](docs/TESTING.md)
 - **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- **Security policy:** [`SECURITY.md`](SECURITY.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+APiX receives security fixes on the following release lines:
+
+| Version line | Supported |
+|---|---|
+| 2.1.x | ✅ |
+| 2.0.x | ✅ (critical fixes only) |
+| < 2.0.0 | ❌ |
+
+## Reporting a Vulnerability
+
+Please do **not** open public issues for suspected vulnerabilities.
+
+Report privately by emailing: **security@apix.dev**
+
+Include:
+- affected version(s)
+- reproduction steps or proof-of-concept
+- impact assessment
+- any known mitigations
+
+You will receive an acknowledgement within 3 business days.
+
+## Disclosure Workflow
+
+1. Maintainers acknowledge and triage the report.
+2. A fix is prepared privately and validated.
+3. A coordinated release is prepared.
+4. Security advisory and mitigation guidance are published.
+
+We aim to credit reporters unless they prefer to remain anonymous.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,7 @@ Welcome to APiX documentation. Start here to find what you're looking for.
 
 **For developers & contributors:**
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — how to contribute code and issues
+- [`../SECURITY.md`](../SECURITY.md) — vulnerability reporting and supported security-fix versions
 - [Architecture](#architecture-concepts) — system design deep dives
 - [Testing](#testing-strategy) — testing layers and strategies
 - [Reference](#reference) — CLI, gRPC, config, glossary


### PR DESCRIPTION
Summary:
- add SECURITY.md with supported-version policy and private reporting path
- document disclosure workflow and acknowledgement expectations
- link security policy from README and docs index

Closes #461