### PR TITLE
release: define semantic versioning and support policy (closes #459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 All notable changes to APiX are documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
@@ -27,4 +29,3 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 - Foundation release with HTTP/HTTPS interception, breakpoints, replay, storage, CLI, and VS Code integration.
-

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ See [`docs/INDEX.md`](docs/INDEX.md) for the complete documentation index.
 - **Configuration:** [`docs/CONFIG_VALIDATION.md`](docs/CONFIG_VALIDATION.md)
 - **Architecture:** [`docs/ARCHITECTURE/`](docs/ARCHITECTURE/)
 - **CLI & MCP:** [`docs/REFERENCE/cli_mcp.md`](docs/REFERENCE/cli_mcp.md)
+- **Versioning policy:** [`docs/REFERENCE/versioning-policy.md`](docs/REFERENCE/versioning-policy.md)
 - **Testing:** [`docs/TESTING.md`](docs/TESTING.md)
 - **Contributing:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - **Security policy:** [`SECURITY.md`](SECURITY.md)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -67,6 +67,7 @@ Stable contracts and schemas:
 - [`REFERENCE/glossary.md`](REFERENCE/glossary.md) — terminology and concepts
 - [`REFERENCE/OTEL.md`](REFERENCE/OTEL.md) — OpenTelemetry and Prometheus metrics
 - [`REFERENCE/plugin-sdk.md`](REFERENCE/plugin-sdk.md) — plugin interfaces and lifecycle
+- [`REFERENCE/versioning-policy.md`](REFERENCE/versioning-policy.md) — semantic versioning, support window, and deprecation rules
 - [`REFERENCE/stability-policy.md`](REFERENCE/stability-policy.md) — stable/experimental/deprecated policy
 
 ---

--- a/docs/REFERENCE/versioning-policy.md
+++ b/docs/REFERENCE/versioning-policy.md
@@ -1,0 +1,41 @@
+# Versioning and Support Policy
+
+This policy defines semantic versioning, support windows, and deprecation behavior across APiX public surfaces.
+
+## Semantic versioning rules
+
+APiX uses `MAJOR.MINOR.PATCH`.
+
+| Surface | PATCH | MINOR | MAJOR |
+|---|---|---|---|
+| Engine / CLI binaries | bug fixes, non-breaking behavior fixes | additive commands/flags/options | breaking CLI behavior or workflow contract changes |
+| gRPC API (`pkg/api/proto/apix.proto`) | non-breaking server fixes | additive fields/RPCs | breaking field/RPC changes |
+| Config keys | bug fixes to existing key behavior | additive keys | removal or incompatible key behavior changes |
+| VS Code extension | bug fixes | additive UX/features | breaking workflow/contract changes |
+| Storage schema | non-breaking internal migrations | additive schema that preserves reads/writes | incompatible schema requiring manual migration |
+
+## Support window
+
+| Release line | Support level |
+|---|---|
+| Current minor (N) | full fixes (security, bugs, regressions) |
+| Previous minor (N-1) | security + critical fixes |
+| Older than N-1 | unsupported |
+
+Supported versions are also listed in [`SECURITY.md`](../../SECURITY.md).
+
+## Deprecation policy
+
+1. Mark feature/key/command as deprecated in docs and release notes.
+2. Keep deprecated behavior for at least one minor release when practical.
+3. Provide migration steps in [`UPGRADE.md`](../../UPGRADE.md).
+4. Remove only in a planned release with explicit notice.
+
+## Release note labeling
+
+Every release should label user-facing changes as:
+- **Additive**
+- **Breaking**
+- **Deprecated**
+
+These labels are reflected in `CHANGELOG.md` and generated release notes.


### PR DESCRIPTION
Summary:
- add versioning policy for binaries, CLI, proto API, config, extension, and storage schema
- define support window and deprecation lifecycle
- link policy from README and docs index

Closes #459