### PR TITLE
refactor: route API handlers through engine domain methods

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	logging "github.com/mnafshin/apix/internal/logging"
 	"io"
@@ -358,4 +359,132 @@ func (e *Engine) PluginRuntime() PluginRuntime { return e.pluginRT }
 // RewriteRules loads the current list of rewrite rules from storage.
 func (e *Engine) RewriteRules() ([]*proxy.RewriteRuleProto, error) {
 	return e.db.ListRewriteRules()
+}
+
+func (e *Engine) SaveRequest(r *storage.RequestRecord) error {
+	return e.db.SaveRequest(r)
+}
+
+func (e *Engine) SaveResponse(r *storage.ResponseRecord) error {
+	return e.db.SaveResponse(r)
+}
+
+func (e *Engine) SaveRequestTemplate(tpl *storage.RequestTemplateRecord) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.SaveRequestTemplate(tpl)
+}
+
+func (e *Engine) ListRequestTemplates() ([]*storage.RequestTemplateRecord, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, err
+	}
+	return db.ListRequestTemplates()
+}
+
+func (e *Engine) DeleteRequestTemplate(id string) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.DeleteRequestTemplate(id)
+}
+
+func (e *Engine) SaveBreakpoint(id, urlPattern string, methods []string, enabled bool, label, headerName, headerValue, bodyPattern string, statusCodes []int32) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.SaveBreakpoint(id, urlPattern, methods, enabled, label, headerName, headerValue, bodyPattern, statusCodes)
+}
+
+func (e *Engine) DeleteBreakpoint(id string) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.DeleteBreakpoint(id)
+}
+
+func (e *Engine) ListTransactions(limit, offset int, urlFilter, methodFilter string, statusFilter int, bodyFilter string) ([]*storage.RequestRecord, []*storage.ResponseRecord, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, nil, err
+	}
+	return db.ListTransactions(limit, offset, urlFilter, methodFilter, statusFilter, bodyFilter)
+}
+
+func (e *Engine) ExportTransactions(transactionIDs []string) ([]*storage.RequestRecord, []*storage.ResponseRecord, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, nil, err
+	}
+	return db.ExportTransactions(transactionIDs)
+}
+
+func (e *Engine) DeleteAllTransactions() error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.DeleteAllTransactions()
+}
+
+func (e *Engine) AddRewriteRule(rule *apix.RewriteRule) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.AddRewriteRule(rule)
+}
+
+func (e *Engine) UpdateRewriteRule(rule *apix.RewriteRule) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.UpdateRewriteRule(rule)
+}
+
+func (e *Engine) DeleteRewriteRule(id string) error {
+	db, err := e.storageAccess()
+	if err != nil {
+		return err
+	}
+	return db.DeleteRewriteRule(id)
+}
+
+func (e *Engine) GetRewriteRule(id string) (*apix.RewriteRule, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, err
+	}
+	return db.GetRewriteRule(id)
+}
+
+func (e *Engine) ListRewriteRules() ([]*apix.RewriteRule, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, err
+	}
+	return db.ListRewriteRules()
+}
+
+func (e *Engine) ListWebSocketFrames(transactionID string) ([]*storage.WebSocketFrameRecord, error) {
+	db, err := e.storageAccess()
+	if err != nil {
+		return nil, err
+	}
+	return db.ListWebSocketFrames(transactionID)
+}
+
+func (e *Engine) storageAccess() (StorageAccess, error) {
+	db := e.DB()
+	if db == nil {
+		return nil, errors.New("engine storage access is unavailable")
+	}
+	return db, nil
 }

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -26,7 +26,7 @@ type EngineServer struct {
 	apix.UnimplementedEngineServer
 	traffic       TrafficSubscriber
 	breakpointMgr BreakpointManagerServer
-	db            ServerRepository
+	engine        EngineDomain
 	plugins       PluginLister
 	replayEngine  *replay.Engine
 	cfg           *config.Config
@@ -46,7 +46,7 @@ func NewEngineServer(eng *engine.Engine, re *replay.Engine, cfg *config.Config) 
 	return &EngineServer{
 		traffic:       eng,
 		breakpointMgr: eng.BreakpointManager(),
-		db:            eng.DB(),
+		engine:        eng,
 		plugins:       eng.PluginRuntime(),
 		replayEngine:  re,
 		cfg:           cfg,

--- a/internal/server/handlers_breakpoints.go
+++ b/internal/server/handlers_breakpoints.go
@@ -36,7 +36,7 @@ func (s *EngineServer) SetBreakpoint(ctx context.Context, req *apix.BreakpointRu
 		return nil, status.Errorf(codes.InvalidArgument, "invalid breakpoint: %v", err)
 	}
 	// Persist to storage.
-	if err := s.db.SaveBreakpoint(added.ID, added.URLPattern, added.Methods, added.Enabled, added.Label, added.HeaderName, added.HeaderValue, added.BodyPattern, added.StatusCodes); err != nil {
+	if err := s.engine.SaveBreakpoint(added.ID, added.URLPattern, added.Methods, added.Enabled, added.Label, added.HeaderName, added.HeaderValue, added.BodyPattern, added.StatusCodes); err != nil {
 		logging.Errorf(ctx, "grpc: save breakpoint: %v", err)
 	}
 	s.auditLog(ctx, "set_breakpoint", added.ID, map[string]any{
@@ -63,7 +63,7 @@ func (s *EngineServer) DeleteBreakpoint(ctx context.Context, req *apix.Breakpoin
 	if err := s.breakpointMgr.RemoveRule(req.Id); err != nil {
 		return nil, status.Errorf(codes.NotFound, "breakpoint not found: %v", err)
 	}
-	if err := s.db.DeleteBreakpoint(req.Id); err != nil {
+	if err := s.engine.DeleteBreakpoint(req.Id); err != nil {
 		logging.Errorf(ctx, "grpc: delete breakpoint from storage: %v", err)
 	}
 	s.auditLog(ctx, "delete_breakpoint", req.Id, nil)

--- a/internal/server/handlers_replay.go
+++ b/internal/server/handlers_replay.go
@@ -98,7 +98,7 @@ func (s *EngineServer) SaveRequestTemplate(ctx context.Context, req *apix.Reques
 		Body:      req.GetRequest().Body,
 		UpdatedAt: time.Now(),
 	}
-	if err := s.db.SaveRequestTemplate(record); err != nil {
+	if err := s.engine.SaveRequestTemplate(record); err != nil {
 		return nil, status.Errorf(codes.Internal, "save request template: %v", err)
 	}
 	s.auditLog(ctx, "save_request_template", id, map[string]any{
@@ -110,7 +110,7 @@ func (s *EngineServer) SaveRequestTemplate(ctx context.Context, req *apix.Reques
 }
 
 func (s *EngineServer) ListRequestTemplates(_ context.Context, _ *apix.Empty) (*apix.RequestTemplateList, error) {
-	records, err := s.db.ListRequestTemplates()
+	records, err := s.engine.ListRequestTemplates()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "list request templates: %v", err)
 	}
@@ -125,7 +125,7 @@ func (s *EngineServer) DeleteRequestTemplate(ctx context.Context, req *apix.Requ
 	if req.GetId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "id is required")
 	}
-	if err := s.db.DeleteRequestTemplate(req.GetId()); err != nil {
+	if err := s.engine.DeleteRequestTemplate(req.GetId()); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete request template: %v", err)
 	}
 	s.auditLog(ctx, "delete_request_template", req.GetId(), nil)

--- a/internal/server/handlers_rewrite.go
+++ b/internal/server/handlers_rewrite.go
@@ -13,7 +13,7 @@ func (s *EngineServer) AddRewriteRule(ctx context.Context, rule *apix.RewriteRul
 	if rule.Id == "" {
 		rule.Id = uuid.NewString()
 	}
-	if err := s.db.AddRewriteRule(rule); err != nil {
+	if err := s.engine.AddRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "add rewrite rule: %v", err)
 	}
 	s.auditLog(ctx, "add_rewrite_rule", rule.Id, map[string]any{
@@ -29,7 +29,7 @@ func (s *EngineServer) UpdateRewriteRule(ctx context.Context, rule *apix.Rewrite
 	if rule.Id == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	if err := s.db.UpdateRewriteRule(rule); err != nil {
+	if err := s.engine.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "update rewrite rule: %v", err)
 	}
 	s.auditLog(ctx, "update_rewrite_rule", rule.Id, map[string]any{
@@ -45,7 +45,7 @@ func (s *EngineServer) DeleteRewriteRule(ctx context.Context, req *apix.RewriteR
 	if req.RuleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	if err := s.db.DeleteRewriteRule(req.RuleId); err != nil {
+	if err := s.engine.DeleteRewriteRule(req.RuleId); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete rewrite rule: %v", err)
 	}
 	s.auditLog(ctx, "delete_rewrite_rule", req.RuleId, nil)
@@ -53,7 +53,7 @@ func (s *EngineServer) DeleteRewriteRule(ctx context.Context, req *apix.RewriteR
 }
 
 func (s *EngineServer) ListRewriteRules(ctx context.Context, _ *apix.Empty) (*apix.RewriteRuleList, error) {
-	rules, err := s.db.ListRewriteRules()
+	rules, err := s.engine.ListRewriteRules()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "list rewrite rules: %v", err)
 	}
@@ -64,7 +64,7 @@ func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteR
 	if req.RuleId == "" {
 		return nil, status.Error(codes.InvalidArgument, "rule_id is required")
 	}
-	rule, err := s.db.GetRewriteRule(req.RuleId)
+	rule, err := s.engine.GetRewriteRule(req.RuleId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "get rewrite rule: %v", err)
 	}
@@ -72,7 +72,7 @@ func (s *EngineServer) ToggleRewriteRule(ctx context.Context, req *apix.RewriteR
 		return nil, status.Errorf(codes.NotFound, "rule %q not found", req.RuleId)
 	}
 	rule.Enabled = !rule.Enabled
-	if err := s.db.UpdateRewriteRule(rule); err != nil {
+	if err := s.engine.UpdateRewriteRule(rule); err != nil {
 		return nil, status.Errorf(codes.Internal, "toggle rewrite rule: %v", err)
 	}
 	s.auditLog(ctx, "toggle_rewrite_rule", rule.Id, map[string]any{"enabled": rule.Enabled})

--- a/internal/server/handlers_traffic.go
+++ b/internal/server/handlers_traffic.go
@@ -36,7 +36,7 @@ func (s *EngineServer) GetHistory(req *apix.HistoryQuery, stream grpc.ServerStre
 	if limit <= 0 {
 		limit = 100
 	}
-	reqs, resps, err := s.db.ListTransactions(
+	reqs, resps, err := s.engine.ListTransactions(
 		limit, int(req.Offset),
 		req.UrlFilter, req.MethodFilter, int(req.StatusFilter), req.BodyFilter,
 	)
@@ -125,7 +125,7 @@ func (s *EngineServer) GetWebSocketFrames(req *apix.GetWebSocketFramesRequest, s
 		return status.Error(codes.InvalidArgument, "transaction_id is required")
 	}
 
-	frames, err := s.db.ListWebSocketFrames(req.TransactionId)
+	frames, err := s.engine.ListWebSocketFrames(req.TransactionId)
 	if err != nil {
 		return status.Errorf(codes.Internal, "list websocket frames: %v", err)
 	}
@@ -162,7 +162,7 @@ func (s *EngineServer) GetWebSocketFrames(req *apix.GetWebSocketFramesRequest, s
 }
 
 func (s *EngineServer) ClearHistory(ctx context.Context, _ *apix.Empty) (*apix.Empty, error) {
-	if err := s.db.DeleteAllTransactions(); err != nil {
+	if err := s.engine.DeleteAllTransactions(); err != nil {
 		return nil, status.Errorf(codes.Internal, "clear history: %v", err)
 	}
 	s.auditLog(ctx, "clear_history", "", nil)
@@ -170,7 +170,7 @@ func (s *EngineServer) ClearHistory(ctx context.Context, _ *apix.Empty) (*apix.E
 }
 
 func (s *EngineServer) ExportHAR(_ context.Context, req *apix.ExportHARRequest) (*apix.ExportHARResponse, error) {
-	requests, responses, err := s.db.ExportTransactions(req.TransactionIds)
+	requests, responses, err := s.engine.ExportTransactions(req.TransactionIds)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "export HAR: %v", err)
 	}
@@ -195,11 +195,11 @@ func (s *EngineServer) ImportHAR(ctx context.Context, req *apix.ImportHARRequest
 		default:
 		}
 
-		if err := s.db.SaveRequest(tx.Request); err != nil {
+		if err := s.engine.SaveRequest(tx.Request); err != nil {
 			return nil, status.Errorf(codes.Internal, "import HAR request: %v", err)
 		}
 		if tx.Response != nil {
-			if err := s.db.SaveResponse(tx.Response); err != nil {
+			if err := s.engine.SaveResponse(tx.Response); err != nil {
 				return nil, status.Errorf(codes.Internal, "import HAR response: %v", err)
 			}
 		}

--- a/internal/server/interfaces.go
+++ b/internal/server/interfaces.go
@@ -24,9 +24,9 @@ type BreakpointManagerServer interface {
 	Resume(requestID string, decision *breakpoints.ResumeDecision) error
 }
 
-// ServerRepository is the storage interface used by all gRPC handlers.
-// *storage.DB satisfies this interface.
-type ServerRepository interface {
+// EngineDomain is the orchestration interface used by gRPC handlers.
+// *engine.Engine satisfies this interface and delegates to storage internally.
+type EngineDomain interface {
 	SaveRequest(r *storage.RequestRecord) error
 	SaveResponse(r *storage.ResponseRecord) error
 	SaveRequestTemplate(tpl *storage.RequestTemplateRecord) error

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -309,7 +309,7 @@ func (h *mcpHandler) callHistory(args map[string]interface{}) (interface{}, erro
 	sinceMS := int64Arg(args, "since_ms", 0)
 	bodyFilter := stringArg(args, "body_filter")
 
-	reqs, resps, err := h.srv.db.ListTransactions(limit, offset, urlFilter, methodFilter, statusFilter, bodyFilter)
+	reqs, resps, err := h.srv.engine.ListTransactions(limit, offset, urlFilter, methodFilter, statusFilter, bodyFilter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- replace direct storage access in gRPC/MCP handlers with engine domain calls
- make EngineServer depend on an engine orchestration interface instead of raw repository wiring
- add explicit engine domain passthrough methods so handler flow is gRPC handler -> engine -> storage

## Testing
- make lint
- make test

Closes #319