### PR TITLE
feat(cli): add ANSI color support to text output (#346)

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -47,10 +47,10 @@ type app struct {
 	conn   *grpc.ClientConn
 	client apix.EngineClient
 	// Color functions (may be no-op if colors are disabled)
-	errorColor  func(string, ...interface{}) string
-	warnColor   func(string, ...interface{}) string
+	errorColor   func(string, ...interface{}) string
+	warnColor    func(string, ...interface{}) string
 	successColor func(string, ...interface{}) string
-	infoColor   func(string, ...interface{}) string
+	infoColor    func(string, ...interface{}) string
 }
 
 type historyListOptions struct {
@@ -263,7 +263,7 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		errw: errw,
 		cfg:  config.LoadConfig(cfgPath),
 	}
-	
+
 	// Initialize color functions based on noColor flag
 	if opts.noColor {
 		app.errorColor = func(format string, args ...interface{}) string {
@@ -284,7 +284,7 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		app.successColor = color.GreenString
 		app.infoColor = color.BlueString
 	}
-	
+
 	defer app.close()
 
 	// --config-check: validate config then exit without starting anything.
@@ -2102,14 +2102,14 @@ func (a *app) cmdDoctor() error {
 		configMsg = a.errorColor(configValidation)
 	}
 	writef(a.out, "Config validation: %s\n", configMsg)
-	
+
 	certReady := cert["ready"]
 	certMsg := fmt.Sprintf("%v", certReady)
 	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
 		certMsg = a.warnColor(certMsg)
 	}
 	writef(a.out, "Cert ready: %s\n", certMsg)
-	
+
 	if reachable, _ := engine["reachable"].(bool); reachable {
 		status := a.successColor("reachable")
 		writef(a.out, "Engine: %s (%s)\n", status, engine["version"])

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/mnafshin/apix/internal/config"
 	apix "github.com/mnafshin/apix/pkg/api/generated"
 	"google.golang.org/grpc"
@@ -45,6 +46,11 @@ type app struct {
 	cfg    *config.Config
 	conn   *grpc.ClientConn
 	client apix.EngineClient
+	// Color functions (may be no-op if colors are disabled)
+	errorColor  func(string, ...interface{}) string
+	warnColor   func(string, ...interface{}) string
+	successColor func(string, ...interface{}) string
+	infoColor   func(string, ...interface{}) string
 }
 
 type historyListOptions struct {
@@ -257,6 +263,28 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		errw: errw,
 		cfg:  config.LoadConfig(cfgPath),
 	}
+	
+	// Initialize color functions based on noColor flag
+	if opts.noColor {
+		app.errorColor = func(format string, args ...interface{}) string {
+			return fmt.Sprintf(format, args...)
+		}
+		app.warnColor = func(format string, args ...interface{}) string {
+			return fmt.Sprintf(format, args...)
+		}
+		app.successColor = func(format string, args ...interface{}) string {
+			return fmt.Sprintf(format, args...)
+		}
+		app.infoColor = func(format string, args ...interface{}) string {
+			return fmt.Sprintf(format, args...)
+		}
+	} else {
+		app.errorColor = color.RedString
+		app.warnColor = color.YellowString
+		app.successColor = color.GreenString
+		app.infoColor = color.BlueString
+	}
+	
 	defer app.close()
 
 	// --config-check: validate config then exit without starting anything.
@@ -324,7 +352,12 @@ func (a *app) wrapErr(err error) int {
 	if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
 		displayErr = fmt.Errorf("APiX engine is not running.\n  Start it with: apix-engine\n  Or check: apix-cli status")
 	}
-	writeLine(a.errw, displayErr)
+	if a.opts.output == "text" {
+		errMsg := a.errorColor("error: %v", displayErr)
+		writeLine(a.errw, errMsg)
+	} else {
+		writeLine(a.errw, displayErr)
+	}
 	return exitCode
 }
 
@@ -535,8 +568,12 @@ func (a *app) cmdStatus() error {
 			"tls_enabled": resp.TlsEnabled,
 		})
 	}
+	statusLabel := resp.Status
+	if resp.Status == "running" && a.opts.output == "text" {
+		statusLabel = a.successColor(resp.Status)
+	}
 	writef(a.out, "APiX engine: %s\tversion=%s\tproxy=%d\tgrpc=%d\ttls=%t\n",
-		resp.Status, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
+		statusLabel, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
 	return nil
 }
 
@@ -2060,10 +2097,22 @@ func (a *app) cmdDoctor() error {
 	}
 
 	writef(a.out, "Config: %s\n", configPath)
-	writef(a.out, "Config validation: %s\n", configValidation)
-	writef(a.out, "Cert ready: %v\n", cert["ready"])
+	configMsg := configValidation
+	if configValidation != "ok" && a.opts.output == "text" {
+		configMsg = a.errorColor(configValidation)
+	}
+	writef(a.out, "Config validation: %s\n", configMsg)
+	
+	certReady := cert["ready"]
+	certMsg := fmt.Sprintf("%v", certReady)
+	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
+		certMsg = a.warnColor(certMsg)
+	}
+	writef(a.out, "Cert ready: %s\n", certMsg)
+	
 	if reachable, _ := engine["reachable"].(bool); reachable {
-		writef(a.out, "Engine: reachable (%s)\n", engine["version"])
+		status := a.successColor("reachable")
+		writef(a.out, "Engine: %s (%s)\n", status, engine["version"])
 	} else {
 		writef(a.out, "Engine: unreachable (%v)\n", engine["error"])
 	}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/fatih/color v1.19.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -42,6 +43,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
+github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -76,6 +78,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=


### PR DESCRIPTION
**Issue:** #346

Adds colored output for errors, status, and diagnostic messages in the CLI.

**Changes:**
- Import `fatih/color` library for cross-platform ANSI support
- Add color functions to app struct (error, warn, success, info)
- Initialize colors based on `--no-color` flag
- Apply colors to:
  - Error messages (red)
  - Status 'running' indicator (green)
  - Doctor validation success (green)
  - Warnings (yellow)

**Testing:**
- All existing tests pass
- Build succeeds
- No breaking changes

**Related:**
- Addresses UX improvement for CLI usability
- Works alongside existing --no-color flag for compatibility