### PR TITLE
feat(metrics): add request/response size tracking (Fixes #389)

### DIFF
--- a/internal/storage/mapper.go
+++ b/internal/storage/mapper.go
@@ -77,15 +77,16 @@ func scanTransactionRows(rows *sql.Rows) ([]*RequestRecord, []*ResponseRecord, e
 			reqID, method, url, reqHeaders string
 			protocol                       string
 			reqBody                        []byte
-			tsMs, durMs                    int64
+			tsMs, durMs, reqBodySize       int64
 			respReqID                      sql.NullString
 			statusCode                     sql.NullInt64
 			statusText, respHeaders        sql.NullString
 			respBody                       []byte
+			respBodySize                   sql.NullInt64
 		)
 		if err := rows.Scan(
-			&reqID, &method, &url, &reqHeaders, &reqBody, &tsMs, &durMs, &protocol,
-			&respReqID, &statusCode, &statusText, &respHeaders, &respBody,
+			&reqID, &method, &url, &reqHeaders, &reqBody, &tsMs, &durMs, &protocol, &reqBodySize,
+			&respReqID, &statusCode, &statusText, &respHeaders, &respBody, &respBodySize,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan transaction: %w", err)
 		}
@@ -98,6 +99,7 @@ func scanTransactionRows(rows *sql.Rows) ([]*RequestRecord, []*ResponseRecord, e
 			Timestamp:  time.UnixMilli(tsMs),
 			DurationMs: durMs,
 			Protocol:   protocol,
+			BodySize:   reqBodySize,
 		}
 		if err := json.Unmarshal([]byte(reqHeaders), &req.Headers); err != nil {
 			logging.Warnf(logging.WithRequestID(context.Background(), reqID), "failed to unmarshal request headers for request %s: %v", reqID, err)
@@ -116,6 +118,7 @@ func scanTransactionRows(rows *sql.Rows) ([]*RequestRecord, []*ResponseRecord, e
 				StatusCode: int(statusCode.Int64),
 				StatusText: statusText.String,
 				Body:       respBody,
+				BodySize:   respBodySize.Int64,
 			}
 			if respHeaders.Valid {
 				if err := json.Unmarshal([]byte(respHeaders.String), &resp.Headers); err != nil {

--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -24,6 +24,7 @@ type RequestRecord struct {
 	Timestamp  time.Time
 	DurationMs int64
 	Protocol   string // negotiated protocol: "HTTP/1.1", "HTTP/2.0", "h2c"
+	BodySize   int64
 }
 
 // ResponseRecord is the Go representation of a row in the responses table.
@@ -33,6 +34,7 @@ type ResponseRecord struct {
 	StatusText string
 	Headers    map[string]string
 	Body       []byte
+	BodySize   int64
 }
 
 // BreakpointRecord is the Go representation of a row in the breakpoints table.
@@ -197,8 +199,8 @@ func (d *DB) ListTransactions(limit, offset int, urlFilter, methodFilter string,
 
 	query := fmt.Sprintf(`
 		SELECT r.id, r.method, r.url, r.headers, r.body, r.timestamp, r.duration_ms,
-		       COALESCE(r.protocol,'HTTP/1.1'),
-		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body
+		       COALESCE(r.protocol,'HTTP/1.1'), COALESCE(r.body_size,0),
+		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body, COALESCE(resp.body_size,0)
 		FROM requests r
 		LEFT JOIN responses resp ON r.id = resp.request_id
 		%s
@@ -214,8 +216,8 @@ func (d *DB) ListTransactions(limit, offset int, urlFilter, methodFilter string,
 func (d *DB) ExportTransactions(transactionIDs []string) ([]*RequestRecord, []*ResponseRecord, error) {
 	query := `
 		SELECT r.id, r.method, r.url, r.headers, r.body, r.timestamp, r.duration_ms,
-		       COALESCE(r.protocol,'HTTP/1.1'),
-		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body
+		       COALESCE(r.protocol,'HTTP/1.1'), COALESCE(r.body_size,0),
+		       resp.request_id, resp.status_code, resp.status_text, resp.headers, resp.body, COALESCE(resp.body_size,0)
 		FROM requests r
 		LEFT JOIN responses resp ON r.id = resp.request_id`
 	args := make([]interface{}, 0, len(transactionIDs))

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS requests (
     body        BLOB,
     timestamp   INTEGER NOT NULL,           -- Unix milliseconds
     duration_ms INTEGER NOT NULL DEFAULT 0,
-    protocol    TEXT NOT NULL DEFAULT 'HTTP/1.1'  -- negotiated protocol
+    protocol    TEXT NOT NULL DEFAULT 'HTTP/1.1',  -- negotiated protocol
+    body_size   INTEGER NOT NULL DEFAULT 0
 );`
 
 const CreateResponsesTable = `
@@ -23,6 +24,7 @@ CREATE TABLE IF NOT EXISTS responses (
     status_text TEXT NOT NULL DEFAULT '',
     headers     TEXT NOT NULL DEFAULT '{}', -- JSON object
     body        BLOB,
+    body_size   INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (request_id) REFERENCES requests(id) ON DELETE CASCADE
 );`
 


### PR DESCRIPTION
Add body_size fields to track request and response body sizes in the engine and storage layer.

This foundation enables future features like bandwidth metrics, request/response size visualization in the UI, and performance analysis.