### PR TITLE
feat(cli): execute saved templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Intercept, inspect, and modify HTTP/HTTPS traffic with a local MITM proxy, a gRP
 - **gRPC API** (`:9090` by default) for extension/CLI automation
 - **Breakpoints** with conditions (URL, method, headers, body regex, response status)
 - **Replay + compose** requests (`ReplayRequest`, `ComposeRequest`)
-- **Saved request templates** (save/list/delete)
+- **Saved request templates** (save/list/delete/execute)
 - **History storage** in SQLite, plus HAR export/import
 - **WebSocket frame capture** for upgraded sessions
 - **GraphQL metadata extraction** for request/response inspection
@@ -73,7 +73,7 @@ Then run the extension from VS Code (`Run Extension`), or package/install from `
 - `breakpoints list|add|delete|enable|disable`
 - `paused watch|forward|drop|respond`
 - `send`
-- `templates save|list|delete`
+- `templates save|list|delete|execute`
 - `replay`
 - `cert`, `config`, `doctor`, `completion`
 

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -296,7 +296,7 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		writeLine(errw, "  breakpoints list|add|delete|enable|disable")
 		writeLine(errw, "  paused watch|forward|drop|respond")
 		writeLine(errw, "  send")
-		writeLine(errw, "  templates save|list|delete")
+		writeLine(errw, "  templates save|list|delete|execute")
 		writeLine(errw, "  replay")
 		writeLine(errw, "  cert status")
 		writeLine(errw, "  config show|reload")
@@ -1613,7 +1613,7 @@ func (a *app) cmdSend(args []string) error {
 
 func (a *app) cmdTemplates(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("usage: templates save|list|delete")
+		return fmt.Errorf("usage: templates save|list|delete|execute")
 	}
 	client, err := a.clientConn()
 	if err != nil {
@@ -1700,6 +1700,11 @@ func (a *app) cmdTemplates(args []string) error {
 			writef(tw, "%s\t%s\t%s\t%s\n", tpl.Id, tpl.Name, tpl.GetRequest().GetMethod(), tpl.GetRequest().GetUrl())
 		}
 		return tw.Flush()
+	case "execute":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: templates execute <id-or-name>")
+		}
+		return a.cmdTemplatesExecute(client, args[1])
 	case "delete":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: templates delete <id>")
@@ -1716,6 +1721,59 @@ func (a *app) cmdTemplates(args []string) error {
 		return nil
 	default:
 		return fmt.Errorf("unknown templates subcommand: %s", args[0])
+	}
+}
+
+func (a *app) cmdTemplatesExecute(client apix.EngineClient, identifier string) error {
+	tpl, err := a.lookupRequestTemplate(client, identifier)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := a.unaryContext()
+	defer cancel()
+	resp, err := client.ComposeRequest(ctx, &apix.ComposeSpec{
+		Request:         tpl.GetRequest(),
+		FollowRedirects: true,
+	})
+	if err != nil {
+		return err
+	}
+	return a.renderResponse(resp)
+}
+
+func (a *app) lookupRequestTemplate(client apix.EngineClient, identifier string) (*apix.RequestTemplate, error) {
+	ctx, cancel := a.unaryContext()
+	defer cancel()
+	resp, err := client.ListRequestTemplates(ctx, &apix.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	if identifier == "" {
+		return nil, fmt.Errorf("template identifier is required")
+	}
+
+	var nameMatches []*apix.RequestTemplate
+	for _, tpl := range resp.Templates {
+		if tpl.GetId() == identifier {
+			return tpl, nil
+		}
+		if tpl.GetName() == identifier {
+			nameMatches = append(nameMatches, tpl)
+		}
+	}
+
+	switch len(nameMatches) {
+	case 0:
+		return nil, status.Errorf(codes.NotFound, "template %q not found", identifier)
+	case 1:
+		return nameMatches[0], nil
+	default:
+		ids := make([]string, 0, len(nameMatches))
+		for _, tpl := range nameMatches {
+			ids = append(ids, tpl.GetId())
+		}
+		sort.Strings(ids)
+		return nil, fmt.Errorf("template name %q is ambiguous; matched ids: %s", identifier, strings.Join(ids, ", "))
 	}
 }
 
@@ -1951,7 +2009,7 @@ _apix() {
   local cur prev words cword
   _init_completion || return
   local commands="status plugins history watch breakpoints paused send templates replay cert config completion doctor help"
-  local subcommands="list get clear add delete enable disable watch forward drop respond save show reload status"
+  local subcommands="list get clear add delete enable disable watch forward drop respond save execute show reload status"
   COMPREPLY=( $(compgen -W "${commands} ${subcommands}" -- "$cur") )
 }
 complete -F _apix apix

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -637,7 +637,7 @@ func (a *app) cmdStatus() error {
 	}
 	statusLabel := resp.Status
 	if resp.Status == "running" && a.opts.output == "text" {
-		statusLabel = a.successColor(resp.Status)
+		statusLabel = a.successColor("%s", resp.Status)
 	}
 	writef(a.out, "APiX engine: %s\tversion=%s\tproxy=%d\tgrpc=%d\ttls=%t\n",
 		statusLabel, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
@@ -2329,14 +2329,14 @@ func (a *app) cmdDoctor() error {
 	writef(a.out, "Config: %s\n", configPath)
 	configMsg := configValidation
 	if configValidation != "ok" && a.opts.output == "text" {
-		configMsg = a.errorColor(configValidation)
+		configMsg = a.errorColor("%s", configValidation)
 	}
 	writef(a.out, "Config validation: %s\n", configMsg)
 
 	certReady := cert["ready"]
 	certMsg := fmt.Sprintf("%v", certReady)
 	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
-		certMsg = a.warnColor(certMsg)
+		certMsg = a.warnColor("%s", certMsg)
 	}
 	writef(a.out, "Cert ready: %s\n", certMsg)
 

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -364,6 +364,27 @@ func TestCLIWriteWorkflows_EngineBacked(t *testing.T) {
 	if len(templates) != 1 || templates[0]["id"] != "tpl-1" {
 		t.Fatalf("unexpected templates list: %#v", templates)
 	}
+	exit, out, errOut = runCLI(t, stack.args("--output", "json", "templates", "execute", "tpl-1")...)
+	if exit != 0 {
+		t.Fatalf("templates execute by id exit=%d err=%s", exit, errOut)
+	}
+	var execResp map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &execResp); err != nil {
+		t.Fatalf("templates execute by id json: %v", err)
+	}
+	if int(execResp["status_code"].(float64)) != 200 || execResp["body"] != "pong" {
+		t.Fatalf("unexpected execute response by id: %#v", execResp)
+	}
+	exit, out, errOut = runCLI(t, stack.args("--output", "json", "templates", "execute", "health")...)
+	if exit != 0 {
+		t.Fatalf("templates execute by name exit=%d err=%s", exit, errOut)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &execResp); err != nil {
+		t.Fatalf("templates execute by name json: %v", err)
+	}
+	if int(execResp["status_code"].(float64)) != 200 || execResp["body"] != "pong" {
+		t.Fatalf("unexpected execute response by name: %#v", execResp)
+	}
 	exit, _, errOut = runCLI(t, stack.args("templates", "delete", "tpl-1")...)
 	if exit != 0 {
 		t.Fatalf("templates delete exit=%d err=%s", exit, errOut)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -153,6 +153,7 @@ map_local_rules:
 ```bash
 ./apix-cli templates save --id <req-id> --name "get-user"
 ./apix-cli templates list
+./apix-cli templates execute <id-or-name>
 ./apix-cli templates delete <name>
 ```
 

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -10,7 +10,7 @@ Commands:
   breakpoints list|add|delete|enable|disable
   paused watch|forward|drop|respond
   send
-  templates save|list|delete
+  templates save|list|delete|execute
   replay
   cert status
   config show|reload

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -1,5 +1,13 @@
 Usage: apix [global flags] <command> [args]
 
+Environment Variables:
+  APIX_HOST        Engine host (default: localhost)
+  APIX_PORT        Engine gRPC port (default: 9090)
+  APIX_TLS         Use TLS for connection (default: false)
+  APIX_TOKEN       Authentication token
+  APIX_OUTPUT      Output format: text|json|ndjson (default: text)
+  APIX_TIMEOUT     Per-command timeout (default: 0)
+
 Commands:
   status
   plugins list
@@ -26,19 +34,19 @@ Commands:
   -debug
     	enable detailed diagnostic logs
   -host string
-    	engine host (default "localhost")
+    	engine host (env: APIX_HOST) (default "localhost")
   -no-color
     	disable color output
   -output string
-    	output format: text|json|ndjson (default "text")
+    	output format: text|json|ndjson (env: APIX_OUTPUT) (default "text")
   -port int
-    	engine gRPC port (default 9090)
+    	engine gRPC port (env: APIX_PORT) (default 9090)
   -timeout duration
-    	per-command timeout (0 = sensible default)
+    	per-command timeout (0 = sensible default) (env: APIX_TIMEOUT)
   -tls
-    	use TLS for gRPC connection
+    	use TLS for gRPC connection (env: APIX_TLS)
   -token string
-    	auth token
+    	auth token (env: APIX_TOKEN)
   -v	shorthand for --verbose
   -verbose
     	enable diagnostic logs


### PR DESCRIPTION
Fixes #360.

## Summary
- add `apix templates execute <id-or-name>`
- resolve templates by id first, then by unique name
- document the new CLI surface and cover it with tests

## Testing
- make test
- make lint