### PR TITLE
feat(cli): read request body from stdin

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -678,7 +678,7 @@ func (a *app) cmdStatus() error {
 	}
 	statusLabel := resp.Status
 	if resp.Status == "running" && a.opts.output == "text" {
-		statusLabel = a.successColor(resp.Status)
+		statusLabel = a.successColor("%s", resp.Status)
 	}
 	writef(a.out, "APiX engine: %s\tversion=%s\tproxy=%d\tgrpc=%d\ttls=%t\n",
 		statusLabel, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
@@ -2334,14 +2334,14 @@ func (a *app) cmdDoctor() error {
 	writef(a.out, "Config: %s\n", configPath)
 	configMsg := configValidation
 	if configValidation != "ok" && a.opts.output == "text" {
-		configMsg = a.errorColor(configValidation)
+		configMsg = a.errorColor("%s", configValidation)
 	}
 	writef(a.out, "Config validation: %s\n", configMsg)
 
 	certReady := cert["ready"]
 	certMsg := fmt.Sprintf("%v", certReady)
 	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
-		certMsg = a.warnColor(certMsg)
+		certMsg = a.warnColor("%s", certMsg)
 	}
 	writef(a.out, "Cert ready: %s\n", certMsg)
 

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -44,6 +44,7 @@ type app struct {
 	opts   rootOptions
 	out    io.Writer
 	errw   io.Writer
+	stdin  io.Reader
 	cfg    *config.Config
 	conn   *grpc.ClientConn
 	client apix.EngineClient
@@ -87,17 +88,29 @@ type exportOptions struct {
 	limit  int
 }
 
+type bodyFlag struct {
+	value string
+	set   bool
+}
+
+func (b *bodyFlag) String() string { return b.value }
+func (b *bodyFlag) Set(v string) error {
+	b.value = v
+	b.set = true
+	return nil
+}
+
 type sendOptions struct {
 	method          string
 	url             string
 	headers         headerFlags
-	body            string
+	body            bodyFlag
 	followRedirects bool
 }
 
 type replayOptions struct {
 	headers         headerFlags
-	body            string
+	body            bodyFlag
 	followRedirects bool
 }
 
@@ -186,6 +199,29 @@ func writeString(w io.Writer, s string) {
 	_, _ = io.WriteString(w, s)
 }
 
+func stdinIsTerminal(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func readBodyFromStdin(r io.Reader) (string, error) {
+	if r == nil {
+		return "", nil
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
 // checkHelpFlag returns true if args contain --help or -h, and returns the remaining args
 func checkHelpFlag(args []string) (bool, []string) {
 	for i, arg := range args {
@@ -245,6 +281,10 @@ func getEnvBool(envVar string, defaultVal bool) bool {
 }
 
 func Run(args []string, out io.Writer, errw io.Writer) int {
+	return runWithStdin(args, out, errw, os.Stdin)
+}
+
+func runWithStdin(args []string, out io.Writer, errw io.Writer, stdin io.Reader) int {
 	// Read environment variables for defaults (will be overridden by CLI flags)
 	envHost := os.Getenv("APIX_HOST")
 	if envHost == "" {
@@ -328,6 +368,7 @@ func Run(args []string, out io.Writer, errw io.Writer) int {
 		opts: opts,
 		out:  out,
 		errw: errw,
+		stdin: stdin,
 		cfg:  config.LoadConfig(cfgPath),
 	}
 
@@ -1578,7 +1619,7 @@ func (a *app) cmdSend(args []string) error {
 	fs.StringVar(&opts.method, "method", "GET", "HTTP method")
 	fs.StringVar(&opts.url, "url", "", "request URL")
 	fs.Var(&opts.headers, "header", "repeatable header key:value")
-	fs.StringVar(&opts.body, "body", "", "request body")
+	fs.Var(&opts.body, "body", "request body")
 	fs.BoolVar(&opts.followRedirects, "follow-redirects", true, "follow redirects")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -1589,6 +1630,17 @@ func (a *app) cmdSend(args []string) error {
 	headers, err := opts.headers.Map()
 	if err != nil {
 		return err
+	}
+	body := opts.body.value
+	if !opts.body.set {
+		if stdinIsTerminal(a.stdin) {
+			body = ""
+		} else {
+			body, err = readBodyFromStdin(a.stdin)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	client, err := a.clientConn()
 	if err != nil {
@@ -1601,7 +1653,7 @@ func (a *app) cmdSend(args []string) error {
 			Method:  opts.method,
 			Url:     opts.url,
 			Headers: headers,
-			Body:    []byte(opts.body),
+			Body:    []byte(body),
 		},
 		FollowRedirects: opts.followRedirects,
 	})
@@ -1724,7 +1776,7 @@ func (a *app) cmdReplay(args []string) error {
 	fs.SetOutput(a.errw)
 	opts := replayOptions{}
 	fs.Var(&opts.headers, "header", "repeatable override header key:value")
-	fs.StringVar(&opts.body, "body", "", "override body")
+	fs.Var(&opts.body, "body", "override body")
 	fs.BoolVar(&opts.followRedirects, "follow-redirects", true, "follow redirects")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -1737,6 +1789,17 @@ func (a *app) cmdReplay(args []string) error {
 	if err != nil {
 		return err
 	}
+	body := opts.body.value
+	if !opts.body.set {
+		if stdinIsTerminal(a.stdin) {
+			body = ""
+		} else {
+			body, err = readBodyFromStdin(a.stdin)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	client, err := a.clientConn()
 	if err != nil {
 		return err
@@ -1746,7 +1809,7 @@ func (a *app) cmdReplay(args []string) error {
 	resp, err := client.ReplayRequest(ctx, &apix.ReplaySpec{
 		Source:          &apix.ReplaySpec_RequestId{RequestId: id},
 		OverrideHeaders: headers,
-		OverrideBody:    []byte(opts.body),
+		OverrideBody:    []byte(body),
 		FollowRedirects: opts.followRedirects,
 	})
 	if err != nil {

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -142,8 +142,13 @@ func reqBodyBytes(body string) []byte {
 
 func runCLI(t *testing.T, args ...string) (int, string, string) {
 	t.Helper()
+	return runCLIWithInput(t, "", args...)
+}
+
+func runCLIWithInput(t *testing.T, stdin string, args ...string) (int, string, string) {
+	t.Helper()
 	var out, errb bytes.Buffer
-	exit := Run(args, &out, &errb)
+	exit := runWithStdin(args, &out, &errb, bytes.NewBufferString(stdin))
 	return exit, out.String(), errb.String()
 }
 
@@ -399,6 +404,71 @@ func TestCLIWriteWorkflows_EngineBacked(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("paused request not resumed")
+	}
+}
+
+func TestCLISendAndReplayReadBodyFromStdin(t *testing.T) {
+	stack := newCLITestStack(t, "")
+
+	sendBodies := make(chan string, 1)
+	sendErrs := make(chan error, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			sendErrs <- err
+			return
+		}
+		_ = r.Body.Close()
+		sendBodies <- string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	exit, _, errOut := runCLIWithInput(t, "stdin-send-body", stack.args("--output", "json", "send", "--method", "POST", "--url", upstream.URL+"/send")...)
+	if exit != 0 {
+		t.Fatalf("send exit=%d err=%s", exit, errOut)
+	}
+	select {
+	case body := <-sendBodies:
+		if body != "stdin-send-body" {
+			t.Fatalf("send body=%q", body)
+		}
+	case err := <-sendErrs:
+		t.Fatalf("send handler: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for send body")
+	}
+
+	replayBodies := make(chan string, 1)
+	replayErrs := make(chan error, 1)
+	upstreamReplay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			replayErrs <- err
+			return
+		}
+		_ = r.Body.Close()
+		replayBodies <- string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstreamReplay.Close()
+
+	stack.storeTransaction(t, "req-replay-stdin", "POST", upstreamReplay.URL+"/replay", "original-body", "", 200)
+	exit, _, errOut = runCLIWithInput(t, "stdin-replay-body", stack.args("--output", "json", "replay", "req-replay-stdin")...)
+	if exit != 0 {
+		t.Fatalf("replay exit=%d err=%s", exit, errOut)
+	}
+	select {
+	case body := <-replayBodies:
+		if body != "stdin-replay-body" {
+			t.Fatalf("replay body=%q", body)
+		}
+	case err := <-replayErrs:
+		t.Fatalf("replay handler: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for replay body")
 	}
 }
 

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -1,5 +1,13 @@
 Usage: apix [global flags] <command> [args]
 
+Environment Variables:
+  APIX_HOST        Engine host (default: localhost)
+  APIX_PORT        Engine gRPC port (default: 9090)
+  APIX_TLS         Use TLS for connection (default: false)
+  APIX_TOKEN       Authentication token
+  APIX_OUTPUT      Output format: text|json|ndjson (default: text)
+  APIX_TIMEOUT     Per-command timeout (default: 0)
+
 Commands:
   status
   plugins list
@@ -26,19 +34,19 @@ Commands:
   -debug
     	enable detailed diagnostic logs
   -host string
-    	engine host (default "localhost")
+    	engine host (env: APIX_HOST) (default "localhost")
   -no-color
     	disable color output
   -output string
-    	output format: text|json|ndjson (default "text")
+    	output format: text|json|ndjson (env: APIX_OUTPUT) (default "text")
   -port int
-    	engine gRPC port (default 9090)
+    	engine gRPC port (env: APIX_PORT) (default 9090)
   -timeout duration
-    	per-command timeout (0 = sensible default)
+    	per-command timeout (0 = sensible default) (env: APIX_TIMEOUT)
   -tls
-    	use TLS for gRPC connection
+    	use TLS for gRPC connection (env: APIX_TLS)
   -token string
-    	auth token
+    	auth token (env: APIX_TOKEN)
   -v	shorthand for --verbose
   -verbose
     	enable diagnostic logs


### PR DESCRIPTION
Fixes #361.

## Summary
- let `send` and `replay` read a body from stdin when `--body` is omitted
- keep explicit `--body` values as the highest precedence
- add CLI coverage for stdin-fed send and replay flows

## Testing
- make test
- make lint