### PR TITLE
feat(vscode): add keyboard shortcuts

### DIFF
--- a/apix-vscode/package-lock.json
+++ b/apix-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apix",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apix",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.10.0",

--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -140,6 +140,36 @@
         "icon": "$(trash)"
       }
     ],
+    "keybindings": [
+      {
+        "command": "apix.openTrafficPanel",
+        "key": "ctrl+shift+t",
+        "mac": "cmd+shift+t"
+      },
+      {
+        "command": "apix.addBreakpoint",
+        "key": "ctrl+shift+b",
+        "mac": "cmd+shift+b"
+      },
+      {
+        "command": "apix.clearHistory",
+        "key": "ctrl+shift+k",
+        "mac": "cmd+shift+k",
+        "when": "view == apix.trafficView"
+      },
+      {
+        "command": "apix.replayRequest",
+        "key": "ctrl+shift+r",
+        "mac": "cmd+shift+r",
+        "when": "view == apix.trafficView && viewItem == httpTransaction"
+      },
+      {
+        "command": "apix.copyAsCurl",
+        "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c",
+        "when": "view == apix.trafficView && viewItem == httpTransaction"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { EngineClient } from './engineClient';
 import { TrafficPanel } from './trafficPanel';
 import { BreakpointsProvider, BreakpointItem } from './breakpointsProvider';
-import { TrafficProvider, TrafficItem } from './trafficProvider';
+import { TrafficProvider, TrafficItem, ErrorItem } from './trafficProvider';
 import { MocksProvider, MockItem } from './mocksProvider';
 import { EngineProcessManager } from './engineProcessManager';
 import { ReplayPanel } from './replayPanel';
@@ -22,6 +22,8 @@ let mocksProvider: MocksProvider | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
 let pausedRetryTimer: ReturnType<typeof setTimeout> | undefined;
 let pausedRetryDelayMs = 1000;
+let trafficTreeView: vscode.TreeView<TrafficItem | ErrorItem> | undefined;
+let selectedTrafficItem: TrafficItem | undefined;
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const config = vscode.workspace.getConfiguration('apix');
@@ -65,10 +67,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     breakpointsProvider = new BreakpointsProvider(engineClient, outputChannel);
     mocksProvider = new MocksProvider(engineClient, outputChannel);
 
-    const trafficViewDisposable = vscode.window.registerTreeDataProvider(
-        'apix.trafficView',
-        trafficProvider
-    );
+    trafficTreeView = vscode.window.createTreeView('apix.trafficView', {
+        treeDataProvider: trafficProvider,
+        canSelectMany: false,
+    });
+    const trafficSelectionDisposable = trafficTreeView.onDidChangeSelection((e) => {
+        selectedTrafficItem = e.selection.find((item): item is TrafficItem => item instanceof TrafficItem);
+    });
 
     const breakpointsViewDisposable = vscode.window.registerTreeDataProvider(
         'apix.breakpointsView',
@@ -81,7 +86,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     );
 
     context.subscriptions.push(
-        trafficViewDisposable,
+        trafficTreeView,
+        trafficSelectionDisposable,
         breakpointsViewDisposable,
         mocksViewDisposable,
 
@@ -95,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             try {
                 await engineClient?.clearHistory();
                 trafficProvider?.refresh();
+                TrafficPanel.currentPanel?.clearDisplayedHistory();
             } catch (err: any) {
                 vscode.window.showErrorMessage(`APiX: Failed to clear history — ${err?.message || err}`);
             }
@@ -120,14 +127,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             }
         }),
         vscode.commands.registerCommand('apix.replayRequest', (itemOrId: TrafficItem | string) => {
-            const id = typeof itemOrId === 'string' ? itemOrId : itemOrId?.transaction?.id;
+            const id = typeof itemOrId === 'string'
+                ? itemOrId
+                : itemOrId?.transaction?.id || selectedTrafficItem?.transaction?.id;
             if (id) { openReplayPanel(context, engineClient!, id); }
         }),
         vscode.commands.registerCommand('apix.composeRequest', () =>
             openReplayPanel(context, engineClient!)
         ),
         vscode.commands.registerCommand('apix.copyAsCurl', (itemOrTx: TrafficItem | HttpTransaction) =>
-            copyAsCurl(itemOrTx)
+            copyAsCurl(itemOrTx || selectedTrafficItem)
         ),
         vscode.commands.registerCommand('apix.copyRequestId', (itemOrTxOrID: TrafficItem | HttpTransaction | string) =>
             copyRequestId(itemOrTxOrID)
@@ -373,7 +382,7 @@ async function openReplayPanel(
     await ReplayPanel.show(context.extensionUri, client, requestId);
 }
 
-async function copyAsCurl(itemOrTx: TrafficItem | HttpTransaction): Promise<void> {
+async function copyAsCurl(itemOrTx?: TrafficItem | HttpTransaction): Promise<void> {
     const tx = itemOrTx instanceof TrafficItem ? itemOrTx.transaction : itemOrTx;
     if (!tx?.request?.url) {
         vscode.window.showErrorMessage('APiX: No request available to copy as curl.');

--- a/apix-vscode/src/requestEditor.ts
+++ b/apix-vscode/src/requestEditor.ts
@@ -307,6 +307,20 @@ export class RequestEditor {
     validateJsonField('headers', 'headers-error');
     validateJsonField('resp-headers', 'resp-headers-error');
     updateForwardButtonState();
+
+    document.addEventListener('keydown', (event) => {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) {
+        return;
+      }
+
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        forward();
+      } else if (event.key === 'Backspace' && !event.shiftKey) {
+        event.preventDefault();
+        drop();
+      }
+    });
   </script>
 </body>
 </html>`;

--- a/apix-vscode/src/trafficPanel.ts
+++ b/apix-vscode/src/trafficPanel.ts
@@ -185,6 +185,9 @@ export class TrafficPanel {
                     vscode.commands.executeCommand('apix.copyAsCurl', message.data.transaction);
                 }
                 break;
+            case 'clearHistory':
+                vscode.commands.executeCommand('apix.clearHistory');
+                break;
             case 'copyRequestId':
                 if (message.data?.requestId) {
                     vscode.commands.executeCommand('apix.copyRequestId', message.data.requestId);
@@ -268,7 +271,11 @@ export class TrafficPanel {
     .status-3xx { color: var(--vscode-charts-blue); }
     .status-4xx { color: var(--vscode-charts-orange); }
     .status-5xx { color: var(--vscode-charts-red); }
+    .panel-toolbar { display: flex; justify-content: flex-end; margin-bottom: 8px; }
+    .panel-toolbar button { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: none; padding: 4px 12px; border-radius: 3px; cursor: pointer; font-family: inherit; font-size: 13px; }
+    .panel-toolbar button:hover { background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground)); }
     .filter-bar { margin-bottom: 8px; display: flex; flex-direction: column; gap: 6px; }
+    .filter-bar.hidden { display: none; }
     .filter-row { display: flex; gap: 6px; align-items: center; }
     .filter-row input, .filter-row select { background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, #555); padding: 4px 8px; border-radius: 3px; font-family: inherit; font-size: 13px; }
     .filter-row input:focus, .filter-row select:focus { outline: 1px solid var(--vscode-focusBorder); }
@@ -298,6 +305,9 @@ export class TrafficPanel {
   </style>
 </head>
 <body>
+  <div class="panel-toolbar">
+    <button id="toggle-filters-btn" onclick="toggleFilterBar()" title="Toggle filter bar (Ctrl+F)">Hide Filters</button>
+  </div>
   <div id="stream-error"></div>
   <div class="filter-bar">
     <div class="filter-row">
@@ -356,6 +366,7 @@ export class TrafficPanel {
     let currentFramesRequestId = '';
     let sortKey = null;
     let sortAsc = true;
+    let filtersVisible = true;
 
     window.addEventListener('message', function(event) {
       const msg = event.data;
@@ -380,6 +391,8 @@ export class TrafficPanel {
         restoreFilters(msg.data || {});
       } else if (msg.type === 'filtersCleared') {
         clearAllFilters();
+      } else if (msg.type === 'historyCleared') {
+        clearAll();
       }
     });
 
@@ -657,10 +670,37 @@ export class TrafficPanel {
       }
     }
 
+    function setFilterBarVisible(visible) {
+      filtersVisible = visible;
+      const filterBar = document.querySelector('.filter-bar');
+      const toggleBtn = document.getElementById('toggle-filters-btn');
+      if (filterBar) {
+        filterBar.classList.toggle('hidden', !visible);
+      }
+      if (toggleBtn) {
+        toggleBtn.textContent = visible ? 'Hide Filters' : 'Show Filters';
+      }
+      if (visible) {
+        const firstFilter = document.getElementById('filter');
+        if (firstFilter) {
+          firstFilter.focus();
+        }
+      }
+    }
+
+    function toggleFilterBar() {
+      setFilterBarVisible(!filtersVisible);
+    }
+
+    function clearHistory() {
+      vscode.postMessage({ type: 'clearHistory', data: {} });
+    }
+
     function clearAll() {
       document.getElementById('traffic').innerHTML = '';
       transactions = [];
       count = 0;
+      currentFramesRequestId = '';
       document.getElementById('empty').style.display = 'block';
       closeDetail();
     }
@@ -880,6 +920,27 @@ export class TrafficPanel {
         sortTransactions(key);
       });
     });
+
+    document.addEventListener('keydown', function(event) {
+      if (!(event.ctrlKey || event.metaKey) || event.altKey) {
+        return;
+      }
+
+      const key = String(event.key || '').toLowerCase();
+      if (key === 'f' && !event.shiftKey) {
+        event.preventDefault();
+        toggleFilterBar();
+      } else if (key === 'r' && event.shiftKey) {
+        event.preventDefault();
+        replayRequest();
+      } else if (key === 'c' && event.shiftKey) {
+        event.preventDefault();
+        copyAsCurl();
+      } else if (key === 'k' && event.shiftKey) {
+        event.preventDefault();
+        clearHistory();
+      }
+    });
   </script>
 </body>
 </html>`;
@@ -898,5 +959,9 @@ export class TrafficPanel {
             const d = this._disposables.pop();
             if (d) { d.dispose(); }
         }
+    }
+
+    public clearDisplayedHistory(): void {
+        this._panel.webview.postMessage({ type: 'historyCleared' });
     }
 }

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -637,7 +637,7 @@ func (a *app) cmdStatus() error {
 	}
 	statusLabel := resp.Status
 	if resp.Status == "running" && a.opts.output == "text" {
-		statusLabel = a.successColor(resp.Status)
+		statusLabel = a.successColor("%s", resp.Status)
 	}
 	writef(a.out, "APiX engine: %s\tversion=%s\tproxy=%d\tgrpc=%d\ttls=%t\n",
 		statusLabel, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
@@ -2271,14 +2271,14 @@ func (a *app) cmdDoctor() error {
 	writef(a.out, "Config: %s\n", configPath)
 	configMsg := configValidation
 	if configValidation != "ok" && a.opts.output == "text" {
-		configMsg = a.errorColor(configValidation)
+		configMsg = a.errorColor("%s", configValidation)
 	}
 	writef(a.out, "Config validation: %s\n", configMsg)
 
 	certReady := cert["ready"]
 	certMsg := fmt.Sprintf("%v", certReady)
 	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
-		certMsg = a.warnColor(certMsg)
+		certMsg = a.warnColor("%s", certMsg)
 	}
 	writef(a.out, "Cert ready: %s\n", certMsg)
 

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -1,5 +1,13 @@
 Usage: apix [global flags] <command> [args]
 
+Environment Variables:
+  APIX_HOST        Engine host (default: localhost)
+  APIX_PORT        Engine gRPC port (default: 9090)
+  APIX_TLS         Use TLS for connection (default: false)
+  APIX_TOKEN       Authentication token
+  APIX_OUTPUT      Output format: text|json|ndjson (default: text)
+  APIX_TIMEOUT     Per-command timeout (default: 0)
+
 Commands:
   status
   plugins list
@@ -26,19 +34,19 @@ Commands:
   -debug
     	enable detailed diagnostic logs
   -host string
-    	engine host (default "localhost")
+    	engine host (env: APIX_HOST) (default "localhost")
   -no-color
     	disable color output
   -output string
-    	output format: text|json|ndjson (default "text")
+    	output format: text|json|ndjson (env: APIX_OUTPUT) (default "text")
   -port int
-    	engine gRPC port (default 9090)
+    	engine gRPC port (env: APIX_PORT) (default 9090)
   -timeout duration
-    	per-command timeout (0 = sensible default)
+    	per-command timeout (0 = sensible default) (env: APIX_TIMEOUT)
   -tls
-    	use TLS for gRPC connection
+    	use TLS for gRPC connection (env: APIX_TLS)
   -token string
-    	auth token
+    	auth token (env: APIX_TOKEN)
   -v	shorthand for --verbose
   -verbose
     	enable diagnostic logs


### PR DESCRIPTION
Fixes #345.

## Summary
- add platform-specific extension keybindings for common APiX actions
- support keyboard-driven actions in the traffic panel and request editor webviews
- fall back to the selected traffic item for replay/copy commands

## Testing
- make test
- make lint
- cd apix-vscode && npm run compile
- cd apix-vscode && npx tsc --noEmit