### PR TITLE
feat(cli): standardize paused request ids

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -676,7 +676,7 @@ func (a *app) cmdStatus() error {
 	}
 	statusLabel := resp.Status
 	if resp.Status == "running" && a.opts.output == "text" {
-		statusLabel = a.successColor(resp.Status)
+		statusLabel = a.successColor("%s", resp.Status)
 	}
 	writef(a.out, "APiX engine: %s\tversion=%s\tproxy=%d\tgrpc=%d\ttls=%t\n",
 		statusLabel, resp.Version, resp.ProxyPort, resp.GrpcPort, resp.TlsEnabled)
@@ -2351,14 +2351,14 @@ func (a *app) cmdDoctor() error {
 	writef(a.out, "Config: %s\n", configPath)
 	configMsg := configValidation
 	if configValidation != "ok" && a.opts.output == "text" {
-		configMsg = a.errorColor(configValidation)
+		configMsg = a.errorColor("%s", configValidation)
 	}
 	writef(a.out, "Config validation: %s\n", configMsg)
 
 	certReady := cert["ready"]
 	certMsg := fmt.Sprintf("%v", certReady)
 	if ok, _ := certReady.(bool); !ok && a.opts.output == "text" {
-		certMsg = a.warnColor(certMsg)
+		certMsg = a.warnColor("%s", certMsg)
 	}
 	writef(a.out, "Cert ready: %s\n", certMsg)
 

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -174,6 +174,45 @@ func (s *stringSliceFlags) Set(v string) error {
 	return nil
 }
 
+func splitPausedArgs(args []string, valueFlags map[string]struct{}) (string, []string, error) {
+	var requestID string
+	filtered := make([]string, 0, len(args))
+	expectValueFor := ""
+
+	for _, arg := range args {
+		if expectValueFor != "" {
+			filtered = append(filtered, arg)
+			expectValueFor = ""
+			continue
+		}
+
+		if strings.HasPrefix(arg, "-") {
+			filtered = append(filtered, arg)
+			flagName := strings.TrimLeft(arg, "-")
+			if idx := strings.Index(flagName, "="); idx >= 0 {
+				flagName = flagName[:idx]
+			}
+			if _, ok := valueFlags[flagName]; ok && !strings.Contains(arg, "=") {
+				expectValueFor = flagName
+			}
+			continue
+		}
+
+		if requestID == "" {
+			requestID = arg
+			continue
+		}
+
+		return "", nil, fmt.Errorf("too many arguments: %s", arg)
+	}
+
+	if expectValueFor != "" {
+		return "", nil, fmt.Errorf("flag --%s requires a value", expectValueFor)
+	}
+
+	return requestID, filtered, nil
+}
+
 func writeLine(w io.Writer, args ...any) {
 	_, _ = fmt.Fprintln(w, args...)
 }
@@ -1390,18 +1429,24 @@ func (a *app) cmdPaused(args []string) error {
 	case "forward":
 		if helpRequested {
 			writeLine(a.out, "Usage: paused forward <request-id> [flags]")
+			writeLine(a.out, "")
+			writeLine(a.out, "  --request-id ID   Deprecated alias for <request-id>")
 			return nil
 		}
 		return a.cmdPausedForward(client, remaining[1:])
 	case "drop":
 		if helpRequested {
 			writeLine(a.out, "Usage: paused drop <request-id>")
+			writeLine(a.out, "")
+			writeLine(a.out, "  --request-id ID   Deprecated alias for <request-id>")
 			return nil
 		}
 		return a.cmdPausedDrop(client, remaining[1:])
 	case "respond":
 		if helpRequested {
 			writeLine(a.out, "Usage: paused respond <request-id> [flags]")
+			writeLine(a.out, "")
+			writeLine(a.out, "  --request-id ID   Deprecated alias for <request-id>")
 			writeLine(a.out, "")
 			writeLine(a.out, "Flags:")
 			writeLine(a.out, "  --status N         HTTP status code")
@@ -1470,23 +1515,36 @@ func (a *app) cmdPausedForward(client apix.EngineClient, args []string) error {
 	fs := flag.NewFlagSet("paused forward", flag.ContinueOnError)
 	fs.SetOutput(a.errw)
 	opts := pausedForwardOptions{}
-	fs.StringVar(&opts.requestID, "request-id", "", "paused request id")
+	fs.StringVar(&opts.requestID, "request-id", "", "deprecated alias for the positional request ID")
 	fs.StringVar(&opts.method, "method", "", "override method")
 	fs.StringVar(&opts.url, "url", "", "override URL")
 	fs.Var(&opts.headers, "header", "repeatable header override key:value")
 	fs.StringVar(&opts.body, "body", "", "override body")
-	if err := fs.Parse(args); err != nil {
+	requestID, flagArgs, err := splitPausedArgs(args, map[string]struct{}{
+		"request-id": {},
+		"method":      {},
+		"url":         {},
+		"header":      {},
+		"body":        {},
+	})
+	if err != nil {
 		return err
 	}
-	if opts.requestID == "" {
-		return fmt.Errorf("paused forward requires --request-id")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if requestID == "" {
+		requestID = opts.requestID
+	}
+	if requestID == "" {
+		return fmt.Errorf("paused forward requires <request-id>")
 	}
 	headers, err := opts.headers.Map()
 	if err != nil {
 		return err
 	}
 	req := &apix.ResumeAction{
-		RequestId: opts.requestID,
+		RequestId: requestID,
 		Action:    apix.ResumeAction_FORWARD,
 	}
 	if opts.method != "" || opts.url != "" || len(headers) > 0 || opts.body != "" {
@@ -1502,41 +1560,63 @@ func (a *app) cmdPausedForward(client apix.EngineClient, args []string) error {
 	if _, err := client.ResumeRequest(ctx, req); err != nil {
 		return err
 	}
-	return a.simpleResult("forwarded", opts.requestID)
+	return a.simpleResult("forwarded", requestID)
 }
 
 func (a *app) cmdPausedDrop(client apix.EngineClient, args []string) error {
 	fs := flag.NewFlagSet("paused drop", flag.ContinueOnError)
 	fs.SetOutput(a.errw)
-	requestID := fs.String("request-id", "", "paused request id")
-	if err := fs.Parse(args); err != nil {
+	requestIDFlag := fs.String("request-id", "", "deprecated alias for the positional request ID")
+	requestID, flagArgs, err := splitPausedArgs(args, map[string]struct{}{
+		"request-id": {},
+	})
+	if err != nil {
 		return err
 	}
-	if *requestID == "" {
-		return fmt.Errorf("paused drop requires --request-id")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if requestID == "" {
+		requestID = *requestIDFlag
+	}
+	if requestID == "" {
+		return fmt.Errorf("paused drop requires <request-id>")
 	}
 	ctx, cancel := a.unaryContext()
 	defer cancel()
-	if _, err := client.ResumeRequest(ctx, &apix.ResumeAction{RequestId: *requestID, Action: apix.ResumeAction_DROP}); err != nil {
+	if _, err := client.ResumeRequest(ctx, &apix.ResumeAction{RequestId: requestID, Action: apix.ResumeAction_DROP}); err != nil {
 		return err
 	}
-	return a.simpleResult("dropped", *requestID)
+	return a.simpleResult("dropped", requestID)
 }
 
 func (a *app) cmdPausedRespond(client apix.EngineClient, args []string) error {
 	fs := flag.NewFlagSet("paused respond", flag.ContinueOnError)
 	fs.SetOutput(a.errw)
 	opts := pausedRespondOptions{statusCode: 200, statusText: "OK"}
-	fs.StringVar(&opts.requestID, "request-id", "", "paused request id")
+	fs.StringVar(&opts.requestID, "request-id", "", "deprecated alias for the positional request ID")
 	fs.IntVar(&opts.statusCode, "status-code", 200, "response status code")
 	fs.StringVar(&opts.statusText, "status-text", "OK", "response status text")
 	fs.Var(&opts.headers, "header", "repeatable header key:value")
 	fs.StringVar(&opts.body, "body", "", "response body")
-	if err := fs.Parse(args); err != nil {
+	requestID, flagArgs, err := splitPausedArgs(args, map[string]struct{}{
+		"request-id":  {},
+		"status-code": {},
+		"status-text": {},
+		"header":      {},
+		"body":        {},
+	})
+	if err != nil {
 		return err
 	}
-	if opts.requestID == "" {
-		return fmt.Errorf("paused respond requires --request-id")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if requestID == "" {
+		requestID = opts.requestID
+	}
+	if requestID == "" {
+		return fmt.Errorf("paused respond requires <request-id>")
 	}
 	headers, err := opts.headers.Map()
 	if err != nil {
@@ -1549,7 +1629,7 @@ func (a *app) cmdPausedRespond(client apix.EngineClient, args []string) error {
 		return err
 	}
 	if _, err := client.ResumeRequest(ctx, &apix.ResumeAction{
-		RequestId: opts.requestID,
+		RequestId: requestID,
 		Action:    apix.ResumeAction_RESPOND,
 		ModifiedResponse: &apix.HttpResponse{
 			StatusCode: statusCode,
@@ -1560,7 +1640,7 @@ func (a *app) cmdPausedRespond(client apix.EngineClient, args []string) error {
 	}); err != nil {
 		return err
 	}
-	return a.simpleResult("responded", opts.requestID)
+	return a.simpleResult("responded", requestID)
 }
 
 func (a *app) simpleResult(action, id string) error {

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -391,7 +391,7 @@ func TestCLIWriteWorkflows_EngineBacked(t *testing.T) {
 		close(done)
 	}()
 	time.Sleep(50 * time.Millisecond)
-	exit, _, errOut = runCLI(t, stack.args("paused", "drop", "--request-id", "paused-1")...)
+	exit, _, errOut = runCLI(t, stack.args("paused", "drop", "paused-1")...)
 	if exit != 0 {
 		t.Fatalf("paused drop exit=%d err=%s", exit, errOut)
 	}
@@ -399,6 +399,70 @@ func TestCLIWriteWorkflows_EngineBacked(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("paused request not resumed")
+	}
+}
+
+func TestCLIPausedCommandsUsePositionalRequestIDs(t *testing.T) {
+	stack := newCLITestStack(t, "")
+
+	pauseAndResume := func(id, method, rawURL string) chan struct{} {
+		done := make(chan struct{})
+		go func() {
+			entry := breakpoints.NewPausedEntry(id, "bp-1", mustRequest(t, method, rawURL))
+			_, _ = stack.bpm.Pause(context.Background(), entry)
+			close(done)
+		}()
+		time.Sleep(50 * time.Millisecond)
+		return done
+	}
+
+	forwardDone := pauseAndResume("paused-forward", "POST", "https://example.com/forward")
+	exit, _, errOut := runCLI(t, stack.args("paused", "forward", "paused-forward", "--method", "PATCH", "--url", "https://example.com/forwarded")...)
+	if exit != 0 {
+		t.Fatalf("paused forward exit=%d err=%s", exit, errOut)
+	}
+	select {
+	case <-forwardDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("paused forward request not resumed")
+	}
+
+	respondDone := pauseAndResume("paused-respond", "GET", "https://example.com/respond")
+	exit, _, errOut = runCLI(t, stack.args("paused", "respond", "paused-respond", "--status-code", "418", "--status-text", "I'm a teapot")...)
+	if exit != 0 {
+		t.Fatalf("paused respond exit=%d err=%s", exit, errOut)
+	}
+	select {
+	case <-respondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("paused respond request not resumed")
+	}
+
+	aliasDone := pauseAndResume("paused-alias", "GET", "https://example.com/alias")
+	exit, _, errOut = runCLI(t, stack.args("paused", "drop", "--request-id", "paused-alias")...)
+	if exit != 0 {
+		t.Fatalf("paused drop alias exit=%d err=%s", exit, errOut)
+	}
+	select {
+	case <-aliasDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("paused alias request not resumed")
+	}
+}
+
+func TestCLIPausedForwardHelpMentionsPositionalRequestID(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+
+	exit, out, errOut := runCLI(t, stack.args("paused", "forward", "--help")...)
+	if exit != 0 {
+		t.Fatalf("paused forward help exit=%d err=%s", exit, errOut)
+	}
+	if !strings.Contains(out, "Usage: paused forward <request-id> [flags]") {
+		t.Fatalf("missing positional usage text: %s", out)
+	}
+	if !strings.Contains(out, "--request-id ID   Deprecated alias for <request-id>") {
+		t.Fatalf("missing deprecated alias text: %s", out)
 	}
 }
 

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -1,5 +1,13 @@
 Usage: apix [global flags] <command> [args]
 
+Environment Variables:
+  APIX_HOST        Engine host (default: localhost)
+  APIX_PORT        Engine gRPC port (default: 9090)
+  APIX_TLS         Use TLS for connection (default: false)
+  APIX_TOKEN       Authentication token
+  APIX_OUTPUT      Output format: text|json|ndjson (default: text)
+  APIX_TIMEOUT     Per-command timeout (default: 0)
+
 Commands:
   status
   plugins list
@@ -26,19 +34,19 @@ Commands:
   -debug
     	enable detailed diagnostic logs
   -host string
-    	engine host (default "localhost")
+    	engine host (env: APIX_HOST) (default "localhost")
   -no-color
     	disable color output
   -output string
-    	output format: text|json|ndjson (default "text")
+    	output format: text|json|ndjson (env: APIX_OUTPUT) (default "text")
   -port int
-    	engine gRPC port (default 9090)
+    	engine gRPC port (env: APIX_PORT) (default 9090)
   -timeout duration
-    	per-command timeout (0 = sensible default)
+    	per-command timeout (0 = sensible default) (env: APIX_TIMEOUT)
   -tls
-    	use TLS for gRPC connection
+    	use TLS for gRPC connection (env: APIX_TLS)
   -token string
-    	auth token
+    	auth token (env: APIX_TOKEN)
   -v	shorthand for --verbose
   -verbose
     	enable diagnostic logs


### PR DESCRIPTION
Fixes #353.

## Summary
- make paused forward/drop/respond accept positional request ids
- keep `--request-id` as a deprecated compatibility alias
- update help text and CLI coverage for both forms

## Testing
- make test
- make lint