### PR TITLE
feat(vscode): add tri-state traffic table sorting

### DIFF
--- a/apix-vscode/src/trafficPanel.ts
+++ b/apix-vscode/src/trafficPanel.ts
@@ -750,10 +750,14 @@ export class TrafficPanel {
     }
 
     function sortTransactions(key) {
-      if (sortKey === key) {
-        sortAsc = !sortAsc;
-      } else {
+      // Cycle sort state: asc -> desc -> default (newest first)
+      if (sortKey !== key) {
         sortKey = key;
+        sortAsc = true;
+      } else if (sortAsc) {
+        sortAsc = false;
+      } else {
+        sortKey = null;
         sortAsc = true;
       }
       updateSortIndicators();
@@ -816,16 +820,18 @@ export class TrafficPanel {
         return true;
       });
 
-      if (sortKey) {
-        filtered.sort(function(a, b) {
-          const aVal = getSortValue(a, sortKey);
-          const bVal = getSortValue(b, sortKey);
-          let cmp = 0;
-          if (aVal < bVal) { cmp = -1; }
-          else if (aVal > bVal) { cmp = 1; }
-          return sortAsc ? cmp : -cmp;
-        });
+      if (!sortKey) {
+        return filtered.reverse();
       }
+
+      filtered.sort(function(a, b) {
+        const aVal = getSortValue(a, sortKey);
+        const bVal = getSortValue(b, sortKey);
+        let cmp = 0;
+        if (aVal < bVal) { cmp = -1; }
+        else if (aVal > bVal) { cmp = 1; }
+        return sortAsc ? cmp : -cmp;
+      });
 
       return filtered;
     }


### PR DESCRIPTION
## Summary\n- add tri-state column sorting in APiX TrafficPanel webview table\n- implement header click cycle: asc -> desc -> default\n- restore default ordering to newest-first when sort is reset\n\n## Issue\nCloses #349\n