### PR TITLE
feat(vscode): add structured extension logger

### DIFF
--- a/apix-vscode/package.json
+++ b/apix-vscode/package.json
@@ -344,6 +344,11 @@
           "type": "number",
           "default": 500,
           "description": "Maximum number of traffic items to display in the Traffic view."
+        },
+        "apix.logging.verbose": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable verbose DEBUG logs in the APiX output channel."
         }
       }
     }

--- a/apix-vscode/src/breakpointsProvider.ts
+++ b/apix-vscode/src/breakpointsProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { EngineClient } from './engineClient';
 import { BreakpointRule } from './types';
+import { Logger } from './logger';
 
 /**
  * BreakpointsProvider implements TreeDataProvider for the APiX Breakpoints view.
@@ -10,7 +11,7 @@ export class BreakpointsProvider implements vscode.TreeDataProvider<BreakpointIt
     private _onDidChangeTreeData = new vscode.EventEmitter<BreakpointItem | ErrorItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-    constructor(private readonly client: EngineClient, private readonly output?: vscode.OutputChannel) {}
+    constructor(private readonly client: EngineClient, private readonly logger: Logger) {}
 
     /** Force a refresh of the tree view. */
     refresh(): void {
@@ -34,7 +35,7 @@ export class BreakpointsProvider implements vscode.TreeDataProvider<BreakpointIt
             return (list.breakpoints || []).map(rule => new BreakpointItem(rule));
         } catch (err: any) {
             const msg = err?.message || String(err);
-            this.output?.appendLine(`[APiX] Breakpoints view error: ${msg}`);
+            this.logger.error('Breakpoints view error', { message: msg });
             return [new ErrorItem(`Connection lost: ${msg}`, 'apix.refreshBreakpoints')];
         }
     }

--- a/apix-vscode/src/engineClient.ts
+++ b/apix-vscode/src/engineClient.ts
@@ -18,6 +18,7 @@ import {
     RewriteRuleList,
     RequestTemplate,
 } from './types';
+import { Logger } from './logger';
 
 const PROTO_PATH = path.resolve(__dirname, '../../proto/apix.proto');
 
@@ -32,7 +33,8 @@ export class EngineClient {
         private readonly host: string,
         private readonly port: number,
         private readonly tlsEnabled: boolean,
-        authToken: string
+        authToken: string,
+        private readonly logger?: Logger
     ) {
         this.authToken = authToken.trim();
         this.metadata = new grpc.Metadata();
@@ -57,7 +59,12 @@ export class EngineClient {
             this.stub = new EngineService(address, credentials);
             this.client = this.stub as grpc.Client;
         } catch (err) {
-            console.error('EngineClient: failed to load proto or create stub:', err);
+            this.logger?.error('Failed to initialize EngineClient gRPC stub', {
+                host: this.host,
+                port: this.port,
+                tlsEnabled: this.tlsEnabled,
+                error: err instanceof Error ? err.message : String(err),
+            });
         }
     }
 

--- a/apix-vscode/src/engineProcessManager.ts
+++ b/apix-vscode/src/engineProcessManager.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 import * as path from 'path';
+import { Logger } from './logger';
 
 /**
  * EngineProcessManager starts and stops the apix-engine binary as a child
@@ -21,7 +22,6 @@ export class EngineProcessManager {
     private restartAttempts = 0;
     private restartTimer: ReturnType<typeof setTimeout> | null = null;
     private stopping = false;
-    private outputChannel: vscode.OutputChannel | null = null;
     /** Callback invoked after a successful auto-restart so streams can be re-established. */
     onRestart: (() => void) | null = null;
     /** Callback invoked when an unexpected exit is detected. */
@@ -29,7 +29,10 @@ export class EngineProcessManager {
     /** Callback invoked when auto-restart has been scheduled. */
     onRestarting: ((attempt: number, delayMs: number) => void) | null = null;
 
-    constructor(private readonly context: vscode.ExtensionContext) {}
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly logger: Logger
+    ) {}
 
     /** Start the engine subprocess. Resolves when the engine signals readiness. */
     async start(): Promise<void> {
@@ -45,11 +48,7 @@ export class EngineProcessManager {
         this.isStarting = true;
         try {
             const binaryPath = this._binaryPath();
-            if (!this.outputChannel) {
-                this.outputChannel = vscode.window.createOutputChannel('APiX Engine');
-            }
-            const outputChannel = this.outputChannel;
-            outputChannel.show(true);
+            this.logger.info('Starting engine process', { binaryPath });
 
             this.startPromise = new Promise((resolve, reject) => {
                 try {
@@ -69,13 +68,13 @@ export class EngineProcessManager {
                     };
 
                     const timeout = setTimeout(() => {
-                        outputChannel.appendLine('[APiX] Warning: engine did not signal ready within 10s — proceeding anyway.');
+                        this.logger.warn('Engine did not signal ready within 10s; proceeding anyway.');
                         resolveOnce();
                     }, 10000);
 
                     proc.stdout?.on('data', (data: Buffer) => {
                         const text = data.toString();
-                        outputChannel.append(text);
+                        this.logEngineOutput('stdout', text);
                         if (text.includes('gRPC server listening') || text.includes('Starting gRPC')) {
                             clearTimeout(timeout);
                             resolveOnce();
@@ -83,12 +82,12 @@ export class EngineProcessManager {
                     });
 
                     proc.stderr?.on('data', (data: Buffer) => {
-                        outputChannel.append(data.toString());
+                        this.logEngineOutput('stderr', data.toString());
                     });
 
                     proc.on('error', (err: Error) => {
                         clearTimeout(timeout);
-                        outputChannel.appendLine(`[APiX] Process error: ${err.message}`);
+                        this.logger.error('Engine process error', { message: err.message });
                         if (!resolved) {
                             resolved = true;
                             this.isStarting = false;
@@ -104,7 +103,7 @@ export class EngineProcessManager {
                         }
                         if (!this.stopping && code !== 0 && code !== null) {
                             const msg = `APiX Engine exited unexpectedly (code ${code}, signal ${signal})`;
-                            outputChannel.appendLine(`[APiX] ${msg}`);
+                            this.logger.error(msg);
                             this.onUnexpectedExit?.(msg);
                             this.scheduleAutoRestart();
                         }
@@ -158,14 +157,18 @@ export class EngineProcessManager {
         }
         if (this.restartAttempts >= MAX_RESTART_ATTEMPTS) {
             const msg = `APiX Engine failed to restart after ${MAX_RESTART_ATTEMPTS} attempts.`;
-            this.outputChannel?.appendLine(`[APiX] ${msg}`);
+            this.logger.error(msg);
             void vscode.window.showErrorMessage(msg);
             return;
         }
 
         this.restartAttempts += 1;
         const delayMs = Math.min(BACKOFF_INITIAL_MS * Math.pow(2, this.restartAttempts - 1), BACKOFF_MAX_MS);
-        this.outputChannel?.appendLine(`[APiX] Auto-restart attempt ${this.restartAttempts}/${MAX_RESTART_ATTEMPTS} in ${delayMs}ms`);
+        this.logger.warn('Scheduling engine auto-restart', {
+            attempt: this.restartAttempts,
+            maxAttempts: MAX_RESTART_ATTEMPTS,
+            delayMs,
+        });
         this.onRestarting?.(this.restartAttempts, delayMs);
 
         this.restartTimer = setTimeout(async () => {
@@ -178,10 +181,24 @@ export class EngineProcessManager {
                 this.onRestart?.();
             } catch (err: any) {
                 const msg = err?.message || String(err);
-                this.outputChannel?.appendLine(`[APiX] Auto-restart attempt ${this.restartAttempts} failed: ${msg}`);
+                this.logger.error('Engine auto-restart attempt failed', {
+                    attempt: this.restartAttempts,
+                    message: msg,
+                });
                 this.scheduleAutoRestart();
             }
         }, delayMs);
+    }
+
+    private logEngineOutput(stream: 'stdout' | 'stderr', raw: string): void {
+        const lines = raw.split(/\r?\n/).map(line => line.trim()).filter(line => line.length > 0);
+        for (const line of lines) {
+            if (stream === 'stderr') {
+                this.logger.warn('Engine output', { stream, line });
+            } else {
+                this.logger.debug('Engine output', { stream, line });
+            }
+        }
     }
 
     /** Resolve the path to the bundled engine binary. */

--- a/apix-vscode/src/extension.ts
+++ b/apix-vscode/src/extension.ts
@@ -10,6 +10,7 @@ import { RequestEditor } from './requestEditor';
 import { HttpTransaction } from './types';
 import { buildCurlCommand } from './trafficFormats';
 import { WelcomePanel } from './welcomePanel';
+import { Logger } from './logger';
 
 const AUTH_TOKEN_SECRET_KEY = 'apix.authToken';
 const WELCOME_SHOWN_KEY = 'apix.welcomeShown';
@@ -23,6 +24,7 @@ let trafficProvider: TrafficProvider | undefined;
 let breakpointsProvider: BreakpointsProvider | undefined;
 let mocksProvider: MocksProvider | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let logger: Logger | undefined;
 let pausedRetryTimer: ReturnType<typeof setTimeout> | undefined;
 let pausedRetryDelayMs = 1000;
 let trafficTreeView: vscode.TreeView<TrafficItem | ErrorItem> | undefined;
@@ -45,11 +47,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     // Output channel for extension logging and error reporting
     outputChannel = vscode.window.createOutputChannel('APiX');
+    logger = new Logger(outputChannel, 'extension');
     context.subscriptions.push(outputChannel);
 
-    processManager = new EngineProcessManager(context);
-    const authToken = await resolveAuthToken(context, config, outputChannel);
-    engineClient = new EngineClient(host, grpcPort, tlsEnabled, authToken);
+    processManager = new EngineProcessManager(context, logger.child('engineProcess'));
+    const authToken = await resolveAuthToken(context, config, logger.child('auth'));
+    engineClient = new EngineClient(host, grpcPort, tlsEnabled, authToken, logger.child('engineClient'));
     processManager.onUnexpectedExit = (message: string) => {
         statusBarItem!.text = '$(debug-disconnect) APiX: Disconnected';
         statusBarItem!.tooltip = message;
@@ -61,14 +64,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         statusBarItem!.command = 'apix.startEngine';
     };
     processManager.onRestart = () => {
-        outputChannel?.appendLine('[APiX] Engine restarted; re-initializing extension streams…');
+        logger?.info('Engine restarted; re-initializing extension streams');
         startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!, mocksProvider)
-            .catch(err => outputChannel?.appendLine(`APiX: reconnect failed — ${err?.message || err}`));
+            .catch(err => logger?.error('Reconnect failed', { message: err?.message || String(err) }));
     };
 
-    trafficProvider = new TrafficProvider(engineClient, outputChannel);
-    breakpointsProvider = new BreakpointsProvider(engineClient, outputChannel);
-    mocksProvider = new MocksProvider(engineClient, outputChannel);
+    trafficProvider = new TrafficProvider(engineClient, logger.child('trafficProvider'));
+    breakpointsProvider = new BreakpointsProvider(engineClient, logger.child('breakpointsProvider'));
+    mocksProvider = new MocksProvider(engineClient, logger.child('mocksProvider'));
 
     trafficTreeView = vscode.window.createTreeView('apix.trafficView', {
         treeDataProvider: trafficProvider,
@@ -194,7 +197,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // Start engine asynchronously to avoid blocking extension activation.
         // Errors are logged to the output channel so the user can inspect them.
         startEngine(context, processManager!, engineClient!, breakpointsProvider!, trafficProvider!)
-            .catch(err => outputChannel?.appendLine(`APiX: auto-start failed — ${err?.message || err}`));
+            .catch(err => logger?.error('Auto-start failed', { message: err?.message || String(err) }));
 
     }
 
@@ -234,7 +237,8 @@ export function deactivate(): void {
     statusBarItem?.dispose();
 
     // Dispose output channel
-    outputChannel?.dispose();
+                outputChannel?.dispose();
+                logger = undefined;
 }
 
 async function startEngine(
@@ -315,7 +319,7 @@ function _startWatchPausedRequests(context: vscode.ExtensionContext, client: Eng
             },
             (err) => {
                 // Log to output channel so user can inspect stream errors
-                outputChannel?.appendLine(`[APiX] WatchPausedRequests stream error: ${err?.message || err}`);
+                logger?.error('WatchPausedRequests stream error', { message: err?.message || String(err) });
                 RequestEditor.closeAll();
                 breakpointsProvider?.refresh();
                 if (processManager?.isRunning()) {
@@ -327,7 +331,7 @@ function _startWatchPausedRequests(context: vscode.ExtensionContext, client: Eng
                 }
             },
             () => {
-                console.log('[APiX] WatchPausedRequests stream ended.');
+                logger?.warn('WatchPausedRequests stream ended');
                 RequestEditor.closeAll();
                 breakpointsProvider?.refresh();
                 if (processManager?.isRunning()) {
@@ -341,7 +345,7 @@ function _startWatchPausedRequests(context: vscode.ExtensionContext, client: Eng
         );
         pausedRequestsStream = stream;
     } catch (err) {
-        outputChannel?.appendLine(`[APiX] Could not start WatchPausedRequests: ${err}`);
+        logger?.error('Could not start WatchPausedRequests', { message: String(err) });
     }
 }
 
@@ -461,7 +465,7 @@ async function importHAR(client: EngineClient, provider: TrafficProvider): Promi
 async function resolveAuthToken(
     context: vscode.ExtensionContext,
     config: vscode.WorkspaceConfiguration,
-    output?: vscode.OutputChannel
+    authLogger: Logger
 ): Promise<string> {
     const legacy = (config.get<string>('engine.authToken', '') || '').trim();
     const secret = (await context.secrets.get(AUTH_TOKEN_SECRET_KEY))?.trim() || '';
@@ -473,14 +477,14 @@ async function resolveAuthToken(
     }
 
     await context.secrets.store(AUTH_TOKEN_SECRET_KEY, legacy);
-    await clearLegacyAuthTokenSetting(config, output);
-    output?.appendLine('[APiX] Migrated apix.engine.authToken to VS Code SecretStorage.');
+    await clearLegacyAuthTokenSetting(config, authLogger);
+    authLogger.info('Migrated apix.engine.authToken to VS Code SecretStorage');
     return legacy;
 }
 
 async function clearLegacyAuthTokenSetting(
     config: vscode.WorkspaceConfiguration,
-    output?: vscode.OutputChannel
+    authLogger?: Logger
 ): Promise<void> {
     const inspected = config.inspect<string>('engine.authToken');
     const tasks: Promise<void>[] = [];
@@ -499,7 +503,9 @@ async function clearLegacyAuthTokenSetting(
     const results = await Promise.allSettled(tasks);
     for (const result of results) {
         if (result.status === 'rejected') {
-            output?.appendLine(`[APiX] Failed to clear deprecated apix.engine.authToken setting: ${result.reason}`);
+            authLogger?.error('Failed to clear deprecated apix.engine.authToken setting', {
+                reason: String(result.reason),
+            });
         }
     }
 }
@@ -524,13 +530,17 @@ async function setAuthToken(
     if (trimmed === '') {
         await context.secrets.delete(AUTH_TOKEN_SECRET_KEY);
         client.setAuthToken('');
-        await clearLegacyAuthTokenSetting(config, outputChannel);
+        if (logger) {
+            await clearLegacyAuthTokenSetting(config, logger.child('auth'));
+        }
         vscode.window.showInformationMessage('APiX: Auth token cleared.');
         return;
     }
 
     await context.secrets.store(AUTH_TOKEN_SECRET_KEY, trimmed);
     client.setAuthToken(trimmed);
-    await clearLegacyAuthTokenSetting(config, outputChannel);
+    if (logger) {
+        await clearLegacyAuthTokenSetting(config, logger.child('auth'));
+    }
     vscode.window.showInformationMessage('APiX: Auth token saved to SecretStorage.');
 }

--- a/apix-vscode/src/logger.ts
+++ b/apix-vscode/src/logger.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+
+export class Logger {
+    constructor(
+        private readonly channel: vscode.OutputChannel,
+        private readonly scope = 'apix'
+    ) {}
+
+    child(scope: string): Logger {
+        return new Logger(this.channel, scope);
+    }
+
+    debug(message: string, meta?: Record<string, unknown>): void {
+        if (!this.isVerboseEnabled()) {
+            return;
+        }
+        this.write('DEBUG', message, meta);
+    }
+
+    info(message: string, meta?: Record<string, unknown>): void {
+        this.write('INFO', message, meta);
+    }
+
+    warn(message: string, meta?: Record<string, unknown>): void {
+        this.write('WARN', message, meta);
+    }
+
+    error(message: string, meta?: Record<string, unknown>): void {
+        this.write('ERROR', message, meta);
+    }
+
+    private write(level: LogLevel, message: string, meta?: Record<string, unknown>): void {
+        const payload: Record<string, unknown> = {
+            ts: new Date().toISOString(),
+            level,
+            scope: this.scope,
+            msg: message,
+        };
+        if (meta && Object.keys(meta).length > 0) {
+            payload.meta = meta;
+        }
+        this.channel.appendLine(`[APiX] ${JSON.stringify(payload)}`);
+    }
+
+    private isVerboseEnabled(): boolean {
+        const cfg = vscode.workspace.getConfiguration('apix');
+        return cfg.get<boolean>('logging.verbose', false);
+    }
+}

--- a/apix-vscode/src/mocksProvider.ts
+++ b/apix-vscode/src/mocksProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { EngineClient } from './engineClient';
 import { RewriteRule } from './types';
+import { Logger } from './logger';
 
 /**
  * MocksProvider implements TreeDataProvider for the APiX Mocks view.
@@ -10,7 +11,7 @@ export class MocksProvider implements vscode.TreeDataProvider<MockItem | ErrorIt
     private _onDidChangeTreeData = new vscode.EventEmitter<MockItem | ErrorItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-    constructor(private readonly client: EngineClient, private readonly output?: vscode.OutputChannel) {}
+    constructor(private readonly client: EngineClient, private readonly logger: Logger) {}
 
     /** Force a refresh of the tree view. */
     refresh(): void {
@@ -34,7 +35,7 @@ export class MocksProvider implements vscode.TreeDataProvider<MockItem | ErrorIt
             return (list.rules || []).map(rule => new MockItem(rule));
         } catch (err: any) {
             const msg = err?.message || String(err);
-            this.output?.appendLine(`[APiX] Mocks view error: ${msg}`);
+            this.logger.error('Mocks view error', { message: msg });
             return [new ErrorItem(`Engine unreachable: ${msg}`)];
         }
     }

--- a/apix-vscode/src/trafficProvider.ts
+++ b/apix-vscode/src/trafficProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { EngineClient } from './engineClient';
 import { HttpTransaction } from './types';
 import { isWebSocketTransaction } from './trafficFormats';
+import { Logger } from './logger';
 
 /**
  * TrafficProvider implements TreeDataProvider for the APiX Traffic tree view.
@@ -19,7 +20,7 @@ export class TrafficProvider implements vscode.TreeDataProvider<TrafficItem | Er
     private captureRetryTimer: ReturnType<typeof setTimeout> | undefined;
     private captureRetryDelayMs = 1000;
 
-    constructor(private readonly client: EngineClient, private readonly output?: vscode.OutputChannel) {
+    constructor(private readonly client: EngineClient, private readonly logger: Logger) {
         const config = vscode.workspace.getConfiguration('apix');
         this.maxItems = config.get<number>('traffic.maxItems', 500);
         this.startCapture();
@@ -61,7 +62,7 @@ export class TrafficProvider implements vscode.TreeDataProvider<TrafficItem | Er
             return txs.map(tx => new TrafficItem(tx));
         } catch (err: any) {
             const msg = err?.message || String(err);
-            this.output?.appendLine(`[APiX] Traffic view error: ${msg}`);
+            this.logger.error('Traffic view error', { message: msg });
             return [new ErrorItem(`Connection lost: ${msg}`, 'apix.refreshTraffic')];
         }
     }
@@ -80,14 +81,14 @@ export class TrafficProvider implements vscode.TreeDataProvider<TrafficItem | Er
                     this.scheduleRefresh();
                 },
                 (err) => {
-                    this.output?.appendLine(`[APiX] Traffic stream error: ${err?.message || err}`);
+                    this.logger.error('Traffic stream error', { message: err?.message || String(err) });
                     this.scheduleCaptureRetry();
                 },
                 () => this.scheduleCaptureRetry()
             );
             this.captureStream = { cancel: () => stream.cancel() };
         } catch (err) {
-            this.output?.appendLine(`[APiX] Could not start traffic stream: ${err}`);
+            this.logger.error('Could not start traffic stream', { message: String(err) });
             this.scheduleCaptureRetry();
         }
     }


### PR DESCRIPTION
## Summary
- add a shared Logger utility with timestamped severity levels
- route extension/provider/engine-process logs through the APiX output channel
- add `apix.logging.verbose` for DEBUG-level logging
- replace ad-hoc appendLine/console logging in extension paths

## Issue
Closes #387
