### PR TITLE
feat(logging): add configurable rotating engine log output

### DIFF
--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -45,7 +45,15 @@ func main() {
 	cfg := config.LoadConfig(cfgPath)
 	format := firstNonEmpty(*logFormat, os.Getenv("LOG_FORMAT"), cfg.LogFormat, "text")
 	level := firstNonEmpty(*logLevel, os.Getenv("LOG_LEVEL"), cfg.LogLevel, "info")
-	logging.InitWithFormatAndLevel(os.Stdout, format, level)
+	logWriter, logCloser, err := logging.OpenWriter(cfg.LogOutput, cfg.LogMaxSizeMB, cfg.LogMaxFiles, cfg.LogCompress)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "apix-engine: initialize log output failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		_ = logCloser.Close()
+	}()
+	logging.InitWithFormatAndLevel(logWriter, format, level)
 
 	// Initialize metrics (Prometheus endpoint + slowlog)
 	metrics.Init(cfg.MetricsEnabled)

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,8 +79,12 @@ type Config struct {
 	HistoryMaxRows    int `yaml:"history_max_rows"`     // 0 = unlimited
 
 	// Logging
-	LogFormat string `yaml:"log_format"` // text|json
-	LogLevel  string `yaml:"log_level"`  // debug|info|warn|error
+	LogFormat    string `yaml:"log_format"`      // text|json
+	LogLevel     string `yaml:"log_level"`       // debug|info|warn|error
+	LogOutput    string `yaml:"log_output"`      // stdout|stderr|/path/to/file.log
+	LogMaxSizeMB int    `yaml:"log_max_size_mb"` // max size per file in MB before rotation
+	LogMaxFiles  int    `yaml:"log_max_files"`   // number of rotated files to keep
+	LogCompress  bool   `yaml:"log_compress"`    // gzip rotated files when true
 
 	// GRPCRateLimitPerSec is the maximum number of gRPC unary calls allowed
 	// per peer address per second. Stream RPCs count as 1 call on open.
@@ -210,6 +214,10 @@ func LoadConfig(path string) *Config {
 		OTelSampleRate:      1.0,
 		LogFormat:           "text",
 		LogLevel:            "info",
+		LogOutput:           "stdout",
+		LogMaxSizeMB:        100,
+		LogMaxFiles:         5,
+		LogCompress:         true,
 		MCPEnabled:          false,
 		MCPPort:             "9093",
 		MCPBindAddress:      "127.0.0.1",

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -17,6 +17,10 @@ mcp_allow_compose: false
 # Logging
 log_format: "text"  # text | json
 log_level: "info"   # debug | info | warn | error
+log_output: "stdout"  # stdout | stderr | /path/to/apix.log
+log_max_size_mb: 100  # rotate after this size (MB)
+log_max_files: 5      # number of rotated files to retain
+log_compress: true    # gzip rotated files
 access_log_enabled: false
 access_log_format: "json"  # json | common | combined
 access_log_path: "stdout"  # stdout | stderr | /path/to/file.log

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,18 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if cfg.AuditLogPath != "stdout" {
 		t.Errorf("AuditLogPath: got %q want stdout", cfg.AuditLogPath)
 	}
+	if cfg.LogOutput != "stdout" {
+		t.Errorf("LogOutput: got %q want stdout", cfg.LogOutput)
+	}
+	if cfg.LogMaxSizeMB != 100 {
+		t.Errorf("LogMaxSizeMB: got %d want 100", cfg.LogMaxSizeMB)
+	}
+	if cfg.LogMaxFiles != 5 {
+		t.Errorf("LogMaxFiles: got %d want 5", cfg.LogMaxFiles)
+	}
+	if !cfg.LogCompress {
+		t.Error("LogCompress: expected true by default")
+	}
 }
 
 func TestLoadConfig_YAMLOverride(t *testing.T) {
@@ -126,6 +138,10 @@ mcp_enabled: true
 mcp_port: "9100"
 log_format: "json"
 log_level: "debug"
+log_output: "/tmp/apix-engine.log"
+log_max_size_mb: 250
+log_max_files: 12
+log_compress: false
 otel_enabled: true
 otel_endpoint: "otel-collector:4317"
 otel_service_name: "apix-dev"
@@ -183,6 +199,18 @@ audit_log_path: "/tmp/apix-audit.log"
 	}
 	if cfg.LogLevel != "debug" {
 		t.Errorf("LogLevel: got %q want debug", cfg.LogLevel)
+	}
+	if cfg.LogOutput != "/tmp/apix-engine.log" {
+		t.Errorf("LogOutput: got %q want /tmp/apix-engine.log", cfg.LogOutput)
+	}
+	if cfg.LogMaxSizeMB != 250 {
+		t.Errorf("LogMaxSizeMB: got %d want 250", cfg.LogMaxSizeMB)
+	}
+	if cfg.LogMaxFiles != 12 {
+		t.Errorf("LogMaxFiles: got %d want 12", cfg.LogMaxFiles)
+	}
+	if cfg.LogCompress {
+		t.Error("LogCompress should be false from YAML override")
 	}
 	if !cfg.OTelEnabled {
 		t.Error("OTelEnabled should be true from YAML override")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -281,6 +281,12 @@ func (c *Config) validateLogging() []error {
 			errs = append(errs, fmt.Errorf("log_level %q is invalid — use debug|info|warn|error", c.LogLevel))
 		}
 	}
+	if c.LogMaxSizeMB < 0 {
+		errs = append(errs, fmt.Errorf("log_max_size_mb must be >= 0 (got %d)", c.LogMaxSizeMB))
+	}
+	if c.LogMaxFiles < 0 {
+		errs = append(errs, fmt.Errorf("log_max_files must be >= 0 (got %d)", c.LogMaxFiles))
+	}
 	if c.AccessLogFormat != "" {
 		switch strings.ToLower(c.AccessLogFormat) {
 		case "json", "common", "combined":

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -9,9 +9,12 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/google/uuid"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // ctxKey is a private type for context keys in this package.
@@ -25,6 +28,9 @@ const RequestIDHeader = "X-Request-ID"
 // global holds the active *slog.Logger with lock-free loads/stores.
 var global atomic.Pointer[slog.Logger]
 var levelVar slog.LevelVar
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
 
 func getLogger() *slog.Logger {
 	if l := global.Load(); l != nil {
@@ -78,6 +84,40 @@ func parseLevel(level string) slog.Level {
 		return slog.LevelError
 	default:
 		return slog.LevelInfo
+	}
+}
+
+// OpenWriter returns a configured log writer based on output target.
+// output supports: "stdout", "stderr", or a file path.
+// File targets use size-based rotation with lumberjack.
+func OpenWriter(output string, maxSizeMB, maxFiles int, compress bool) (io.Writer, io.Closer, error) {
+	target := strings.TrimSpace(strings.ToLower(output))
+	switch target {
+	case "", "stdout":
+		return os.Stdout, noopCloser{}, nil
+	case "stderr":
+		return os.Stderr, noopCloser{}, nil
+	default:
+		dir := filepath.Dir(output)
+		if dir != "." && dir != "" {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, nil, fmt.Errorf("create log directory %q: %w", dir, err)
+			}
+		}
+		if maxSizeMB <= 0 {
+			maxSizeMB = 100
+		}
+		if maxFiles <= 0 {
+			maxFiles = 5
+		}
+		rotator := &lumberjack.Logger{
+			Filename:   output,
+			MaxSize:    maxSizeMB,
+			MaxBackups: maxFiles,
+			Compress:   compress,
+			LocalTime:  true,
+		}
+		return rotator, rotator, nil
 	}
 }
 

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -122,5 +123,32 @@ func TestEnsureRequestIDNilHeader(t *testing.T) {
 	rid := EnsureRequestID(nil)
 	if rid == "" {
 		t.Fatal("expected non-empty request ID for nil header")
+	}
+}
+
+func TestOpenWriterStdStreams(t *testing.T) {
+	writer, closer, err := OpenWriter("stdout", 0, 0, true)
+	if err != nil {
+		t.Fatalf("OpenWriter(stdout): %v", err)
+	}
+	if writer == nil {
+		t.Fatal("expected non-nil stdout writer")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("stdout closer.Close(): %v", err)
+	}
+}
+
+func TestOpenWriterFileRotation(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "apix.log")
+	writer, closer, err := OpenWriter(logPath, 1, 2, true)
+	if err != nil {
+		t.Fatalf("OpenWriter(file): %v", err)
+	}
+	if writer == nil {
+		t.Fatal("expected non-nil file writer")
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatalf("file closer.Close(): %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add config knobs for engine log output target and rotation limits
- support stdout/stderr or rotating file output using lumberjack
- wire cmd/apix-engine startup to use configured log writer
- add config/logging tests for defaults and rotation writer paths

## Issue
Closes #393
