### PR TITLE
feat(metrics): add error rate and latency percentile signals

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	logging "github.com/mnafshin/apix/internal/logging"
+	metrics "github.com/mnafshin/apix/internal/metrics"
 	"io"
 	"net/http"
 	"sync"
@@ -233,7 +234,9 @@ func (e *Engine) PauseRequest(tx *proxy.Transaction) (*proxy.Transaction, proxy.
 	}
 
 	entry := breakpoints.NewPausedEntry(tx.ID, bpID, tx.Request.Raw)
+	pauseStart := time.Now()
 	decision, err := e.bpManager.Pause(pauseCtx, entry)
+	metrics.ObserveBreakpointPause(time.Since(pauseStart).Seconds())
 	if err != nil {
 		// Timeout or context cancellation: forward unchanged rather than dropping.
 		return tx, proxy.ResumeForward, nil
@@ -293,7 +296,9 @@ func (e *Engine) PauseResponse(tx *proxy.Transaction, statusCode int, responseBo
 	}
 
 	entry := breakpoints.NewPausedEntry(tx.ID, bpID, tx.Request.Raw)
+	pauseStart := time.Now()
 	decision, err := e.bpManager.Pause(pauseCtx, entry)
+	metrics.ObserveBreakpointPause(time.Since(pauseStart).Seconds())
 	if err != nil || decision == nil {
 		return tx, proxy.ResumeForward, nil
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,9 +12,17 @@ import (
 var enabled int32
 
 var (
-	requestsTotal     *prometheus.CounterVec
-	requestDuration   *prometheus.HistogramVec
-	activeConnections prometheus.Gauge
+	requestsTotal              *prometheus.CounterVec
+	errorsTotal                *prometheus.CounterVec
+	requestDuration            *prometheus.HistogramVec
+	requestDurationSummary     *prometheus.SummaryVec
+	breakpointsHitTotal        prometheus.Counter
+	breakpointPauseDuration    prometheus.Histogram
+	pluginExecutionDuration    *prometheus.HistogramVec
+	pluginErrorsTotal          *prometheus.CounterVec
+	webSocketFramesTotal       *prometheus.CounterVec
+	webSocketConnectionsActive prometheus.Gauge
+	activeConnections          prometheus.Gauge
 )
 
 // Init enables metrics collection and registers Prometheus collectors when
@@ -40,13 +48,76 @@ func Init(enabledFlag bool) {
 		Buckets:   prometheus.DefBuckets,
 	}, []string{"method", "status_class"})
 
+	requestDurationSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace:  "apix",
+		Name:       "request_duration_summary_seconds",
+		Help:       "Request duration summary in seconds (quantiles: p50,p90,p95,p99)",
+		Objectives: map[float64]float64{0.50: 0.01, 0.90: 0.01, 0.95: 0.005, 0.99: 0.001},
+	}, []string{"method"})
+
+	errorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "apix",
+		Name:      "errors_total",
+		Help:      "Total number of proxied requests resulting in 4xx/5xx",
+	}, []string{"method", "status_class"})
+
+	breakpointsHitTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "apix",
+		Name:      "breakpoints_hit_total",
+		Help:      "Total number of breakpoint pauses triggered",
+	})
+
+	breakpointPauseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "apix",
+		Name:      "breakpoints_pause_duration_seconds",
+		Help:      "Time spent waiting at breakpoints in seconds",
+		Buckets:   prometheus.DefBuckets,
+	})
+
+	pluginExecutionDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "apix",
+		Name:      "plugin_execution_duration_seconds",
+		Help:      "Plugin execution duration in seconds",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"plugin_name", "phase"})
+
+	pluginErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "apix",
+		Name:      "plugin_errors_total",
+		Help:      "Total number of plugin execution errors",
+	}, []string{"plugin_name", "phase"})
+
+	webSocketFramesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "apix",
+		Name:      "websocket_frames_total",
+		Help:      "Total number of proxied websocket frames",
+	}, []string{"direction"})
+
+	webSocketConnectionsActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "apix",
+		Name:      "websocket_connections_active",
+		Help:      "Number of active proxied websocket connections",
+	})
+
 	activeConnections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "apix",
 		Name:      "active_connections",
 		Help:      "Number of active proxied connections",
 	})
 
-	prometheus.MustRegister(requestsTotal, requestDuration, activeConnections)
+	prometheus.MustRegister(
+		requestsTotal,
+		errorsTotal,
+		requestDuration,
+		requestDurationSummary,
+		breakpointsHitTotal,
+		breakpointPauseDuration,
+		pluginExecutionDuration,
+		pluginErrorsTotal,
+		webSocketFramesTotal,
+		webSocketConnectionsActive,
+		activeConnections,
+	)
 	atomic.StoreInt32(&enabled, 1)
 }
 
@@ -75,4 +146,52 @@ func ObserveRequest(method string, statusCode int, durationSec float64) {
 	statusClass := fmt.Sprintf("%dxx", statusCode/100)
 	requestsTotal.WithLabelValues(method, statusClass).Inc()
 	requestDuration.WithLabelValues(method, statusClass).Observe(durationSec)
+	requestDurationSummary.WithLabelValues(method).Observe(durationSec)
+	if statusCode >= 400 {
+		errorsTotal.WithLabelValues(method, statusClass).Inc()
+	}
+}
+
+// ObserveBreakpointPause records a breakpoint hit and pause duration.
+func ObserveBreakpointPause(durationSec float64) {
+	if atomic.LoadInt32(&enabled) != 1 {
+		return
+	}
+	breakpointsHitTotal.Inc()
+	breakpointPauseDuration.Observe(durationSec)
+}
+
+// ObservePluginExecution records plugin execution latency and optional errors.
+func ObservePluginExecution(pluginName, phase string, durationSec float64, hadError bool) {
+	if atomic.LoadInt32(&enabled) != 1 {
+		return
+	}
+	pluginExecutionDuration.WithLabelValues(pluginName, phase).Observe(durationSec)
+	if hadError {
+		pluginErrorsTotal.WithLabelValues(pluginName, phase).Inc()
+	}
+}
+
+// IncWebSocketFrame increments websocket frame counter by direction.
+func IncWebSocketFrame(direction string) {
+	if atomic.LoadInt32(&enabled) != 1 {
+		return
+	}
+	webSocketFramesTotal.WithLabelValues(direction).Inc()
+}
+
+// IncWebSocketActive increments active websocket connection gauge.
+func IncWebSocketActive() {
+	if atomic.LoadInt32(&enabled) != 1 {
+		return
+	}
+	webSocketConnectionsActive.Inc()
+}
+
+// DecWebSocketActive decrements active websocket connection gauge.
+func DecWebSocketActive() {
+	if atomic.LoadInt32(&enabled) != 1 {
+		return
+	}
+	webSocketConnectionsActive.Dec()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,11 +16,43 @@ func TestInitRegistersCollectors(t *testing.T) {
 	if requestDuration != nil {
 		prometheus.Unregister(requestDuration)
 	}
+	if requestDurationSummary != nil {
+		prometheus.Unregister(requestDurationSummary)
+	}
+	if errorsTotal != nil {
+		prometheus.Unregister(errorsTotal)
+	}
+	if breakpointsHitTotal != nil {
+		prometheus.Unregister(breakpointsHitTotal)
+	}
+	if breakpointPauseDuration != nil {
+		prometheus.Unregister(breakpointPauseDuration)
+	}
+	if pluginExecutionDuration != nil {
+		prometheus.Unregister(pluginExecutionDuration)
+	}
+	if pluginErrorsTotal != nil {
+		prometheus.Unregister(pluginErrorsTotal)
+	}
+	if webSocketFramesTotal != nil {
+		prometheus.Unregister(webSocketFramesTotal)
+	}
+	if webSocketConnectionsActive != nil {
+		prometheus.Unregister(webSocketConnectionsActive)
+	}
 	if activeConnections != nil {
 		prometheus.Unregister(activeConnections)
 	}
 	requestsTotal = nil
 	requestDuration = nil
+	requestDurationSummary = nil
+	errorsTotal = nil
+	breakpointsHitTotal = nil
+	breakpointPauseDuration = nil
+	pluginExecutionDuration = nil
+	pluginErrorsTotal = nil
+	webSocketFramesTotal = nil
+	webSocketConnectionsActive = nil
 	activeConnections = nil
 
 	// Initialize metrics and assert registration.
@@ -32,34 +64,76 @@ func TestInitRegistersCollectors(t *testing.T) {
 	// Exercise the vector metrics so they appear in the default registry (CounterVec/HistogramVec
 	// do not expose metric families until a label combination is created).
 	ObserveRequest("GET", 200, 0.123)
+	ObserveRequest("POST", 500, 0.456)
+	ObserveBreakpointPause(0.2)
+	ObservePluginExecution("mock_response", "request", 0.03, false)
+	ObservePluginExecution("mock_response", "response", 0.02, true)
+	IncWebSocketFrame("client")
+	IncWebSocketActive()
+	DecWebSocketActive()
 
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
 		t.Fatalf("prometheus gather failed: %v", err)
 	}
 
-	var foundReq, foundDur, foundActive bool
+	var foundReq, foundErr, foundDur, foundDurSummary, foundActive bool
+	var foundBreakpointHits, foundBreakpointPause, foundPluginDur, foundPluginErr bool
+	var foundWSFrames, foundWSActive bool
 	for _, mf := range mfs {
 		switch mf.GetName() {
 		case "apix_requests_total":
 			foundReq = true
+		case "apix_errors_total":
+			foundErr = true
 		case "apix_request_duration_seconds":
 			foundDur = true
+		case "apix_request_duration_summary_seconds":
+			foundDurSummary = true
+		case "apix_breakpoints_hit_total":
+			foundBreakpointHits = true
+		case "apix_breakpoints_pause_duration_seconds":
+			foundBreakpointPause = true
+		case "apix_plugin_execution_duration_seconds":
+			foundPluginDur = true
+		case "apix_plugin_errors_total":
+			foundPluginErr = true
+		case "apix_websocket_frames_total":
+			foundWSFrames = true
+		case "apix_websocket_connections_active":
+			foundWSActive = true
 		case "apix_active_connections":
 			foundActive = true
 		}
 	}
 
-	if !foundReq || !foundDur || !foundActive {
-		t.Fatalf("expected metrics registered: requests=%v duration=%v active=%v", foundReq, foundDur, foundActive)
+	if !foundReq || !foundErr || !foundDur || !foundDurSummary || !foundBreakpointHits || !foundBreakpointPause || !foundPluginDur || !foundPluginErr || !foundWSFrames || !foundWSActive || !foundActive {
+		t.Fatalf("expected metrics registered: req=%v err=%v dur=%v summary=%v bpHits=%v bpPause=%v pluginDur=%v pluginErr=%v wsFrames=%v wsActive=%v active=%v",
+			foundReq, foundErr, foundDur, foundDurSummary, foundBreakpointHits, foundBreakpointPause, foundPluginDur, foundPluginErr, foundWSFrames, foundWSActive, foundActive)
 	}
 
 	// Cleanup so other tests aren't affected.
 	prometheus.Unregister(requestsTotal)
+	prometheus.Unregister(errorsTotal)
 	prometheus.Unregister(requestDuration)
+	prometheus.Unregister(requestDurationSummary)
+	prometheus.Unregister(breakpointsHitTotal)
+	prometheus.Unregister(breakpointPauseDuration)
+	prometheus.Unregister(pluginExecutionDuration)
+	prometheus.Unregister(pluginErrorsTotal)
+	prometheus.Unregister(webSocketFramesTotal)
+	prometheus.Unregister(webSocketConnectionsActive)
 	prometheus.Unregister(activeConnections)
 	atomic.StoreInt32(&enabled, 0)
 	requestsTotal = nil
 	requestDuration = nil
+	requestDurationSummary = nil
+	errorsTotal = nil
+	breakpointsHitTotal = nil
+	breakpointPauseDuration = nil
+	pluginExecutionDuration = nil
+	pluginErrorsTotal = nil
+	webSocketFramesTotal = nil
+	webSocketConnectionsActive = nil
 	activeConnections = nil
 }

--- a/internal/proxy/plugin_runner.go
+++ b/internal/proxy/plugin_runner.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
+	"time"
 
 	logging "github.com/mnafshin/apix/internal/logging"
+	metrics "github.com/mnafshin/apix/internal/metrics"
 	"github.com/mnafshin/apix/pkg/plugins"
 )
 
@@ -18,6 +21,8 @@ func runPluginRequest(ctx context.Context, chain any, req *plugins.ProxyRequest,
 	if !ok || rp == nil {
 		return req, nil
 	}
+	pluginName := pluginMetricName(chain)
+	start := time.Now()
 	var runErr error
 	func() {
 		defer func() {
@@ -33,6 +38,7 @@ func runPluginRequest(ctx context.Context, chain any, req *plugins.ProxyRequest,
 		}
 		req = modified
 	}()
+	metrics.ObservePluginExecution(pluginName, "request", time.Since(start).Seconds(), runErr != nil)
 	if runErr != nil {
 		return nil, runErr
 	}
@@ -48,6 +54,8 @@ func runPluginResponse(ctx context.Context, chain any, req *plugins.ProxyRequest
 	if !ok || rp == nil {
 		return resp, nil
 	}
+	pluginName := pluginMetricName(chain)
+	start := time.Now()
 	var runErr error
 	func() {
 		defer func() {
@@ -65,10 +73,25 @@ func runPluginResponse(ctx context.Context, chain any, req *plugins.ProxyRequest
 			resp = modResp
 		}
 	}()
+	metrics.ObservePluginExecution(pluginName, "response", time.Since(start).Seconds(), runErr != nil)
 	if runErr != nil {
 		return nil, runErr
 	}
 	return resp, nil
+}
+
+func pluginMetricName(chain any) string {
+	if chain == nil {
+		return "unknown"
+	}
+	t := reflect.TypeOf(chain)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if name := t.Name(); name != "" {
+		return name
+	}
+	return "unknown"
 }
 
 // drainPluginResponseBody reads the response body from a plugin-modified response.

--- a/internal/proxy/websocket.go
+++ b/internal/proxy/websocket.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	logging "github.com/mnafshin/apix/internal/logging"
+	metrics "github.com/mnafshin/apix/internal/metrics"
 	"io"
 	"net"
 	"net/http"
@@ -101,6 +102,8 @@ func copyHeadersExcluding(src http.Header, exclude ...string) http.Header {
 func relayWebSocket(ctx context.Context, engine TransactionStore, transactionID string, clientConn, upstreamConn *websocket.Conn) {
 	relayCtx, cancelRelay := context.WithCancel(ctx)
 	defer cancelRelay()
+	metrics.IncWebSocketActive()
+	defer metrics.DecWebSocketActive()
 
 	var forwardCloseOnce sync.Once
 	var shutdownOnce sync.Once
@@ -194,6 +197,7 @@ func isExpectedWebSocketClose(err error) bool {
 }
 
 func recordWebSocketFrame(ctx context.Context, engine TransactionStore, transactionID, direction string, opcode int, payload []byte) {
+	metrics.IncWebSocketFrame(direction)
 	if engine == nil {
 		return
 	}


### PR DESCRIPTION
## Summary\n- add `apix_errors_total` and `apix_request_duration_summary_seconds`\n- add breakpoint hit/pause metrics\n- add plugin execution duration + error metrics\n- add websocket frame + active connection metrics\n\n## Issue\nCloses #391\n