### PR TITLE
perf: add benchmark regression gate and SLO thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,22 @@ jobs:
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
 
+  performance:
+    name: Benchmark Regression Gate
+    runs-on: ubuntu-latest
+    needs: [go]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Performance threshold check
+        run: make perf-check
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [go]
+    needs: [go, performance]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cli test lint proto clean package-ext install-ext help
+.PHONY: build build-cli test lint proto clean package-ext install-ext bench perf-check help
 
 # Default Go binary output
 ENGINE_BIN := apix-engine
@@ -17,6 +17,15 @@ build-cli:
 # Go tests
 test:
 	go test ./... -count=1
+
+# Run benchmark suite
+bench:
+	go test ./internal/storage ./internal/pluginrt ./internal/proxy ./internal/breakpoints \
+		-run '^$$' -bench 'BenchmarkStorage_SaveRequest|BenchmarkStorage_ListTransactions|BenchmarkPluginRuntime_RunRequest_5Plugins|BenchmarkHTTPProxy_Parallel|BenchmarkBreakpoints_Evaluate' -benchmem -count=1
+
+# Check benchmark regression thresholds
+perf-check:
+	bash scripts/perf/check_benchmarks.sh
 
 # Go tests with coverage
 test-coverage:
@@ -86,6 +95,8 @@ help:
 	@echo "  build          - Build engine binary"
 	@echo "  build-cli      - Build apix (and apix-cli compatibility alias)"
 	@echo "  test           - Run Go tests"
+	@echo "  bench          - Run benchmark suite for core performance paths"
+	@echo "  perf-check     - Run benchmark regression threshold checks"
 	@echo "  test-coverage  - Run Go tests with coverage report"
 	@echo "  test-one       - Run single test (TEST=name PKG=path)"
 	@echo "  lint           - Run go vet"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -84,6 +84,7 @@ Comprehensive testing coverage:
 - [`testing/testing_resilience.md`](testing/testing_resilience.md) — fault injection and resilience testing
 - [`testing/testing_stateful_workflows.md`](testing/testing_stateful_workflows.md) — end-to-end stateful workflows
 - [`testing/testing_mcp_suite.md`](testing/testing_mcp_suite.md) — MCP integration tests
+- [`testing/testing_performance_regression.md`](testing/testing_performance_regression.md) — benchmark thresholds and regression gate
 
 ---
 

--- a/docs/RELEASE_GATE.md
+++ b/docs/RELEASE_GATE.md
@@ -7,6 +7,7 @@ This checklist defines required validation before cutting a release tag.
 | Surface | Required checks | Blocking |
 |---|---|---|
 | Engine + core Go packages | `go build ./...`, `go vet ./...`, `go test ./internal/... -race` | Yes |
+| Performance regression budget | `make perf-check` | Yes |
 | End-to-end behavior | `go test ./tests/e2e/...` | Yes |
 | Proto contract | `buf lint`, `buf breaking` against `main` | Yes |
 | VS Code extension | `npm ci`, `npx tsc --noEmit`, `npm run compile` | Yes |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -226,17 +226,16 @@ go test -bench=. -benchmem ./internal/proxy ./internal/storage ./internal/breakp
 # Run one benchmark
 go test -bench=BenchmarkStorage_SaveRequest -benchmem ./internal/storage
 
-# Compare with baseline
-go test -bench=. -benchmem ./internal/proxy -benchstat=old.txt > new.txt
-# (requires benchstat tool)
+# CI regression gate with explicit thresholds
+make perf-check
 ```
 
 **Guidelines:**
 - Use real components (proxy, storage, engine) not mocks
 - Reset timer after setup: `b.ResetTimer()`
 - Allocations matter: `-benchmem` shows allocs/op
-- Track historical baseline in CI artifacts before asserting performance targets
-- Increases >10% should be investigated
+- Thresholds are maintained in `scripts/perf/thresholds.tsv`
+- Any threshold violation is a release-blocking regression
 
 ## Infrastructure & Helpers
 

--- a/docs/testing/testing_performance_regression.md
+++ b/docs/testing/testing_performance_regression.md
@@ -1,0 +1,34 @@
+# Performance regression thresholds
+
+APiX keeps a small, deterministic benchmark gate for critical paths so regressions are detected before release.
+
+## Scope
+
+Current CI-gated benchmarks:
+
+- `BenchmarkStorage_SaveRequest`
+- `BenchmarkStorage_ListTransactions`
+- `BenchmarkPluginRuntime_RunRequest_5Plugins`
+- `BenchmarkHTTPProxy_Parallel`
+- `BenchmarkBreakpoints_Evaluate`
+
+Thresholds are tracked in: `scripts/perf/thresholds.tsv`
+
+## Run locally
+
+```bash
+make bench
+make perf-check
+```
+
+`make perf-check` runs the benchmark set and fails when `ns/op` or `allocs/op` exceed the configured max for any benchmark.
+
+## Updating thresholds
+
+Only update thresholds when:
+
+1. A real improvement or unavoidable architecture tradeoff is intentionally introduced.
+2. The benchmark was run repeatedly on comparable hardware and noise is ruled out.
+3. The PR description explains why the threshold change is justified.
+
+If performance improves, tighten thresholds in the same PR.

--- a/scripts/perf/check_benchmarks.sh
+++ b/scripts/perf/check_benchmarks.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+THRESHOLDS="$ROOT_DIR/scripts/perf/thresholds.tsv"
+
+if [[ ! -f "$THRESHOLDS" ]]; then
+  echo "missing thresholds file: $THRESHOLDS" >&2
+  exit 1
+fi
+
+TMP_RAW="$(mktemp)"
+TMP_PARSED="$(mktemp)"
+trap 'rm -f "$TMP_RAW" "$TMP_PARSED"' EXIT
+
+cd "$ROOT_DIR"
+
+go test ./internal/storage ./internal/pluginrt ./internal/proxy ./internal/breakpoints \
+  -run '^$' \
+  -bench 'BenchmarkStorage_SaveRequest|BenchmarkStorage_ListTransactions|BenchmarkPluginRuntime_RunRequest_5Plugins|BenchmarkHTTPProxy_Parallel|BenchmarkBreakpoints_Evaluate' \
+  -benchmem -count=1 | tee "$TMP_RAW"
+
+awk '
+  /^Benchmark/ {
+    name=$1
+    sub(/-[0-9]+$/, "", name)
+    ns=""
+    allocs=""
+    for (i=1; i<=NF; i++) {
+      if ($i=="ns/op" && i>1) { ns=$(i-1) }
+      if ($i=="allocs/op" && i>1) { allocs=$(i-1) }
+    }
+    if (ns!="") {
+      print name "\t" ns "\t" allocs
+    }
+  }
+' "$TMP_RAW" > "$TMP_PARSED"
+
+echo
+echo "Benchmark threshold checks:"
+
+status=0
+while IFS=$'\t' read -r name max_ns max_allocs; do
+  [[ -z "${name:-}" || "${name:0:1}" == "#" ]] && continue
+
+  row="$(awk -F '\t' -v target="$name" '$1==target {print $0}' "$TMP_PARSED" | tail -n 1)"
+  if [[ -z "$row" ]]; then
+    echo "FAIL: $name missing from benchmark output"
+    status=1
+    continue
+  fi
+
+  measured_ns="$(echo "$row" | awk -F '\t' '{print $2}')"
+  measured_allocs="$(echo "$row" | awk -F '\t' '{print $3}')"
+  ns_ok=0
+  alloc_ok=0
+  awk "BEGIN {exit !($measured_ns <= $max_ns)}" && ns_ok=1 || true
+  awk "BEGIN {exit !($measured_allocs <= $max_allocs)}" && alloc_ok=1 || true
+
+  ns_label="PASS"
+  alloc_label="PASS"
+  if [[ $ns_ok -ne 1 ]]; then
+    ns_label="FAIL"
+    status=1
+  fi
+  if [[ $alloc_ok -ne 1 ]]; then
+    alloc_label="FAIL"
+    status=1
+  fi
+
+  echo "$name  ns/op=$measured_ns (max=$max_ns, $ns_label)  allocs/op=$measured_allocs (max=$max_allocs, $alloc_label)"
+done < "$THRESHOLDS"
+
+if [[ $status -ne 0 ]]; then
+  echo
+  echo "performance regression threshold check failed" >&2
+  exit 1
+fi

--- a/scripts/perf/thresholds.tsv
+++ b/scripts/perf/thresholds.tsv
@@ -1,0 +1,6 @@
+# benchmark_name	max_ns_per_op	max_allocs_per_op
+BenchmarkStorage_SaveRequest	200000	64
+BenchmarkStorage_ListTransactions	1200000	7000
+BenchmarkPluginRuntime_RunRequest_5Plugins	1500	12
+BenchmarkHTTPProxy_Parallel	800000	400
+BenchmarkBreakpoints_Evaluate	100000	80


### PR DESCRIPTION
## Summary\n- add a deterministic performance regression gate via `make perf-check`\n- define explicit benchmark budgets (ns/op and allocs/op) in `scripts/perf/thresholds.tsv`\n- wire performance checks into CI and release gate docs\n- add focused documentation for benchmark policy and contributor workflow\n\nCloses #463