### PR TITLE
fix(ci): restore green pipelines for integration and lint/docs

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -2565,15 +2565,19 @@ func (a *app) cmdDoctorBundle(args []string) error {
 	}
 
 	payload, engine, _ := a.collectDoctorSnapshot()
-	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+	cleanPath := filepath.Clean(filePath)
+	if err := os.MkdirAll(filepath.Dir(cleanPath), 0o750); err != nil {
 		return fmt.Errorf("create diagnostic bundle directory: %w", err)
 	}
 
-	outFile, err := os.Create(filePath)
+	//nolint:gosec // output path is intentionally user-provided for local diagnostic export
+	outFile, err := os.Create(cleanPath)
 	if err != nil {
 		return fmt.Errorf("create diagnostic bundle: %w", err)
 	}
-	defer outFile.Close()
+	defer func() {
+		_ = outFile.Close()
+	}()
 
 	zw := zip.NewWriter(outFile)
 
@@ -2617,9 +2621,7 @@ func (a *app) cmdDoctorBundle(args []string) error {
 	if err := zw.Close(); err != nil {
 		return err
 	}
-	if err := outFile.Close(); err != nil {
-		return err
-	}
+	filePath = cleanPath
 
 	if a.opts.output == "json" {
 		return emitJSON(a.out, map[string]any{

--- a/cmd/apix-cli/tui/run.go
+++ b/cmd/apix-cli/tui/run.go
@@ -216,14 +216,14 @@ func renderDetails(table *tview.Table, details *tview.TextView, items []trafficI
 	}
 	sort.Strings(headerKeys)
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("[yellow]ID:[-] %s\n", item.id))
-	sb.WriteString(fmt.Sprintf("[yellow]Request ID:[-] %s\n", item.requestID))
-	sb.WriteString(fmt.Sprintf("[yellow]Method:[-] %s\n", item.method))
-	sb.WriteString(fmt.Sprintf("[yellow]URL:[-] %s\n", item.url))
-	sb.WriteString(fmt.Sprintf("[yellow]Timestamp:[-] %s\n\n", item.timestamp))
+	_, _ = fmt.Fprintf(&sb, "[yellow]ID:[-] %s\n", item.id)
+	_, _ = fmt.Fprintf(&sb, "[yellow]Request ID:[-] %s\n", item.requestID)
+	_, _ = fmt.Fprintf(&sb, "[yellow]Method:[-] %s\n", item.method)
+	_, _ = fmt.Fprintf(&sb, "[yellow]URL:[-] %s\n", item.url)
+	_, _ = fmt.Fprintf(&sb, "[yellow]Timestamp:[-] %s\n\n", item.timestamp)
 	sb.WriteString("[yellow]Headers[-]\n")
 	for _, k := range headerKeys {
-		sb.WriteString(fmt.Sprintf("%s: %s\n", k, item.headers[k]))
+		_, _ = fmt.Fprintf(&sb, "%s: %s\n", k, item.headers[k])
 	}
 	if item.body != "" {
 		sb.WriteString("\n[yellow]Body[-]\n")

--- a/docs/contracts/config-keys.txt
+++ b/docs/contracts/config-keys.txt
@@ -15,8 +15,12 @@ http_read_header_timeout_sec
 http_read_timeout_sec
 http_write_timeout_sec
 idle_conn_timeout_sec
+log_compress
 log_format
 log_level
+log_max_files
+log_max_size_mb
+log_output
 max_body_size_mb
 max_header_value_bytes
 max_headers_per_request

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -28,6 +28,7 @@ const RequestIDHeader = "X-Request-ID"
 // global holds the active *slog.Logger with lock-free loads/stores.
 var global atomic.Pointer[slog.Logger]
 var levelVar slog.LevelVar
+
 type noopCloser struct{}
 
 func (noopCloser) Close() error { return nil }
@@ -100,7 +101,7 @@ func OpenWriter(output string, maxSizeMB, maxFiles int, compress bool) (io.Write
 	default:
 		dir := filepath.Dir(output)
 		if dir != "." && dir != "" {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
+			if err := os.MkdirAll(dir, 0o750); err != nil {
 				return nil, nil, fmt.Errorf("create log directory %q: %w", dir, err)
 			}
 		}

--- a/tests/integration/testcontainers_test.go
+++ b/tests/integration/testcontainers_test.go
@@ -210,7 +210,7 @@ func TestContainers_ProxyCapturesHTTPBinRequest(t *testing.T) {
 	// Give the engine a moment to persist.
 	time.Sleep(300 * time.Millisecond)
 
-	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0)
+	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0, "")
 	if err != nil {
 		t.Fatalf("ListTransactions: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestContainers_ProxyCapturesPostBody(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0)
+	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0, "")
 	if err != nil {
 		t.Fatalf("ListTransactions: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestContainers_ReplayFromStoredTransaction(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0)
+	txs, _, err := stack.db.ListTransactions(10, 0, "", "", 0, "")
 	if err != nil || len(txs) == 0 {
 		t.Fatalf("no stored transactions: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestContainers_MultipleRequestsDifferentEndpoints(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	txs, _, err := stack.db.ListTransactions(20, 0, "", "", 0)
+	txs, _, err := stack.db.ListTransactions(20, 0, "", "", 0, "")
 	if err != nil {
 		t.Fatalf("ListTransactions: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update integration testcontainers calls to match the current ListTransactions signature
- fix current lint blockers in doctor bundle + TUI formatting paths
- sync config keys contract snapshot used by docs-sync

## Validation
- make lint
- make test
- go test ./tests/integration -tags=integration -run TestContainers -c