### PR TITLE
feat(storage): version and enforce DB migrations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -51,3 +51,11 @@ Check version compatibility in [`docs/REFERENCE/compatibility-matrix.md`](docs/R
 4. Start old version and run `./apix-cli status`.
 
 If rollback is required because of compatibility, keep your previous version pinned and open an issue with the failing workflow and versions.
+
+## Storage schema compatibility
+
+- APiX storage upgrades are applied at startup using ordered schema migrations.
+- If your DB schema is newer than the running APiX binary supports, startup fails fast with a compatibility error.
+- For rollback across storage-changing releases, restore both binary and DB backup together.
+
+See [`docs/REFERENCE/storage-migrations.md`](docs/REFERENCE/storage-migrations.md) for migration rules.

--- a/docs/ARCHITECTURE/storage_replay.md
+++ b/docs/ARCHITECTURE/storage_replay.md
@@ -33,7 +33,10 @@ Indexes include timestamp/method/url and websocket transaction lookups to keep l
 - `synchronous=NORMAL`
 - `busy_timeout=5000`
 - `foreign_keys=ON`
-- schema bootstrap + lightweight migrations
+- schema bootstrap + versioned migrations (`PRAGMA user_version`)
+
+Migration policy and compatibility guarantees are documented in
+[`docs/REFERENCE/storage-migrations.md`](../REFERENCE/storage-migrations.md).
 
 In-memory mode (`:memory:`) pins connection count to 1 so tests share one database.
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -69,6 +69,7 @@ Stable contracts and schemas:
 - [`REFERENCE/glossary.md`](REFERENCE/glossary.md) — terminology and concepts
 - [`REFERENCE/OTEL.md`](REFERENCE/OTEL.md) — OpenTelemetry and Prometheus metrics
 - [`REFERENCE/plugin-sdk.md`](REFERENCE/plugin-sdk.md) — plugin interfaces and lifecycle
+- [`REFERENCE/storage-migrations.md`](REFERENCE/storage-migrations.md) — storage schema versioning and migration compatibility
 - [`REFERENCE/versioning-policy.md`](REFERENCE/versioning-policy.md) — semantic versioning, support window, and deprecation rules
 - [`REFERENCE/stability-policy.md`](REFERENCE/stability-policy.md) — stable/experimental/deprecated policy
 

--- a/docs/REFERENCE/storage-migrations.md
+++ b/docs/REFERENCE/storage-migrations.md
@@ -1,0 +1,30 @@
+# Storage Migration Policy
+
+APiX uses SQLite `PRAGMA user_version` plus ordered code migrations to keep storage upgrades predictable.
+
+## Versioning contract
+
+1. Storage migrations are versioned as contiguous integers (`1, 2, 3, ...`).
+2. Each migration is applied exactly once at startup when opening the DB.
+3. Startup fails fast if a DB has a newer schema version than the running binary supports.
+
+## Ordering and safety rules
+
+1. Migrations must be strictly increasing and contiguous.
+2. Each migration runs in a transaction.
+3. `user_version` is updated only after migration steps succeed.
+4. If a migration fails, startup fails and no partial version bump is committed.
+
+## Compatibility expectations
+
+- **Forward compatibility (new binary on old DB):** supported through migrations.
+- **Backward compatibility (old binary on new DB):** not supported; APiX returns a clear startup error.
+
+## Contributor workflow
+
+When changing storage schema:
+
+1. Add a new migration entry in `internal/storage/migrations.go`.
+2. Bump `storageSchemaVersion`.
+3. Add tests for upgrade and failure behavior in `internal/storage/storage_test.go`.
+4. Update release notes/upgrade guidance when migration impacts users.

--- a/internal/storage/migrations.go
+++ b/internal/storage/migrations.go
@@ -1,0 +1,123 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const storageSchemaVersion = 1
+
+type storageMigration struct {
+	version int
+	name    string
+	up      func(tx *sql.Tx) error
+}
+
+var storageMigrations = []storageMigration{
+	{
+		version: 1,
+		name:    "breakpoints-match-extensions",
+		up: func(tx *sql.Tx) error {
+			ddls := []string{
+				`ALTER TABLE breakpoints ADD COLUMN header_name TEXT NOT NULL DEFAULT ''`,
+				`ALTER TABLE breakpoints ADD COLUMN header_value TEXT NOT NULL DEFAULT ''`,
+				`ALTER TABLE breakpoints ADD COLUMN body_pattern TEXT NOT NULL DEFAULT ''`,
+				`ALTER TABLE breakpoints ADD COLUMN status_codes TEXT NOT NULL DEFAULT '[]'`,
+			}
+			for _, ddl := range ddls {
+				if err := execMigrationDDL(tx, ddl); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
+}
+
+func applyStorageMigrations(db *sql.DB) error {
+	if err := validateStorageMigrations(storageMigrations); err != nil {
+		return err
+	}
+
+	currentVersion, err := readStorageUserVersion(db)
+	if err != nil {
+		return err
+	}
+	if currentVersion > storageSchemaVersion {
+		return fmt.Errorf(
+			"database schema version %d is newer than this binary supports (%d); upgrade APiX",
+			currentVersion, storageSchemaVersion,
+		)
+	}
+
+	for _, migration := range storageMigrations {
+		if migration.version <= currentVersion {
+			continue
+		}
+		if err := runStorageMigration(db, migration); err != nil {
+			return err
+		}
+		currentVersion = migration.version
+	}
+	return nil
+}
+
+func validateStorageMigrations(migrations []storageMigration) error {
+	last := 0
+	for _, migration := range migrations {
+		if migration.version <= last {
+			return fmt.Errorf("storage migrations must be strictly increasing: got %d after %d", migration.version, last)
+		}
+		if migration.version != last+1 {
+			return fmt.Errorf("storage migrations must be contiguous: missing version %d", last+1)
+		}
+		if migration.up == nil {
+			return fmt.Errorf("storage migration v%d (%s) has no up function", migration.version, migration.name)
+		}
+		last = migration.version
+	}
+	if last != storageSchemaVersion {
+		return fmt.Errorf("storage schema version mismatch: latest migration v%d != storageSchemaVersion v%d", last, storageSchemaVersion)
+	}
+	return nil
+}
+
+func runStorageMigration(db *sql.DB, migration storageMigration) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin storage migration v%d (%s): %w", migration.version, migration.name, err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	if err := migration.up(tx); err != nil {
+		return fmt.Errorf("apply storage migration v%d (%s): %w", migration.version, migration.name, err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf("PRAGMA user_version = %d", migration.version)); err != nil {
+		return fmt.Errorf("set storage schema version v%d: %w", migration.version, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit storage migration v%d (%s): %w", migration.version, migration.name, err)
+	}
+	return nil
+}
+
+func readStorageUserVersion(db *sql.DB) (int, error) {
+	var version int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		return 0, fmt.Errorf("read storage schema version: %w", err)
+	}
+	return version, nil
+}
+
+func execMigrationDDL(tx *sql.Tx, ddl string) error {
+	if _, err := tx.Exec(ddl); err != nil {
+		if strings.Contains(err.Error(), "duplicate column name") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // register "sqlite" driver
@@ -73,27 +72,12 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("apply schema: %w", err)
 		}
 	}
-	if err := ensureBreakpointColumns(db); err != nil {
+	if err := applyStorageMigrations(db); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
 
 	return &DB{db: db}, nil
-}
-
-func ensureBreakpointColumns(db *sql.DB) error {
-	ddls := []string{
-		`ALTER TABLE breakpoints ADD COLUMN header_name TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE breakpoints ADD COLUMN header_value TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE breakpoints ADD COLUMN body_pattern TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE breakpoints ADD COLUMN status_codes TEXT NOT NULL DEFAULT '[]'`,
-	}
-	for _, ddl := range ddls {
-		if _, err := db.Exec(ddl); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
-			return fmt.Errorf("migrate breakpoints columns: %w", err)
-		}
-	}
-	return nil
 }
 
 // Close closes the underlying database connection.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -64,6 +65,112 @@ func TestSchemaCreatesHistoryIndexes(t *testing.T) {
 		if !indexes[idx] {
 			t.Errorf("missing index %q", idx)
 		}
+	}
+}
+
+func TestOpenSetsStorageSchemaVersion(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	var got int
+	if err := db.db.QueryRow("PRAGMA user_version").Scan(&got); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if got != storageSchemaVersion {
+		t.Fatalf("schema version: got %d want %d", got, storageSchemaVersion)
+	}
+}
+
+func TestOpenMigratesLegacyBreakpointsSchema(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	if _, err := raw.Exec(`CREATE TABLE breakpoints (
+		id          TEXT PRIMARY KEY,
+		url_pattern TEXT NOT NULL,
+		methods     TEXT NOT NULL DEFAULT '[]',
+		enabled     INTEGER NOT NULL DEFAULT 1,
+		label       TEXT NOT NULL DEFAULT '',
+		created_at  INTEGER NOT NULL
+	);`); err != nil {
+		t.Fatalf("create legacy breakpoints table: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open migrated db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.db.Query(`PRAGMA table_info(breakpoints)`)
+	if err != nil {
+		t.Fatalf("query table_info(breakpoints): %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := map[string]bool{}
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			typ       string
+			notNull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &dfltValue, &pk); err != nil {
+			t.Fatalf("scan table_info row: %v", err)
+		}
+		cols[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate table_info rows: %v", err)
+	}
+
+	required := []string{"header_name", "header_value", "body_pattern", "status_codes"}
+	for _, name := range required {
+		if !cols[name] {
+			t.Fatalf("expected migrated column %q to exist", name)
+		}
+	}
+
+	var gotVersion int
+	if err := db.db.QueryRow("PRAGMA user_version").Scan(&gotVersion); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if gotVersion != storageSchemaVersion {
+		t.Fatalf("schema version after migration: got %d want %d", gotVersion, storageSchemaVersion)
+	}
+}
+
+func TestOpenRejectsFutureStorageSchemaVersion(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "future.db")
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open future db: %v", err)
+	}
+	if _, err := raw.Exec(fmt.Sprintf("PRAGMA user_version = %d", storageSchemaVersion+1)); err != nil {
+		t.Fatalf("set future user_version: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close future db: %v", err)
+	}
+
+	_, err = Open(dbPath)
+	if err == nil {
+		t.Fatal("expected future schema version to fail open")
+	}
+	if !strings.Contains(err.Error(), "newer than this binary supports") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit storage migration framework with ordered/contiguous versions and PRAGMA user_version
- enforce fail-fast behavior when DB schema version is newer than the running binary
- migrate legacy breakpoints schema through the versioned startup migration path
- add tests for version stamping, legacy migration, and future-version rejection
- document migration guarantees and upgrade compatibility guidance

Closes #467