### PR TITLE
feat(cli): add learn command for draft OpenAPI inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Then run the extension from VS Code (`Run Extension`), or package/install from `
 - `send`
 - `templates save|list|delete|execute`
 - `replay`
+- `learn`
 - `cert`, `config`, `doctor`, `tui`, `completion`
 
 Use `apix help` for details.

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fatih/color"
 	tuimode "github.com/mnafshin/apix/cmd/apix-cli/tui"
 	"github.com/mnafshin/apix/internal/config"
+	"github.com/mnafshin/apix/internal/learn"
 	apix "github.com/mnafshin/apix/pkg/api/generated"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -28,6 +29,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 )
 
 type rootOptions struct {
@@ -90,6 +92,14 @@ type exportOptions struct {
 	format string
 	output string
 	limit  int
+}
+
+type learnOptions struct {
+	limit   int
+	output  string
+	format  string
+	title   string
+	version string
 }
 
 type bodyFlag struct {
@@ -376,6 +386,7 @@ func runWithStdin(args []string, out io.Writer, errw io.Writer, stdin io.Reader)
 		writeLine(errw, "  watch [traffic]")
 		writeLine(errw, "  filter")
 		writeLine(errw, "  export")
+		writeLine(errw, "  learn")
 		writeLine(errw, "  breakpoints list|add|delete|enable|disable")
 		writeLine(errw, "  paused watch|forward|drop|respond")
 		writeLine(errw, "  send")
@@ -459,6 +470,8 @@ func runWithStdin(args []string, out io.Writer, errw io.Writer, stdin io.Reader)
 		return app.exec("filter", func() error { return app.cmdFilter(fs.Args()[1:]) })
 	case "export":
 		return app.exec("export", func() error { return app.cmdExport(fs.Args()[1:]) })
+	case "learn":
+		return app.exec("learn", func() error { return app.cmdLearn(fs.Args()[1:]) })
 	case "breakpoints":
 		return app.exec("breakpoints", func() error { return app.cmdBreakpoints(fs.Args()[1:]) })
 	case "paused":
@@ -1312,6 +1325,109 @@ func (a *app) cmdExport(args []string) error {
 			return err
 		}
 	}
+}
+
+func (a *app) cmdLearn(args []string) error {
+	fs := flag.NewFlagSet("learn", flag.ContinueOnError)
+	fs.SetOutput(a.errw)
+	opts := learnOptions{
+		limit:   500,
+		format:  "yaml",
+		title:   "APiX Learned API",
+		version: "0.1.0",
+	}
+	fs.IntVar(&opts.limit, "limit", 500, "max number of transactions to infer from")
+	fs.StringVar(&opts.output, "output", "", "output file path (default: stdout)")
+	fs.StringVar(&opts.format, "format", "yaml", "output format: yaml|json")
+	fs.StringVar(&opts.title, "title", "APiX Learned API", "OpenAPI info.title value")
+	fs.StringVar(&opts.version, "version", "0.1.0", "OpenAPI info.version value")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if opts.limit <= 0 {
+		return fmt.Errorf("limit must be > 0")
+	}
+	if opts.format != "yaml" && opts.format != "json" {
+		return fmt.Errorf("unsupported format %q (use yaml or json)", opts.format)
+	}
+
+	client, err := a.clientConn()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := a.unaryContext()
+	defer cancel()
+	limit, err := int32FromInt(opts.limit, "limit")
+	if err != nil {
+		return err
+	}
+	stream, err := client.GetHistory(ctx, &apix.HistoryQuery{Limit: limit})
+	if err != nil {
+		return err
+	}
+	items, err := recvHistory(stream)
+	if err != nil {
+		return err
+	}
+	observations := make([]learn.Observation, 0, len(items))
+	for _, tx := range items {
+		if tx.GetRequest() == nil {
+			continue
+		}
+		method := tx.GetRequest().GetMethod()
+		if method == "" {
+			continue
+		}
+		observations = append(observations, learn.Observation{
+			Method:          method,
+			URL:             tx.GetRequest().GetUrl(),
+			RequestHeaders:  tx.GetRequest().GetHeaders(),
+			RequestBody:     tx.GetRequest().GetBody(),
+			ResponseStatus:  int(tx.GetResponse().GetStatusCode()),
+			ResponseHeaders: tx.GetResponse().GetHeaders(),
+			ResponseBody:    tx.GetResponse().GetBody(),
+		})
+	}
+
+	spec := learn.BuildOpenAPISpec(observations, opts.title, opts.version)
+	var encoded []byte
+	switch opts.format {
+	case "json":
+		encoded, err = json.MarshalIndent(spec, "", "  ")
+	case "yaml":
+		encoded, err = yaml.Marshal(spec)
+	}
+	if err != nil {
+		return fmt.Errorf("encode learned openapi: %w", err)
+	}
+	if len(encoded) == 0 || encoded[len(encoded)-1] != '\n' {
+		encoded = append(encoded, '\n')
+	}
+
+	if opts.output != "" {
+		cleanPath := filepath.Clean(opts.output)
+		if err := os.WriteFile(cleanPath, encoded, 0o644); err != nil {
+			return fmt.Errorf("write learned openapi: %w", err)
+		}
+		pathCount := 0
+		if paths, ok := spec["paths"].(map[string]any); ok {
+			pathCount = len(paths)
+		}
+		if a.opts.output == "json" {
+			return emitJSON(a.out, map[string]any{
+				"output":             cleanPath,
+				"format":             opts.format,
+				"paths":              pathCount,
+				"observations_count": len(observations),
+			})
+		}
+		writef(a.out, "Draft OpenAPI written: %s (paths=%d, observations=%d)\n", cleanPath, pathCount, len(observations))
+		writeLine(a.out, "Note: this is proposal-only output; review before contract promotion.")
+		return nil
+	}
+
+	_, err = a.out.Write(encoded)
+	return err
 }
 
 func (a *app) cmdBreakpoints(args []string) error {
@@ -2171,7 +2287,7 @@ func completionScript(shell string) (string, error) {
 _apix() {
   local cur prev words cword
   _init_completion || return
-  local commands="status plugins history watch breakpoints paused send templates replay cert config setup tui completion doctor help"
+  local commands="status plugins history watch filter export learn breakpoints paused send templates replay cert config setup tui completion doctor help"
   local subcommands="list get clear add delete enable disable watch forward drop respond save execute show reload status bundle"
   COMPREPLY=( $(compgen -W "${commands} ${subcommands}" -- "$cur") )
 }
@@ -2185,6 +2301,7 @@ _apix() {
     'plugins:Plugin commands'
     'history:History commands'
     'watch:Watch traffic'
+    'learn:Infer draft OpenAPI from observed traffic'
     'breakpoints:Breakpoint commands'
     'paused:Paused request commands'
     'send:Send a raw request'
@@ -2202,7 +2319,7 @@ _apix() {
 }
 _apix "$@"
 `
-	const fish = `complete -c apix -f -a "status plugins history watch breakpoints paused send templates replay cert config setup tui completion doctor help"
+	const fish = `complete -c apix -f -a "status plugins history watch filter export learn breakpoints paused send templates replay cert config setup tui completion doctor help"
 complete -c apix -n "__fish_seen_subcommand_from doctor" -f -a "bundle"
 `
 	switch shell {

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -614,6 +614,33 @@ func TestCLIFilter_EngineBacked(t *testing.T) {
 	}
 }
 
+func TestCLILearn_EngineBacked(t *testing.T) {
+	t.Parallel()
+	stack := newCLITestStack(t, "")
+	stack.storeTransaction(t, "learn-1", "GET", "https://api.example.com/users/123?include=posts", "", `{"id":123,"name":"A"}`, 200)
+	stack.storeTransaction(t, "learn-2", "POST", "https://api.example.com/users", `{"name":"A"}`, `{"id":124}`, 201)
+
+	outPath := filepath.Join(t.TempDir(), "openapi.learned.yaml")
+	exit, out, errOut := runCLI(t, stack.args("--output", "json", "learn", "--format", "yaml", "--output", outPath, "--limit", "50")...)
+	if exit != 0 {
+		t.Fatalf("learn exit=%d err=%s", exit, errOut)
+	}
+	if !strings.Contains(out, `"output":`) {
+		t.Fatalf("learn output=%s", out)
+	}
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read learned file: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "openapi: 3.0.3") {
+		t.Fatalf("missing openapi version in learned output: %s", content)
+	}
+	if !strings.Contains(content, "/users/{id}:") {
+		t.Fatalf("missing normalized /users/{id} path in learned output: %s", content)
+	}
+}
+
 func TestCLIExport_EngineBacked(t *testing.T) {
 	t.Parallel()
 	stack := newCLITestStack(t, "")

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -360,6 +360,7 @@ breakpoints list|add|delete|enable|disable
 paused watch|forward|drop|respond
 templates save|list|delete
 replay                   # replay stored requests
+learn                    # infer draft OpenAPI from observed traffic
 config                   # show/validate config
 doctor [bundle]          # diagnostics or support bundle
 tui                      # interactive live traffic terminal UI

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -15,6 +15,7 @@ Commands:
   watch [traffic]
   filter
   export
+  learn
   breakpoints list|add|delete|enable|disable
   paused watch|forward|drop|respond
   send

--- a/internal/learn/openapi.go
+++ b/internal/learn/openapi.go
@@ -1,0 +1,385 @@
+package learn
+
+import (
+	"encoding/json"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Observation struct {
+	Method          string
+	URL             string
+	RequestHeaders  map[string]string
+	RequestBody     []byte
+	ResponseStatus  int
+	ResponseHeaders map[string]string
+	ResponseBody    []byte
+}
+
+type endpointAggregate struct {
+	Method              string
+	Path                string
+	PathParams          []PathParameter
+	QueryValueSamples   map[string][]string
+	ObservedCount       int
+	AuthObserved        bool
+	RequestBodySamples  []any
+	ResponseBodySamples map[int][]any
+}
+
+// BuildOpenAPISpec infers a draft OpenAPI 3.0 spec from observed traffic.
+func BuildOpenAPISpec(observations []Observation, title, version string) map[string]any {
+	aggregates := map[string]*endpointAggregate{}
+	for _, obs := range observations {
+		method := strings.ToLower(strings.TrimSpace(obs.Method))
+		if method == "" {
+			continue
+		}
+		path, pathParams := NormalizePath(obs.URL)
+		key := method + " " + path
+		agg, ok := aggregates[key]
+		if !ok {
+			agg = &endpointAggregate{
+				Method:              method,
+				Path:                path,
+				PathParams:          pathParams,
+				QueryValueSamples:   map[string][]string{},
+				ResponseBodySamples: map[int][]any{},
+			}
+			aggregates[key] = agg
+		}
+		agg.ObservedCount++
+		if hasAuthorizationHeader(obs.RequestHeaders) {
+			agg.AuthObserved = true
+		}
+		collectQuerySamples(agg, obs.URL)
+		if parsed := parseJSONBody(obs.RequestBody); parsed != nil {
+			agg.RequestBodySamples = append(agg.RequestBodySamples, parsed)
+		}
+		if parsed := parseJSONBody(obs.ResponseBody); parsed != nil {
+			status := obs.ResponseStatus
+			if status <= 0 {
+				status = 200
+			}
+			agg.ResponseBodySamples[status] = append(agg.ResponseBodySamples[status], parsed)
+		}
+	}
+
+	spec := map[string]any{
+		"openapi": "3.0.3",
+		"info": map[string]any{
+			"title":       title,
+			"version":     version,
+			"description": "Draft proposal inferred from observed APiX traffic. Review before promotion to source-of-truth contracts.",
+		},
+		"paths": map[string]any{},
+	}
+
+	paths := spec["paths"].(map[string]any)
+	securityUsed := false
+	keys := make([]string, 0, len(aggregates))
+	for key := range aggregates {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		agg := aggregates[key]
+		item, ok := paths[agg.Path].(map[string]any)
+		if !ok {
+			item = map[string]any{}
+			paths[agg.Path] = item
+		}
+		op := map[string]any{
+			"summary": "Draft inferred from " + strconv.Itoa(agg.ObservedCount) + " observed transaction(s)",
+		}
+		if parameters := buildParameters(agg); len(parameters) > 0 {
+			op["parameters"] = parameters
+		}
+		if len(agg.RequestBodySamples) > 0 {
+			op["requestBody"] = map[string]any{
+				"required": true,
+				"content": map[string]any{
+					"application/json": map[string]any{
+						"schema": inferSchemaFromSamples(agg.RequestBodySamples),
+					},
+				},
+			}
+		}
+		op["responses"] = buildResponses(agg.ResponseBodySamples)
+		if agg.AuthObserved {
+			op["security"] = []map[string][]string{{"bearerAuth": []string{}}}
+			securityUsed = true
+		}
+		item[agg.Method] = op
+	}
+
+	if securityUsed {
+		spec["components"] = map[string]any{
+			"securitySchemes": map[string]any{
+				"bearerAuth": map[string]any{
+					"type":         "http",
+					"scheme":       "bearer",
+					"bearerFormat": "JWT",
+				},
+			},
+		}
+	}
+	return spec
+}
+
+func hasAuthorizationHeader(headers map[string]string) bool {
+	for key, value := range headers {
+		if strings.EqualFold(key, "authorization") && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func collectQuerySamples(agg *endpointAggregate, rawURL string) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return
+	}
+	for key, values := range parsed.Query() {
+		agg.QueryValueSamples[key] = append(agg.QueryValueSamples[key], values...)
+	}
+}
+
+func buildParameters(agg *endpointAggregate) []map[string]any {
+	params := make([]map[string]any, 0, len(agg.PathParams)+len(agg.QueryValueSamples))
+	for _, p := range agg.PathParams {
+		schema := map[string]any{"type": p.Type}
+		if p.Format != "" {
+			schema["format"] = p.Format
+		}
+		params = append(params, map[string]any{
+			"name":     p.Name,
+			"in":       "path",
+			"required": true,
+			"schema":   schema,
+		})
+	}
+
+	queryKeys := make([]string, 0, len(agg.QueryValueSamples))
+	for key := range agg.QueryValueSamples {
+		queryKeys = append(queryKeys, key)
+	}
+	sort.Strings(queryKeys)
+	for _, key := range queryKeys {
+		schema := inferScalarSchema(agg.QueryValueSamples[key])
+		params = append(params, map[string]any{
+			"name":     key,
+			"in":       "query",
+			"required": false,
+			"schema":   schema,
+		})
+	}
+	return params
+}
+
+func buildResponses(samples map[int][]any) map[string]any {
+	if len(samples) == 0 {
+		return map[string]any{
+			"default": map[string]any{"description": "Observed response"},
+		}
+	}
+	keys := make([]int, 0, len(samples))
+	for status := range samples {
+		keys = append(keys, status)
+	}
+	sort.Ints(keys)
+
+	out := map[string]any{}
+	for _, status := range keys {
+		entry := map[string]any{
+			"description": "Observed response",
+		}
+		if len(samples[status]) > 0 {
+			entry["content"] = map[string]any{
+				"application/json": map[string]any{
+					"schema": inferSchemaFromSamples(samples[status]),
+				},
+			}
+		}
+		out[strconv.Itoa(status)] = entry
+	}
+	return out
+}
+
+func parseJSONBody(raw []byte) any {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return nil
+	}
+	return parsed
+}
+
+func inferSchemaFromSamples(samples []any) map[string]any {
+	nonNil := make([]any, 0, len(samples))
+	for _, sample := range samples {
+		if sample != nil {
+			nonNil = append(nonNil, sample)
+		}
+	}
+	if len(nonNil) == 0 {
+		return map[string]any{"type": "object"}
+	}
+	return inferSchemaValue(nonNil)
+}
+
+func inferSchemaValue(values []any) map[string]any {
+	if len(values) == 0 {
+		return map[string]any{"type": "string"}
+	}
+	allObjects := true
+	allArrays := true
+	for _, v := range values {
+		if _, ok := v.(map[string]any); !ok {
+			allObjects = false
+		}
+		if _, ok := v.([]any); !ok {
+			allArrays = false
+		}
+	}
+	if allObjects {
+		return inferObjectSchema(values)
+	}
+	if allArrays {
+		return inferArraySchema(values)
+	}
+	types := uniqueTypes(values)
+	if len(types) == 1 {
+		return map[string]any{"type": types[0]}
+	}
+	oneOf := make([]map[string]any, 0, len(types))
+	for _, typ := range types {
+		oneOf = append(oneOf, map[string]any{"type": typ})
+	}
+	return map[string]any{"oneOf": oneOf}
+}
+
+func inferObjectSchema(values []any) map[string]any {
+	propertySamples := map[string][]any{}
+	requiredCounts := map[string]int{}
+	for _, raw := range values {
+		obj := raw.(map[string]any)
+		for key, value := range obj {
+			propertySamples[key] = append(propertySamples[key], value)
+			requiredCounts[key]++
+		}
+	}
+
+	props := map[string]any{}
+	keys := make([]string, 0, len(propertySamples))
+	for key := range propertySamples {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	required := make([]string, 0, len(keys))
+	for _, key := range keys {
+		props[key] = inferSchemaValue(propertySamples[key])
+		if requiredCounts[key] == len(values) {
+			required = append(required, key)
+		}
+	}
+
+	schema := map[string]any{
+		"type":       "object",
+		"properties": props,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func inferArraySchema(values []any) map[string]any {
+	allItems := make([]any, 0)
+	for _, raw := range values {
+		items := raw.([]any)
+		allItems = append(allItems, items...)
+	}
+	if len(allItems) == 0 {
+		return map[string]any{
+			"type":  "array",
+			"items": map[string]any{"type": "string"},
+		}
+	}
+	return map[string]any{
+		"type":  "array",
+		"items": inferSchemaValue(allItems),
+	}
+}
+
+func inferScalarSchema(values []string) map[string]any {
+	if len(values) == 0 {
+		return map[string]any{"type": "string"}
+	}
+	allInt := true
+	allNumber := true
+	allBool := true
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			allInt = false
+		}
+		if _, err := strconv.ParseFloat(value, 64); err != nil {
+			allNumber = false
+		}
+		if value != "true" && value != "false" {
+			allBool = false
+		}
+	}
+	switch {
+	case allInt:
+		return map[string]any{"type": "integer"}
+	case allNumber:
+		return map[string]any{"type": "number"}
+	case allBool:
+		return map[string]any{"type": "boolean"}
+	default:
+		return map[string]any{"type": "string"}
+	}
+}
+
+func uniqueTypes(values []any) []string {
+	set := map[string]bool{}
+	for _, v := range values {
+		set[valueType(v)] = true
+	}
+	out := make([]string, 0, len(set))
+	for typ := range set {
+		out = append(out, typ)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func valueType(v any) string {
+	switch v.(type) {
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64:
+		f := v.(float64)
+		if f == float64(int64(f)) {
+			return "integer"
+		}
+		return "number"
+	default:
+		return "string"
+	}
+}

--- a/internal/learn/openapi_test.go
+++ b/internal/learn/openapi_test.go
@@ -1,0 +1,44 @@
+package learn
+
+import "testing"
+
+func TestBuildOpenAPISpec(t *testing.T) {
+	t.Parallel()
+
+	spec := BuildOpenAPISpec([]Observation{
+		{
+			Method:         "GET",
+			URL:            "https://api.example.com/users/123?include=posts",
+			RequestHeaders: map[string]string{"Authorization": "Bearer token"},
+			ResponseStatus: 200,
+			ResponseBody:   []byte(`{"id":123,"name":"A"}`),
+		},
+		{
+			Method:         "GET",
+			URL:            "https://api.example.com/users/999?include=comments",
+			RequestHeaders: map[string]string{"Authorization": "Bearer token"},
+			ResponseStatus: 200,
+			ResponseBody:   []byte(`{"id":999,"name":"B","active":true}`),
+		},
+		{
+			Method:         "POST",
+			URL:            "https://api.example.com/users",
+			RequestBody:    []byte(`{"name":"C","email":"c@example.com"}`),
+			ResponseStatus: 201,
+			ResponseBody:   []byte(`{"id":1000}`),
+		},
+	}, "Test API", "0.1.0")
+
+	paths := spec["paths"].(map[string]any)
+	if _, ok := paths["/users/{id}"]; !ok {
+		t.Fatalf("expected inferred /users/{id} path, got %+v", paths)
+	}
+	if _, ok := paths["/users"]; !ok {
+		t.Fatalf("expected inferred /users path, got %+v", paths)
+	}
+	components := spec["components"].(map[string]any)
+	securitySchemes := components["securitySchemes"].(map[string]any)
+	if _, ok := securitySchemes["bearerAuth"]; !ok {
+		t.Fatalf("expected bearerAuth security scheme")
+	}
+}

--- a/internal/learn/path_pattern.go
+++ b/internal/learn/path_pattern.go
@@ -1,0 +1,74 @@
+package learn
+
+import (
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var uuidRE = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+type PathParameter struct {
+	Name   string
+	Type   string
+	Format string
+}
+
+// NormalizePath converts concrete URL paths into OpenAPI path templates.
+func NormalizePath(rawURL string) (string, []PathParameter) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "/", nil
+	}
+
+	path := parsed.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 1 && parts[0] == "" {
+		return "/", nil
+	}
+
+	params := make([]PathParameter, 0, len(parts))
+	seenNames := map[string]int{}
+
+	for i := range parts {
+		segment, unescapeErr := url.PathUnescape(parts[i])
+		if unescapeErr != nil {
+			segment = parts[i]
+		}
+		if isNumericSegment(segment) {
+			name := nextParamName("id", seenNames)
+			parts[i] = "{" + name + "}"
+			params = append(params, PathParameter{Name: name, Type: "integer"})
+			continue
+		}
+		if uuidRE.MatchString(segment) {
+			name := nextParamName("id", seenNames)
+			parts[i] = "{" + name + "}"
+			params = append(params, PathParameter{Name: name, Type: "string", Format: "uuid"})
+			continue
+		}
+		parts[i] = segment
+	}
+
+	return "/" + strings.Join(parts, "/"), params
+}
+
+func isNumericSegment(segment string) bool {
+	if segment == "" {
+		return false
+	}
+	_, err := strconv.ParseInt(segment, 10, 64)
+	return err == nil
+}
+
+func nextParamName(base string, seen map[string]int) string {
+	seen[base]++
+	if seen[base] == 1 {
+		return base
+	}
+	return base + strconv.Itoa(seen[base])
+}

--- a/internal/learn/path_pattern_test.go
+++ b/internal/learn/path_pattern_test.go
@@ -1,0 +1,21 @@
+package learn
+
+import "testing"
+
+func TestNormalizePath(t *testing.T) {
+	t.Parallel()
+
+	path, params := NormalizePath("https://api.example.com/users/123/orders/550e8400-e29b-41d4-a716-446655440000")
+	if path != "/users/{id}/orders/{id2}" {
+		t.Fatalf("path=%q", path)
+	}
+	if len(params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(params))
+	}
+	if params[0].Name != "id" || params[0].Type != "integer" {
+		t.Fatalf("unexpected first param: %+v", params[0])
+	}
+	if params[1].Name != "id2" || params[1].Format != "uuid" {
+		t.Fatalf("unexpected second param: %+v", params[1])
+	}
+}


### PR DESCRIPTION
## Summary
- add new apix learn command to infer a proposal-only OpenAPI 3.0.3 draft from observed traffic history
- infer path templates, path/query parameters, request body schema, response schemas by status, and optional bearer auth scheme
- support yaml/json output with optional file writing
- add inference unit tests and CLI integration test coverage
- update docs and CLI help contract snapshot

Closes #409