### PR TITLE
feat(contract): add v1 contract model and CLI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Then run the extension from VS Code (`Run Extension`), or package/install from `
 - `templates save|list|delete|execute`
 - `replay`
 - `learn`
+- `contract init|validate`
 - `cert`, `config`, `doctor`, `tui`, `completion`
 
 Use `apix help` for details.
@@ -119,6 +120,7 @@ Validate config:
 | `log_format` / `log_level` | `text` / `info` | Engine log output shape and verbosity |
 | `mcp_enabled` / `mcp_port` | `false` / `9093` | MCP server |
 | `mcp_allow_replay` / `mcp_allow_compose` | `false` / `false` | Side-effect MCP tools |
+| `contract_paths` | empty | APiX contract files loaded/validated on engine startup |
 | `map_local_rules` | empty | URL regex -> local file response mapping (`file_path`, with `local_path` alias) |
 
 ## Security model

--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fatih/color"
 	tuimode "github.com/mnafshin/apix/cmd/apix-cli/tui"
 	"github.com/mnafshin/apix/internal/config"
+	"github.com/mnafshin/apix/internal/contracts"
 	"github.com/mnafshin/apix/internal/learn"
 	apix "github.com/mnafshin/apix/pkg/api/generated"
 	"google.golang.org/grpc"
@@ -387,6 +388,7 @@ func runWithStdin(args []string, out io.Writer, errw io.Writer, stdin io.Reader)
 		writeLine(errw, "  filter")
 		writeLine(errw, "  export")
 		writeLine(errw, "  learn")
+		writeLine(errw, "  contract init|validate")
 		writeLine(errw, "  breakpoints list|add|delete|enable|disable")
 		writeLine(errw, "  paused watch|forward|drop|respond")
 		writeLine(errw, "  send")
@@ -472,6 +474,8 @@ func runWithStdin(args []string, out io.Writer, errw io.Writer, stdin io.Reader)
 		return app.exec("export", func() error { return app.cmdExport(fs.Args()[1:]) })
 	case "learn":
 		return app.exec("learn", func() error { return app.cmdLearn(fs.Args()[1:]) })
+	case "contract":
+		return app.exec("contract", func() error { return app.cmdContract(fs.Args()[1:]) })
 	case "breakpoints":
 		return app.exec("breakpoints", func() error { return app.cmdBreakpoints(fs.Args()[1:]) })
 	case "paused":
@@ -1430,6 +1434,91 @@ func (a *app) cmdLearn(args []string) error {
 	return err
 }
 
+func (a *app) cmdContract(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: contract init|validate")
+	}
+	switch args[0] {
+	case "init":
+		fs := flag.NewFlagSet("contract init", flag.ContinueOnError)
+		fs.SetOutput(a.errw)
+		var outPath string
+		title := "APiX Contract"
+		version := "0.1.0"
+		fs.StringVar(&outPath, "output", "contract.apix.yaml", "output file path")
+		fs.StringVar(&title, "title", "APiX Contract", "contract info.title")
+		fs.StringVar(&version, "version", "0.1.0", "contract info.version")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(outPath) == "" {
+			return fmt.Errorf("output path must not be empty")
+		}
+		clean := filepath.Clean(outPath)
+		if _, err := os.Stat(clean); err == nil {
+			return fmt.Errorf("refusing to overwrite existing file: %s", clean)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("check output path: %w", err)
+		}
+		template := contracts.NewTemplate(title, version)
+		if err := contracts.SaveYAML(clean, template); err != nil {
+			return err
+		}
+		if a.opts.output == "json" {
+			return emitJSON(a.out, map[string]any{
+				"output":         clean,
+				"schema_version": contracts.CurrentSchemaVersion,
+				"title":          title,
+				"version":        version,
+			})
+		}
+		writef(a.out, "Contract scaffold written: %s\n", clean)
+		return nil
+	case "validate":
+		fs := flag.NewFlagSet("contract validate", flag.ContinueOnError)
+		fs.SetOutput(a.errw)
+		var path string
+		fs.StringVar(&path, "file", "", "contract file path (.yaml, .yml, .json)")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(path) == "" {
+			return fmt.Errorf("usage: contract validate --file <path>")
+		}
+		clean := filepath.Clean(path)
+		c, validation, err := contracts.ValidateFile(clean)
+		if err != nil {
+			return err
+		}
+		endpointCount := 0
+		if c != nil {
+			endpointCount = len(c.Endpoints)
+		}
+		if validation != nil {
+			if a.opts.output == "json" {
+				return emitJSON(a.out, map[string]any{
+					"valid":       false,
+					"file":        clean,
+					"diagnostics": validation.Diagnostics,
+				})
+			}
+			return validation
+		}
+		if a.opts.output == "json" {
+			return emitJSON(a.out, map[string]any{
+				"valid":          true,
+				"file":           clean,
+				"schema_version": c.SchemaVersion,
+				"endpoints":      endpointCount,
+			})
+		}
+		writef(a.out, "Contract valid: %s (schema=%s, endpoints=%d)\n", clean, c.SchemaVersion, endpointCount)
+		return nil
+	default:
+		return fmt.Errorf("usage: contract init|validate")
+	}
+}
+
 func (a *app) cmdBreakpoints(args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("usage: breakpoints list|add|delete|enable|disable")
@@ -2287,7 +2376,7 @@ func completionScript(shell string) (string, error) {
 _apix() {
   local cur prev words cword
   _init_completion || return
-  local commands="status plugins history watch filter export learn breakpoints paused send templates replay cert config setup tui completion doctor help"
+  local commands="status plugins history watch filter export learn contract breakpoints paused send templates replay cert config setup tui completion doctor help"
   local subcommands="list get clear add delete enable disable watch forward drop respond save execute show reload status bundle"
   COMPREPLY=( $(compgen -W "${commands} ${subcommands}" -- "$cur") )
 }
@@ -2302,6 +2391,7 @@ _apix() {
     'history:History commands'
     'watch:Watch traffic'
     'learn:Infer draft OpenAPI from observed traffic'
+    'contract:Contract schema commands'
     'breakpoints:Breakpoint commands'
     'paused:Paused request commands'
     'send:Send a raw request'
@@ -2319,7 +2409,7 @@ _apix() {
 }
 _apix "$@"
 `
-	const fish = `complete -c apix -f -a "status plugins history watch filter export learn breakpoints paused send templates replay cert config setup tui completion doctor help"
+	const fish = `complete -c apix -f -a "status plugins history watch filter export learn contract breakpoints paused send templates replay cert config setup tui completion doctor help"
 complete -c apix -n "__fish_seen_subcommand_from doctor" -f -a "bundle"
 `
 	switch shell {

--- a/cmd/apix-cli/main_test.go
+++ b/cmd/apix-cli/main_test.go
@@ -641,6 +641,34 @@ func TestCLILearn_EngineBacked(t *testing.T) {
 	}
 }
 
+func TestCLIContractInitAndValidate(t *testing.T) {
+	t.Parallel()
+	contractPath := filepath.Join(t.TempDir(), "service.apix.yaml")
+
+	exit, out, errOut := runCLI(t, "--output", "json", "contract", "init", "--output", contractPath, "--title", "Billing API", "--version", "1.2.0")
+	if exit != 0 {
+		t.Fatalf("contract init exit=%d err=%s", exit, errOut)
+	}
+	if !strings.Contains(out, `"schema_version":"apix.contract/v1"`) {
+		t.Fatalf("unexpected init output: %s", out)
+	}
+	content, err := os.ReadFile(contractPath)
+	if err != nil {
+		t.Fatalf("read contract file: %v", err)
+	}
+	if !strings.Contains(string(content), "schema_version: apix.contract/v1") {
+		t.Fatalf("missing schema version in scaffold: %s", string(content))
+	}
+
+	exit, out, errOut = runCLI(t, "--output", "json", "contract", "validate", "--file", contractPath)
+	if exit != 0 {
+		t.Fatalf("contract validate exit=%d err=%s", exit, errOut)
+	}
+	if !strings.Contains(out, `"valid":true`) {
+		t.Fatalf("unexpected validate output: %s", out)
+	}
+}
+
 func TestCLIExport_EngineBacked(t *testing.T) {
 	t.Parallel()
 	stack := newCLITestStack(t, "")

--- a/cmd/apix-engine/main.go
+++ b/cmd/apix-engine/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mnafshin/apix/internal/breakpoints"
 	"github.com/mnafshin/apix/internal/config"
+	"github.com/mnafshin/apix/internal/contracts"
 	"github.com/mnafshin/apix/internal/engine"
 	"github.com/mnafshin/apix/internal/metrics"
 	"github.com/mnafshin/apix/internal/pluginrt"
@@ -82,8 +83,17 @@ func main() {
 			logging.Errorf(ctx, "config validation failed: %v", err)
 			logging.Fatalf(ctx, "%s", usermsg.UserMessage(err))
 		}
+		if err := validateConfiguredContracts(ctx, cfg.ContractPaths); err != nil {
+			logging.Errorf(ctx, "contract validation failed: %v", err)
+			logging.Fatalf(ctx, "%s", usermsg.UserMessage(err))
+		}
 		logging.Infof(ctx, "config: validation passed")
 		return
+	}
+
+	if err := validateConfiguredContracts(ctx, cfg.ContractPaths); err != nil {
+		logging.Errorf(ctx, "load contracts: %v", err)
+		logging.Fatalf(ctx, "%s", usermsg.UserMessage(err))
 	}
 
 	// 2. Open SQLite database.
@@ -238,6 +248,18 @@ func initStorage(ctx context.Context, cfg *config.Config) *storage.DB {
 	}
 	db.StartPeriodicPrune(ctx, 24*time.Hour, cfg.HistoryMaxAgeDays, cfg.HistoryMaxRows)
 	return db
+}
+
+func validateConfiguredContracts(ctx context.Context, paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	loaded, err := contracts.LoadAll(paths)
+	if err != nil {
+		return fmt.Errorf("load configured contracts: %w", err)
+	}
+	logging.Infof(ctx, "contracts loaded: %d", len(loaded))
+	return nil
 }
 
 func initPlugins(ctx context.Context, cfg *config.Config) (*pluginrt.Runtime, *builtins.OTelTracing) {

--- a/docs/CONFIG_VALIDATION.md
+++ b/docs/CONFIG_VALIDATION.md
@@ -69,6 +69,7 @@ mcp_bind_address: "127.0.0.1"
 mcp_allow_replay: false
 mcp_allow_compose: false
 plugin_paths: []
+contract_paths: []
 url_patterns: []
 map_local_rules: []
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -361,6 +361,7 @@ paused watch|forward|drop|respond
 templates save|list|delete
 replay                   # replay stored requests
 learn                    # infer draft OpenAPI from observed traffic
+contract init|validate   # scaffold and lint APiX contract files
 config                   # show/validate config
 doctor [bundle]          # diagnostics or support bundle
 tui                      # interactive live traffic terminal UI

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,6 +66,7 @@ Stable contracts and schemas:
 - [`REFERENCE/cli-contract-v1.md`](REFERENCE/cli-contract-v1.md) — CLI flags, output formats, exit codes
 - [`REFERENCE/cli_mcp.md`](REFERENCE/cli_mcp.md) — MCP server integration and tools
 - [`REFERENCE/compatibility-matrix.md`](REFERENCE/compatibility-matrix.md) — engine/CLI/extension/API compatibility
+- [`REFERENCE/contract-schema-v1.md`](REFERENCE/contract-schema-v1.md) — APiX contract source-of-truth schema and validation rules
 - [`REFERENCE/glossary.md`](REFERENCE/glossary.md) — terminology and concepts
 - [`REFERENCE/OTEL.md`](REFERENCE/OTEL.md) — OpenTelemetry and Prometheus metrics
 - [`REFERENCE/plugin-sdk.md`](REFERENCE/plugin-sdk.md) — plugin interfaces and lifecycle

--- a/docs/REFERENCE/contract-schema-v1.md
+++ b/docs/REFERENCE/contract-schema-v1.md
@@ -1,0 +1,54 @@
+# APiX Contract Schema v1
+
+APiX contract files are the design-time source of truth for endpoint behavior.
+
+## Versioning
+
+- `schema_version` is mandatory.
+- Current version is `apix.contract/v1`.
+- Unknown versions are rejected.
+
+## Top-level structure
+
+```yaml
+schema_version: apix.contract/v1
+info:
+  title: Billing API
+  version: 1.0.0
+  description: Optional text
+servers:
+  - url: https://api.example.com
+endpoints:
+  - path: /users/{id}
+    operations:
+      GET:
+        parameters:
+          - name: id
+            in: path
+            required: true
+            schema:
+              type: string
+        responses:
+          "200":
+            description: OK
+```
+
+## Validation rules (deterministic)
+
+1. `info.title` and `info.version` are required.
+2. At least one endpoint is required.
+3. Endpoint paths must start with `/`.
+4. Operations must use supported HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`).
+5. Every operation must define at least one response.
+6. Response keys must be `default` or 3-digit status codes.
+7. Parameters must use `in: path|query|header|cookie` and valid primitive/object/array JSON types.
+8. Path placeholders like `{id}` must have a matching `in: path` parameter with `required: true`.
+
+## CLI
+
+- Create scaffold: `apix contract init --output contract.apix.yaml`
+- Validate file: `apix contract validate --file contract.apix.yaml`
+
+## Engine loading
+
+Set `contract_paths` in config to load and validate contracts during engine startup and `--config-check` runs.

--- a/docs/contracts/apix-contract.schema.v1.json
+++ b/docs/contracts/apix-contract.schema.v1.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mnafshin/APiX/docs/contracts/apix-contract.schema.v1.json",
+  "title": "APiX Contract v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "info",
+    "endpoints"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "apix.contract/v1"
+    },
+    "info": {
+      "type": "object",
+      "required": [
+        "title",
+        "version"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "endpoints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "operations"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "operations": {
+            "type": "object"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/contracts/cli-help.txt
+++ b/docs/contracts/cli-help.txt
@@ -16,6 +16,7 @@ Commands:
   filter
   export
   learn
+  contract init|validate
   breakpoints list|add|delete|enable|disable
   paused watch|forward|drop|respond
   send

--- a/docs/contracts/config-keys.txt
+++ b/docs/contracts/config-keys.txt
@@ -4,6 +4,7 @@ access_log_path
 audit_log_enabled
 audit_log_path
 auth_token_require_strict_perms
+contract_paths
 dial_timeout_sec
 grpc_bind_address
 grpc_port

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,9 @@ type Config struct {
 	// Plugin paths — each entry is a path to a plugin shared library or
 	// script. Validated at startup via --config-check.
 	PluginPaths []string `yaml:"plugin_paths"`
+	// Contract paths — APiX contract documents loaded at startup.
+	// Each file must exist and pass contract schema validation.
+	ContractPaths []string `yaml:"contract_paths"`
 
 	// URLPatterns holds pre-configured URL regex patterns (e.g., allow/deny
 	// lists). Each entry must be a valid Go regexp; validated at startup.

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -63,3 +63,7 @@ history_max_rows: 0          # keep at most N transactions (prunes oldest first)
 #     file_path: './mocks/users.json'
 #     content_type: 'application/json'
 #     status_code: 200
+
+# Optional APiX contracts loaded at startup for design-time validation and tooling.
+# contract_paths:
+#   - "./contracts/service.apix.yaml"

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -51,6 +51,7 @@ func (c *Config) validate(allowBoundPorts bool) error {
 	errs = append(errs, c.validateConnectionPool()...)
 	errs = append(errs, c.validateTLSAndAuth()...)
 	errs = append(errs, c.validatePluginPaths()...)
+	errs = append(errs, c.validateContractPaths()...)
 	errs = append(errs, c.validateURLPatterns()...)
 	errs = append(errs, c.validateLogging()...)
 	errs = append(errs, c.validateMapLocalRules()...)
@@ -249,6 +250,20 @@ func (c *Config) validatePluginPaths() []error {
 		}
 	}
 
+	return errs
+}
+
+func (c *Config) validateContractPaths() []error {
+	var errs []error
+	for i, p := range c.ContractPaths {
+		if p == "" {
+			errs = append(errs, fmt.Errorf("contract_paths[%d] is empty — remove the entry or provide a valid path", i))
+			continue
+		}
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			errs = append(errs, fmt.Errorf("contract_paths[%d] %q does not exist — check the path or remove the entry", i, p))
+		}
+	}
 	return errs
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -463,6 +463,31 @@ func TestValidate_PluginPaths(t *testing.T) {
 	}
 }
 
+func TestValidate_ContractPaths(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "service.apix.yaml")
+	if err := os.WriteFile(existing, []byte("schema_version: apix.contract/v1"), 0o600); err != nil {
+		t.Fatalf("create temp contract: %v", err)
+	}
+
+	httpPort, grpcPort := mustFreePorts(t)
+	cfg := &Config{
+		HTTPPort:            httpPort,
+		GRPCPort:            grpcPort,
+		DBPath:              "apix.db",
+		MaxIdleConnsPerHost: 10,
+		ContractPaths:       []string{existing, "/nonexistent/contract.apix.yaml"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for missing contract path")
+	}
+	if !strings.Contains(err.Error(), "contract_paths") {
+		t.Fatalf("expected contract_paths error, got: %v", err)
+	}
+}
+
 // TestValidate_URLPatterns checks that invalid regex patterns are caught.
 func TestValidate_URLPatterns(t *testing.T) {
 	t.Parallel()

--- a/internal/contracts/io.go
+++ b/internal/contracts/io.go
@@ -1,0 +1,73 @@
+package contracts
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func LoadFile(path string) (*Contract, error) {
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath) // #nosec G304 -- operator-provided local file path.
+	if err != nil {
+		return nil, fmt.Errorf("read contract %q: %w", cleanPath, err)
+	}
+	var c Contract
+	switch strings.ToLower(filepath.Ext(cleanPath)) {
+	case ".json":
+		if err := json.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("parse contract %q: %w", cleanPath, err)
+		}
+	default:
+		if err := yaml.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("parse contract %q: %w", cleanPath, err)
+		}
+	}
+	return &c, nil
+}
+
+func SaveYAML(path string, c *Contract) error {
+	cleanPath := filepath.Clean(path)
+	encoded, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("encode contract: %w", err)
+	}
+	if len(encoded) == 0 || encoded[len(encoded)-1] != '\n' {
+		encoded = append(encoded, '\n')
+	}
+	if err := os.WriteFile(cleanPath, encoded, 0o644); err != nil {
+		return fmt.Errorf("write contract %q: %w", cleanPath, err)
+	}
+	return nil
+}
+
+func ValidateFile(path string) (*Contract, *ValidationError, error) {
+	c, err := LoadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	validation := Validate(c)
+	if validation.HasErrors() {
+		return c, validation, nil
+	}
+	return c, nil, nil
+}
+
+func LoadAll(paths []string) ([]*Contract, error) {
+	contracts := make([]*Contract, 0, len(paths))
+	for _, path := range paths {
+		c, validation, err := ValidateFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if validation != nil {
+			return nil, fmt.Errorf("%s", validation.Error())
+		}
+		contracts = append(contracts, c)
+	}
+	return contracts, nil
+}

--- a/internal/contracts/model.go
+++ b/internal/contracts/model.go
@@ -1,0 +1,102 @@
+package contracts
+
+const CurrentSchemaVersion = "apix.contract/v1"
+
+type Contract struct {
+	SchemaVersion string     `json:"schema_version" yaml:"schema_version"`
+	Info          Info       `json:"info" yaml:"info"`
+	Servers       []Server   `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Endpoints     []Endpoint `json:"endpoints" yaml:"endpoints"`
+}
+
+type Info struct {
+	Title       string `json:"title" yaml:"title"`
+	Version     string `json:"version" yaml:"version"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type Server struct {
+	URL         string `json:"url" yaml:"url"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type Endpoint struct {
+	Path       string               `json:"path" yaml:"path"`
+	Operations map[string]Operation `json:"operations" yaml:"operations"`
+}
+
+type Operation struct {
+	Summary     string            `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Parameters  []Parameter       `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	RequestBody *MediaTypeSchema  `json:"request_body,omitempty" yaml:"request_body,omitempty"`
+	Responses   map[string]Result `json:"responses" yaml:"responses"`
+	Auth        []AuthRequirement `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Examples    []Example         `json:"examples,omitempty" yaml:"examples,omitempty"`
+}
+
+type Parameter struct {
+	Name        string   `json:"name" yaml:"name"`
+	In          string   `json:"in" yaml:"in"` // path|query|header|cookie
+	Required    bool     `json:"required,omitempty" yaml:"required,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      JSONType `json:"schema" yaml:"schema"`
+}
+
+type MediaTypeSchema struct {
+	ContentType string                 `json:"content_type,omitempty" yaml:"content_type,omitempty"`
+	Schema      map[string]any         `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Examples    map[string]ExampleData `json:"examples,omitempty" yaml:"examples,omitempty"`
+}
+
+type Result struct {
+	Description string           `json:"description" yaml:"description"`
+	Body        *MediaTypeSchema `json:"body,omitempty" yaml:"body,omitempty"`
+}
+
+type AuthRequirement struct {
+	Type   string   `json:"type" yaml:"type"` // none|apiKey|http|oauth2|mtls
+	Scheme string   `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+}
+
+type Example struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Request     any    `json:"request,omitempty" yaml:"request,omitempty"`
+	Response    any    `json:"response,omitempty" yaml:"response,omitempty"`
+}
+
+type ExampleData struct {
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Value   any    `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+type JSONType struct {
+	Type   string `json:"type" yaml:"type"` // string|integer|number|boolean|object|array
+	Format string `json:"format,omitempty" yaml:"format,omitempty"`
+}
+
+func NewTemplate(title, version string) *Contract {
+	return &Contract{
+		SchemaVersion: CurrentSchemaVersion,
+		Info: Info{
+			Title:       title,
+			Version:     version,
+			Description: "Draft contract. Fill endpoint details before implementation.",
+		},
+		Endpoints: []Endpoint{
+			{
+				Path: "/health",
+				Operations: map[string]Operation{
+					"GET": {
+						Summary: "Health check",
+						Responses: map[string]Result{
+							"200": {Description: "OK"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/contracts/validate.go
+++ b/internal/contracts/validate.go
@@ -1,0 +1,176 @@
+package contracts
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	validMethods = map[string]struct{}{
+		"GET": {}, "POST": {}, "PUT": {}, "PATCH": {}, "DELETE": {}, "HEAD": {}, "OPTIONS": {},
+	}
+	validParamIn = map[string]struct{}{
+		"path": {}, "query": {}, "header": {}, "cookie": {},
+	}
+	validJSONTypes = map[string]struct{}{
+		"string": {}, "integer": {}, "number": {}, "boolean": {}, "object": {}, "array": {},
+	}
+	validAuthTypes = map[string]struct{}{
+		"none": {}, "apiKey": {}, "http": {}, "oauth2": {}, "mtls": {},
+	}
+	pathParamPattern = regexp.MustCompile(`\{([A-Za-z0-9_]+)\}`)
+	statusCodeRegex  = regexp.MustCompile(`^[1-5][0-9][0-9]$`)
+)
+
+type Diagnostic struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type ValidationError struct {
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+func (e *ValidationError) Error() string {
+	if len(e.Diagnostics) == 0 {
+		return "contract validation failed"
+	}
+	lines := make([]string, 0, len(e.Diagnostics))
+	for _, d := range e.Diagnostics {
+		lines = append(lines, fmt.Sprintf("%s: %s", d.Path, d.Message))
+	}
+	return "contract validation failed:\n  - " + strings.Join(lines, "\n  - ")
+}
+
+func (e *ValidationError) HasErrors() bool {
+	return len(e.Diagnostics) > 0
+}
+
+func Validate(c *Contract) *ValidationError {
+	diags := make([]Diagnostic, 0)
+	add := func(path, message string) {
+		diags = append(diags, Diagnostic{Path: path, Message: message})
+	}
+
+	if c == nil {
+		return &ValidationError{Diagnostics: []Diagnostic{{Path: "contract", Message: "contract is required"}}}
+	}
+	if strings.TrimSpace(c.SchemaVersion) == "" {
+		add("schema_version", "is required")
+	} else if c.SchemaVersion != CurrentSchemaVersion {
+		add("schema_version", fmt.Sprintf("must be %q", CurrentSchemaVersion))
+	}
+	if strings.TrimSpace(c.Info.Title) == "" {
+		add("info.title", "is required")
+	}
+	if strings.TrimSpace(c.Info.Version) == "" {
+		add("info.version", "is required")
+	}
+	if len(c.Endpoints) == 0 {
+		add("endpoints", "at least one endpoint is required")
+	}
+
+	seenPaths := make(map[string]int, len(c.Endpoints))
+	for i, ep := range c.Endpoints {
+		base := fmt.Sprintf("endpoints[%d]", i)
+		if strings.TrimSpace(ep.Path) == "" {
+			add(base+".path", "is required")
+			continue
+		}
+		if !strings.HasPrefix(ep.Path, "/") {
+			add(base+".path", "must start with '/'")
+		}
+		if prev, ok := seenPaths[ep.Path]; ok {
+			add(base+".path", fmt.Sprintf("duplicates endpoints[%d].path", prev))
+		} else {
+			seenPaths[ep.Path] = i
+		}
+		if len(ep.Operations) == 0 {
+			add(base+".operations", "at least one operation is required")
+			continue
+		}
+		validateOperations(add, base, ep.Path, ep.Operations)
+	}
+
+	sort.Slice(diags, func(i, j int) bool {
+		if diags[i].Path == diags[j].Path {
+			return diags[i].Message < diags[j].Message
+		}
+		return diags[i].Path < diags[j].Path
+	})
+	return &ValidationError{Diagnostics: diags}
+}
+
+func validateOperations(add func(string, string), basePath, endpointPath string, operations map[string]Operation) {
+	pathParams := make(map[string]struct{})
+	matches := pathParamPattern.FindAllStringSubmatch(endpointPath, -1)
+	for _, m := range matches {
+		if len(m) == 2 {
+			pathParams[m[1]] = struct{}{}
+		}
+	}
+
+	for method, op := range operations {
+		opPath := fmt.Sprintf("%s.operations.%s", basePath, method)
+		normalizedMethod := strings.ToUpper(strings.TrimSpace(method))
+		if normalizedMethod == "" {
+			add(opPath, "method key is required")
+		} else if _, ok := validMethods[normalizedMethod]; !ok {
+			add(opPath, fmt.Sprintf("unsupported HTTP method %q", method))
+		}
+
+		if len(op.Responses) == 0 {
+			add(opPath+".responses", "at least one response is required")
+		}
+		for code, resp := range op.Responses {
+			respPath := fmt.Sprintf("%s.responses.%s", opPath, code)
+			if code != "default" && !statusCodeRegex.MatchString(code) {
+				add(respPath, "status code must be 3 digits (100-599) or 'default'")
+			}
+			if strings.TrimSpace(resp.Description) == "" {
+				add(respPath+".description", "is required")
+			}
+		}
+
+		paramKeys := make(map[string]struct{})
+		pathParamDefinitions := make(map[string]struct{})
+		for i, p := range op.Parameters {
+			paramPath := fmt.Sprintf("%s.parameters[%d]", opPath, i)
+			if strings.TrimSpace(p.Name) == "" {
+				add(paramPath+".name", "is required")
+			}
+			if _, ok := validParamIn[p.In]; !ok {
+				add(paramPath+".in", "must be one of: path, query, header, cookie")
+			}
+			if _, ok := validJSONTypes[p.Schema.Type]; !ok {
+				add(paramPath+".schema.type", "must be one of: string, integer, number, boolean, object, array")
+			}
+			key := p.In + ":" + p.Name
+			if _, ok := paramKeys[key]; ok {
+				add(paramPath, fmt.Sprintf("duplicate parameter %q", key))
+			} else {
+				paramKeys[key] = struct{}{}
+			}
+			if p.In == "path" {
+				if !p.Required {
+					add(paramPath+".required", "must be true for path parameters")
+				}
+				pathParamDefinitions[p.Name] = struct{}{}
+			}
+		}
+		for name := range pathParams {
+			if _, ok := pathParamDefinitions[name]; !ok {
+				add(opPath+".parameters", fmt.Sprintf("missing path parameter definition for {%s}", name))
+			}
+		}
+
+		for i, a := range op.Auth {
+			authPath := fmt.Sprintf("%s.auth[%d].type", opPath, i)
+			if _, ok := validAuthTypes[a.Type]; !ok {
+				add(authPath, "must be one of: none, apiKey, http, oauth2, mtls")
+			}
+		}
+	}
+}

--- a/internal/contracts/validate_test.go
+++ b/internal/contracts/validate_test.go
@@ -1,0 +1,111 @@
+package contracts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidate_ValidContract(t *testing.T) {
+	t.Parallel()
+	c := NewTemplate("Payments API", "1.0.0")
+	c.Endpoints = []Endpoint{
+		{
+			Path: "/users/{id}",
+			Operations: map[string]Operation{
+				"GET": {
+					Parameters: []Parameter{
+						{Name: "id", In: "path", Required: true, Schema: JSONType{Type: "string"}},
+					},
+					Responses: map[string]Result{
+						"200": {Description: "OK"},
+					},
+				},
+			},
+		},
+	}
+	if got := Validate(c); got.HasErrors() {
+		t.Fatalf("expected valid contract, got diagnostics: %+v", got.Diagnostics)
+	}
+}
+
+func TestValidate_InvalidContractDeterministicDiagnostics(t *testing.T) {
+	t.Parallel()
+	c := &Contract{
+		SchemaVersion: "v0",
+		Info:          Info{},
+		Endpoints: []Endpoint{
+			{
+				Path: "users/{id}",
+				Operations: map[string]Operation{
+					"FETCH": {
+						Parameters: []Parameter{
+							{Name: "id", In: "path", Required: false, Schema: JSONType{Type: "id"}},
+						},
+						Responses: map[string]Result{
+							"two-hundred": {},
+						},
+						Auth: []AuthRequirement{
+							{Type: "saml"},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := Validate(c)
+	if !got.HasErrors() {
+		t.Fatal("expected validation diagnostics")
+	}
+	serialized := got.Error()
+	expectedContains := []string{
+		"schema_version: must be \"apix.contract/v1\"",
+		"info.title: is required",
+		"info.version: is required",
+		"endpoints[0].path: must start with '/'",
+		"unsupported HTTP method",
+		"status code must be 3 digits",
+		"must be true for path parameters",
+		"must be one of: string, integer, number, boolean, object, array",
+		"must be one of: none, apiKey, http, oauth2, mtls",
+	}
+	for _, expected := range expectedContains {
+		if !strings.Contains(serialized, expected) {
+			t.Fatalf("expected diagnostic %q in %q", expected, serialized)
+		}
+	}
+}
+
+func TestValidateFile_LoadsAndValidatesYAML(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contract.yaml")
+	if err := SaveYAML(path, NewTemplate("Orders API", "0.3.0")); err != nil {
+		t.Fatalf("save yaml: %v", err)
+	}
+	_, validation, err := ValidateFile(path)
+	if err != nil {
+		t.Fatalf("validate file error: %v", err)
+	}
+	if validation != nil {
+		t.Fatalf("expected valid file, got diagnostics: %+v", validation.Diagnostics)
+	}
+}
+
+func TestLoadFile_JSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "contract.json")
+	payload := `{"schema_version":"apix.contract/v1","info":{"title":"X","version":"1.0.0"},"endpoints":[{"path":"/health","operations":{"GET":{"responses":{"200":{"description":"ok"}}}}}]}`
+	if err := os.WriteFile(path, []byte(payload), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	c, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("load json: %v", err)
+	}
+	if c.Info.Title != "X" {
+		t.Fatalf("unexpected title: %q", c.Info.Title)
+	}
+}


### PR DESCRIPTION
## Summary
- add a versioned APiX contract model (apix.contract/v1) with deterministic validation diagnostics
- add apix contract init and apix contract validate commands
- add engine/config support for contract_paths so contracts are loaded and validated on startup/config-check
- add contract schema/reference docs and tests

## Testing
- make lint
- make test

Closes #498