### PR TITLE
fix(ci): resolve lint and docs-sync regressions after #516

### DIFF
--- a/cmd/apix-cli/main.go
+++ b/cmd/apix-cli/main.go
@@ -1410,7 +1410,7 @@ func (a *app) cmdLearn(args []string) error {
 
 	if opts.output != "" {
 		cleanPath := filepath.Clean(opts.output)
-		if err := os.WriteFile(cleanPath, encoded, 0o644); err != nil {
+		if err := os.WriteFile(cleanPath, encoded, 0o600); err != nil {
 			return fmt.Errorf("write learned openapi: %w", err)
 		}
 		pathCount := 0

--- a/docs/contracts/config-keys.txt
+++ b/docs/contracts/config-keys.txt
@@ -4,7 +4,6 @@ access_log_path
 audit_log_enabled
 audit_log_path
 auth_token_require_strict_perms
-contract_paths
 dial_timeout_sec
 grpc_bind_address
 grpc_port

--- a/internal/contracts/io.go
+++ b/internal/contracts/io.go
@@ -39,7 +39,7 @@ func SaveYAML(path string, c *Contract) error {
 	if len(encoded) == 0 || encoded[len(encoded)-1] != '\n' {
 		encoded = append(encoded, '\n')
 	}
-	if err := os.WriteFile(cleanPath, encoded, 0o644); err != nil {
+	if err := os.WriteFile(cleanPath, encoded, 0o600); err != nil {
 		return fmt.Errorf("write contract %q: %w", cleanPath, err)
 	}
 	return nil

--- a/internal/learn/openapi.go
+++ b/internal/learn/openapi.go
@@ -364,7 +364,7 @@ func uniqueTypes(values []any) []string {
 }
 
 func valueType(v any) string {
-	switch v.(type) {
+	switch v := v.(type) {
 	case map[string]any:
 		return "object"
 	case []any:
@@ -374,8 +374,7 @@ func valueType(v any) string {
 	case bool:
 		return "boolean"
 	case float64:
-		f := v.(float64)
-		if f == float64(int64(f)) {
+		if v == float64(int64(v)) {
 			return "integer"
 		}
 		return "number"


### PR DESCRIPTION
## Summary
- tighten file permissions to satisfy gosec when writing learned/spec outputs
- apply staticcheck-recommended type-switch cleanup in openapi type inference
- keep docs contract snapshot aligned (config-keys)

## Testing
- make lint
- make test